### PR TITLE
feat: cross-project view — issues, logs, and alerts across all projects

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -84,12 +84,15 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" \
             "kubectl apply -f /tmp/bugbarn-deploy/deploy/k8s/production/namespace.yaml"
 
-      - name: Decrypt and apply secret
+      - name: Decrypt and apply secrets
         env:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY_PRODUCTION }}
         run: |
           set -euo pipefail
           sops -d deploy/k8s/production/secret.yaml | \
+            ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" \
+            "kubectl apply -f -"
+          sops -d deploy/k8s/production/smtp-secret.yaml | \
             ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" \
             "kubectl apply -f -"
 

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,5 +3,5 @@ creation_rules:
     age: age1xm6tfpye9a64xf92yyc9eug48e5lfyz9smfu0943368lp6pws4vqg7tjt3
   - path_regex: deploy/k8s/staging/secret\.yaml$
     age: age1gm0rxsqsmasjf36jzs96rmkw6qwadt3mcts8zpql22tsff6uf56s62vemy
-  - path_regex: deploy/k8s/production/secret\.yaml$
-    age: age135zcsd472vweudg2g5f7h7253tlgmq35yfy4rew332ujadm32uaq5fquy9
+  - path_regex: deploy/k8s/production/.*secret.*\.yaml$
+    age: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -230,11 +230,10 @@ func loadConfig() config {
 		}
 	}
 	cfg.digest = digest.Config{
-		Day:         digestDay,
-		Hour:        digestHour,
-		WebhookURL:  os.Getenv("BUGBARN_DIGEST_WEBHOOK_URL"),
-		PublicURL:   cfg.publicURL,
-		ProjectSlug: getenv("BUGBARN_DIGEST_PROJECT", "default"),
+		Day:        digestDay,
+		Hour:       digestHour,
+		WebhookURL: os.Getenv("BUGBARN_DIGEST_WEBHOOK_URL"),
+		PublicURL:  cfg.publicURL,
 		Mail: digest.MailConfig{
 			Enabled: os.Getenv("BUGBARN_DIGEST_ENABLED") == "true",
 			Host:    os.Getenv("SMTP_HOST"),

--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -1,28 +1,28 @@
-apiVersion: ENC[AES256_GCM,data:P8o=,iv:NDmikHhuYzQ/86X/oCzsOHocwxrEn57eIYeo8D5HyHQ=,tag:Bz0F5NgYMBbS1JHcopCgDg==,type:str]
-kind: ENC[AES256_GCM,data:lxa9rXVr,iv:d+Cs/9QXtndEdANvvI3Tg/q9gjdDZqPn0rA2apZ6A04=,tag:pSKCN77uz2X1eVEB2DSXnQ==,type:str]
+apiVersion: ENC[AES256_GCM,data:P4I=,iv:1bznvi+hJz8o8RDn3Nu6QgFalyR1L5OP74SHIe/35o0=,tag:fUDob1gnK0mog9se+mFN3g==,type:str]
+kind: ENC[AES256_GCM,data:FLwb4af8,iv:VGdQkSCaRtBqXylre9aa/QdoZnkppS0pC79zJFv9Tvk=,tag:6jxOs2O0mOI/xBe8GBaCAw==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:/nWL/bFIceCYqwceRf5R,iv:mzj32bNQ9dnl6vA5/3ooTUFYwk8hATAzj4ybI9ND+Rw=,tag:vw08i9SnN/1ZcmCIdY68Xw==,type:str]
-    namespace: ENC[AES256_GCM,data:KcAvg0RX2IqPwpsamLEifxgW,iv:fNI8yKw2KAJyOSo4WE7IaDfFX6e5NxhtlAZkfZkeYz4=,tag:phYntTniE2BX9JD6vK3XUw==,type:str]
-type: ENC[AES256_GCM,data:0ebQzQ9/,iv:zuzh/0FpcMZHUbMw9jRifL1AqcwN3hu73dG166+ALJk=,tag:AyoUeQwIcnzCKsG7yyPg6A==,type:str]
+    name: ENC[AES256_GCM,data:AHJYODxsY0O+CWJxnwvm,iv:SDTqVGCgeTB1+3sYngtpmC3SdSs0hGT+2liVQ73XvjE=,tag:ijjTKCBVIXKLLNrNhgNjqA==,type:str]
+    namespace: ENC[AES256_GCM,data:wGatvWQQ504fd+oBtp/Smxuq,iv:AAlHEbnSS8WjWa45jA+CQIVtfRTGm6iX/AAf3B1OS10=,tag:ovG89OObjwy549U6tc6bIw==,type:str]
+type: ENC[AES256_GCM,data:NuGDWrTF,iv:edEgljWoox3ArHeZynhy0ZQLackURInUYvEw9RBN4q4=,tag:u2QTKuGuukUBK/nYCGjMDw==,type:str]
 stringData:
-    BUGBARN_API_KEY: ENC[AES256_GCM,data:UZll6IpoDORXa4E7Vibk3Ej/EoimgwvmS7A7Ylqgb7N8wmVIilCMGvz742+od+JK,iv:GOklqu2vr+6l8AjsVh+6btYQ/gaHs1fsmbsv8+Zpdz4=,tag:2+Ha/oP2LZwx3Pii7shz2g==,type:str]
-    BUGBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:07oJudQ=,iv:W0991GXTvfX13fAjRHXrBhZB2Ios5scUgX9JKn0rzSQ=,tag:TXouG28acIKfkgYtR4u4Qw==,type:str]
-    BUGBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:aRKBpCdG1BKO/NrFvXbDAQ4yQT1lXIvHb98oPAHGf6HHZydZXZFqHCLSGRf47ImbvnqPgj24NhdCj2Ku,iv:sBLjpflaaN3T1UhxtZhd8de7n4QhZya2NJO5FEOpsVo=,tag:4rvXyZwr8gyiWltjR/MIsw==,type:str]
-    BUGBARN_SESSION_SECRET: ENC[AES256_GCM,data:8WRDfpLr07LWaJedXcHfmwXOyi77dL54k5Nhjj1q3A==,iv:44oyCt+bloPr6IEh9DdlWO9CxCAB2MXjghzmFGcKDeY=,tag:0duff2QZBw32nYQk8vE6YQ==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:JM5xMxRjR+CUuNvJIOAyxUIY,iv:HqkYp/SOQ78g9a4yvOBQfQT4xwb6kv5eN0rALCCMvjE=,tag:2H6t/vei0nXoCLYxJ59slQ==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:0/GxZ50tnQ0wkWyVF4rIOM+bCD9eYDYSjDQI6WB1Dv/J34RuClEsCrEK2csq1CW/,iv:LyN88kkQ3VRUCnHhAPbpoUFQZjAEQk2HZyVDWtUduFk=,tag:rboYXydIzJvBw3dbctLrDg==,type:str]
+    BUGBARN_API_KEY: ENC[AES256_GCM,data:H4nfOAUdRx6fqEYeTqKm9Ofgxo1rBietekaX4xDocpZEoSb1fzDfgQYZkuQSy9V8,iv:DumZytVlyYMlStCq2rXco5MqJUCHDQS175ogwxjwQc0=,tag:B9AHvvpGln3DRchzmzHlJw==,type:str]
+    BUGBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:XWtqUO0=,iv:JOrNisCHJTyXqhmGrbWH5Algkjkcv66S/wQPdlKdlbY=,tag:93UGarNqJLRZkBZMfiVGoA==,type:str]
+    BUGBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:DIbbpsRN14UyxClF0eu26jchJ9Kv+UEcCLyyNjQ0N2JLjeLLYWc/nplg9OMHHkWndmRnfx6CXO7g1wT3,iv:QzKLe/SKwNDnCC3t3vhKUxVjrI8UNm69ocU1XSsdtTQ=,tag:wENTdELnUvho5HH1PQu33A==,type:str]
+    BUGBARN_SESSION_SECRET: ENC[AES256_GCM,data:dEtqc2NoPmxgGNnpCNe/WwZTiHfjFm/VSWpAh8D+sA==,iv:h33hZbOoOhnIu8gSPSQVPLfWfi1yVWlaxDBdBzwlp/M=,tag:opqb1PYfHpPa6mrFN9p29g==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:6r4nwUYDFkdHUtdKTNI3rXyk,iv:ecwG9/p/+N1dh+HAjgSbwSYIEWhNUm9IqCkMHpff1Rc=,tag:4ToujH27CyPojemO+/Kx4Q==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Jx5RusCPiavYCUPK31J6RwXcpbPg4TriXDbCLmvULrg3UMwcytUhzI412KY8nUP7,iv:BVaz6+A2QJTZGykn718f7J3RwiIGa7vtvcAU0PYDEGM=,tag:OS6ETJa2df8UNQr9uhxBOQ==,type:str]
 sops:
     age:
-        - recipient: age135zcsd472vweudg2g5f7h7253tlgmq35yfy4rew332ujadm32uaq5fquy9
+        - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByR0RJdjF3emRVUGVDT3N3
-            bytCYTNWbUVIdHlxWCtyM1IvOFRIQnQrUGxrCnJsK00wTS9DdExGZVpxVWhtQkRy
-            NDZtZ2c3bzN5WnhrUDRUNmJIdEk0cGcKLS0tIDE0RmVpY0pSUkpXdG85Sk1QYkJP
-            QkYyUEJiRzBWRHBRQ1NNMks2dFhwWkkKx0owR49eKnqXV53AmORyxuHBQGXIlbsr
-            wXPrMygcEcOlMLIdspUtOeoD8Y4HzvStL2t+4Gb292f3jrwa+o/0MQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOaUN5aHZwQUlEZEd1dkN2
+            WHZEWU9UR3NoZmhkYUZodXArVlU3eGRmUmhFCndOeXBRTFYwd2dEdThVTEVidUZl
+            d3ZDZEFaNzduYnowNkNPc013K3ZtUHcKLS0tIGYxdWx4dnA4VmxJZ1pWWnd2SjNt
+            cG1DNE4zUXBiSUFxQ21MSVovS2ZWUlkKuUXBX6IFCCLyRdF7m97DIoX31kDLC8O5
+            AipFPIfigkvNphdVHCRBoE3cfVPv0Fl3cYzAB3VscdDfzwlFe0rjUQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-19T14:21:08Z"
-    mac: ENC[AES256_GCM,data:wM9ZEZpQb7PStyIEZXSq8PKzknqsJES+OcBsswV9CI+1LSbNisAu5jSVjNfmgUmnydwsJPcGz/ShtqymWSnFIYqu6eMF2HR0F4JGIJPVTeygGa0xkMnfWlEx2wbgVo6LLxWTVGw/Hpn07psmMoH6/Z8CWFi8iGmgn/UeDWGjSIw=,iv:ilt0QKfQUmibBNGdBKJ2Xjg4fHl3Og8okUWO9C63cwQ=,tag:fxh+e2FbLWhug3+dbzM6qA==,type:str]
+    lastmodified: "2026-04-27T09:54:07Z"
+    mac: ENC[AES256_GCM,data:yYdbCE0n5ykfXfkNi2wV5mrl8dixkezBUtbSWDMBj3Hv+54cijMzbmGstst2OW7LkxSVOMhNMIn5kpe48o/PodIzgdCMgYyMQOh5GGhELNPJoYWBakZ/QCMUioV6/XS7BsCZu833nfLOgl0tK3mNREfRyKqtzRGeoXLn8DANI6o=,iv:O3NAzexSAhKjQtghXj5Kv+lWq1fsqY761VetNlFJsVk=,tag:GoSiU1QHIwW15q7v+KV8Iw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/production/smtp-secret.yaml
+++ b/deploy/k8s/production/smtp-secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: ENC[AES256_GCM,data:j5Q=,iv:kd236DKwq5gvzAzG7MUftd8UG/5Sma0rei8L7mvyOa8=,tag:RlRN/HQQpKsqv28TdV4eGA==,type:str]
+kind: ENC[AES256_GCM,data:qLKFVRoN,iv:Oa2v9vYU/oX4Qzx0rJZs9uHjUQa9/vwEYAbHyhzAaQc=,tag:4GOIAI0c9JpUcMnxg0PZdQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:7D7HeqrN1YdEgfE=,iv:lbL+/xP7hJ3PTUuGl6GGFTLNuBHnPqwiu3QQTS1ANGA=,tag:3x8idvyj0ZaIpdvpbDu8ww==,type:str]
+    namespace: ENC[AES256_GCM,data:ULh8xLo7arlCcltHtPQtH9J0,iv:57Ybo9+ZuCJyNWiLB9y0jR7Pvpw0JUwSWTliRGQPpts=,tag:IF4UqYmRKPp1GZPxZ20gbA==,type:str]
+type: ENC[AES256_GCM,data:SGxibY6V,iv:9CdP44fe0IepjjNVFjOSIxuYhHoo1xnC2AQ/oJ/d6+E=,tag:Q5nWRjpuTMKnIMG1H2zBYw==,type:str]
+stringData:
+    SMTP_HOST: ENC[AES256_GCM,data:Gdw5/HJxXby66oyu3kI=,iv:jmXs9bqMOdgpCIZ1ZkD2FbVSXdBR4jjI8ZAf7LmN3v8=,tag:wTYwfJX9K4mYHORvixhydQ==,type:str]
+    SMTP_PORT: ENC[AES256_GCM,data:Jzkn,iv:Na2zpWHu1trGAPYx7JHYLA/fzISSCeaAe7c9d7iSC+w=,tag:T90M4OrUXgV6J2rOKdfGzQ==,type:str]
+    SMTP_USER: ENC[AES256_GCM,data:G2K19evcayEruhZSxIlJ,iv:nNQ8cIa1axuLFBomMgZb0f/yCinjVx1h14LK5cXJFvk=,tag:84GdRVS90LiFSSeMSC2fgw==,type:str]
+    SMTP_PASS: ENC[AES256_GCM,data:IPKOxjmn3t0=,iv:QCjMkUfGAbUeGLX6NGTePl5EVCLtHeF9EHbp3d5TifI=,tag:HTASsMjnw3L+tSmETm7vLQ==,type:str]
+    SMTP_FROM: ENC[AES256_GCM,data:mAAUzwMxunj6bLKV0OC0,iv:NuXUT8KFOl1eef8LtIeqNVfZKn/N1MRvCLZUr8dh2wM=,tag:j3lt3edXLjwF+gr15v4sWA==,type:str]
+    BUGBARN_DIGEST_ENABLED: ENC[AES256_GCM,data:VuhqUg==,iv:f8MI5JXoGLwxdry6UkCPRXvN64lv5Pd+DfjKktpj+Kk=,tag:sOq0SEWWlmQXdX1GUQGH/Q==,type:str]
+    BUGBARN_DIGEST_TO: ENC[AES256_GCM,data:dHqT8nIiJulaIiiPF5Dw,iv:Airn5zxX+3267h2+/tkTNTahR+0YdNwAJUQB9ZSjDbs=,tag:fWwGxD9qKKkAn48ZuxS66g==,type:str]
+sops:
+    age:
+        - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvOEZjdjZIaTVMVDVWTHNM
+            LzJDOXhNdEtKTEpFYVJsc3ZXcURFZjJVclUwCkdhSjQ2WXpYOUhnNzdlMzZPcVlY
+            UUxndWNjUTNuVzdLckJJRERnV1ZocUkKLS0tIDNCZ0ltSVlhbmVPOWFlblBhRVlp
+            ZEJYWG1WMFFrSXZNSVNwN0djbWZQa2sKtHJRKi1ln4UkOR5Y8l8+P4j8TEoyR04Q
+            637ZoyjapwlgsEhDdQPG1bUK9AY5B/iOOq0YOGTYSibTzeUj46JW2g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-27T09:54:09Z"
+    mac: ENC[AES256_GCM,data:jgxj33VGob9E7ii0vBAtf8drStBBR6sgHU8eWY6nf3C4R+jVgFvl27XqkVBkn+xIVxUj0h35S8Xyn3bb44QWqbwCYsK4/amzOnj/7K+JwbxKUdXJiLirEpeeVSRHN9x+pHyEOLjeyczkCJUjk5nYFXWRhgm9B/UFVXxCn8cP5sg=,iv:r+uTvAxw7tH/3ZDCi/pPBHPTbnJEneQCuMp3woa1nqk=,tag:aZNB9rdJsW9C1z3Ko45gRA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -185,11 +185,8 @@ func (s *Server) serveLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectID, ok := storage.ProjectIDFromContext(r.Context())
-	if !ok || projectID == 0 {
-		http.Error(w, "project required", http.StatusBadRequest)
-		return
-	}
+	projectID, _ := storage.ProjectIDFromContext(r.Context())
+	// projectID == 0 means all projects — handled by ListLogEntries
 
 	limit := 200
 	if v := r.URL.Query().Get("limit"); v != "" {
@@ -239,11 +236,8 @@ func (s *Server) serveLogsStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectID, ok := storage.ProjectIDFromContext(r.Context())
-	if !ok || projectID == 0 {
-		http.Error(w, "project required", http.StatusBadRequest)
-		return
-	}
+	projectID, _ := storage.ProjectIDFromContext(r.Context())
+	// projectID == 0 means all projects — hub.Subscribe(0) receives from all projects
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -165,13 +165,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		} else if usingAPIKey && apiKeyProjectID > 0 {
 			resolvedProjectID = apiKeyProjectID
-		} else if usingSession {
+		} else if usingSession && r.Method != http.MethodGet {
+			// Non-GET writes without an explicit project header default to "default".
+			// GET requests leave resolvedProjectID = 0 = all-projects query mode.
 			if proj, err := s.store.ProjectBySlug(r.Context(), "default"); err == nil {
 				resolvedProjectID = proj.ID
 			}
 		}
-	}
-	if resolvedProjectID > 0 {
+		// Always store the resolved project in context so storage can distinguish
+		// "all projects" (0) from "no context set at all" (absent key).
 		r = r.WithContext(storage.WithProjectID(r.Context(), resolvedProjectID))
 	}
 

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -28,8 +28,7 @@ type Config struct {
 	Mail MailConfig
 
 	// Display
-	PublicURL   string
-	ProjectSlug string
+	PublicURL string
 }
 
 // Enabled reports whether at least one delivery channel is active.
@@ -40,18 +39,22 @@ func (c Config) Enabled() bool {
 // Store is the subset of storage.Store used by the digest.
 type Store interface {
 	WeeklyDigest(ctx context.Context, projectID int64, since time.Time) (storage.DigestData, error)
-	DefaultProjectID() int64
+	ListProjects(ctx context.Context) ([]storage.Project, error)
 }
 
 // payload is the JSON shape POSTed to the webhook.
 type payload struct {
-	Type        string       `json:"type"`
-	PeriodStart string       `json:"period_start"`
-	PeriodEnd   string       `json:"period_end"`
-	Project     string       `json:"project"`
-	PublicURL   string       `json:"public_url,omitempty"`
-	Stats       statsBlock   `json:"stats"`
-	TopIssues   []issueBlock `json:"top_issues"`
+	Type        string           `json:"type"`
+	PeriodStart string           `json:"period_start"`
+	PeriodEnd   string           `json:"period_end"`
+	PublicURL   string           `json:"public_url,omitempty"`
+	Projects    []projectSection `json:"projects"`
+}
+
+type projectSection struct {
+	Project   string       `json:"project"`
+	Stats     statsBlock   `json:"stats"`
+	TopIssues []issueBlock `json:"top_issues"`
 }
 
 type statsBlock struct {
@@ -69,13 +72,9 @@ type issueBlock struct {
 	URL        string `json:"url,omitempty"`
 }
 
-func buildPayload(cfg Config, data storage.DigestData, since, now time.Time) payload {
-	p := payload{
-		Type:        "weekly_digest",
-		PeriodStart: since.UTC().Format(time.RFC3339),
-		PeriodEnd:   now.UTC().Format(time.RFC3339),
-		Project:     cfg.ProjectSlug,
-		PublicURL:   cfg.PublicURL,
+func buildSection(cfg Config, slug string, data storage.DigestData) projectSection {
+	sec := projectSection{
+		Project: slug,
 		Stats: statsBlock{
 			TotalEvents:    data.TotalEvents,
 			NewIssues:      data.NewIssues,
@@ -94,24 +93,46 @@ func buildPayload(cfg Config, data storage.DigestData, since, now time.Time) pay
 		if cfg.PublicURL != "" {
 			ib.URL = fmt.Sprintf("%s/#/issues/%s", cfg.PublicURL, iss.ID)
 		}
-		p.TopIssues = append(p.TopIssues, ib)
+		sec.TopIssues = append(sec.TopIssues, ib)
 	}
-	return p
+	return sec
 }
 
-// Send gathers digest data and delivers to all configured channels.
-// Each channel is attempted independently; failures are returned but do not
-// suppress other channels.
+// Send gathers digest data across all projects and delivers to all configured
+// channels. Projects with no activity in the period are silently skipped.
+// If no projects have any activity the send is a no-op. Each channel is
+// attempted independently; failures are returned but do not suppress others.
 func Send(ctx context.Context, cfg Config, store Store) []error {
 	now := time.Now().UTC()
 	since := now.AddDate(0, 0, -7)
 
-	data, err := store.WeeklyDigest(ctx, store.DefaultProjectID(), since)
+	projects, err := store.ListProjects(ctx)
 	if err != nil {
-		return []error{fmt.Errorf("gather: %w", err)}
+		return []error{fmt.Errorf("list projects: %w", err)}
 	}
 
-	p := buildPayload(cfg, data, since, now)
+	p := payload{
+		Type:        "weekly_digest",
+		PeriodStart: since.UTC().Format(time.RFC3339),
+		PeriodEnd:   now.UTC().Format(time.RFC3339),
+		PublicURL:   cfg.PublicURL,
+	}
+
+	for _, proj := range projects {
+		data, err := store.WeeklyDigest(ctx, proj.ID, since)
+		if err != nil {
+			return []error{fmt.Errorf("gather %s: %w", proj.Slug, err)}
+		}
+		if data.TotalEvents == 0 {
+			continue
+		}
+		p.Projects = append(p.Projects, buildSection(cfg, proj.Slug, data))
+	}
+
+	if len(p.Projects) == 0 {
+		log.Printf("digest: no activity across all projects, skipping")
+		return nil
+	}
 
 	var errs []error
 

--- a/internal/digest/mail.go
+++ b/internal/digest/mail.go
@@ -92,32 +92,35 @@ func deliverEmail(mc MailConfig, subject, plain, html string) error {
 
 // mailData is the template data bag for both plain and HTML renders.
 type mailData struct {
-	Project        string
 	Start, End     string
 	TotalEvents    int
 	NewIssues      int
 	ResolvedIssues int
 	Regressions    int
-	TopIssues      []issueBlock
+	Projects       []projectSection
 	PublicURL      string
 }
 
-var plainTmpl = template.Must(template.New("plain").Parse(`This week in {{.Project}} ({{.Start}} – {{.End}} UTC):
+var plainTmpl = template.Must(template.New("plain").Parse(`BugBarn weekly digest ({{.Start}} – {{.End}} UTC)
 
-  {{.TotalEvents}} events   {{.NewIssues}} new issues   {{.ResolvedIssues}} resolved   {{.Regressions}} regressions
+All projects: {{.TotalEvents}} events   {{.NewIssues}} new issues   {{.ResolvedIssues}} resolved   {{.Regressions}} regressions
+{{range .Projects}}
+── {{.Project}} ──
+  {{.Stats.TotalEvents}} events   {{.Stats.NewIssues}} new   {{.Stats.ResolvedIssues}} resolved   {{.Stats.Regressions}} regressions
 {{- if .TopIssues}}
 
-Top issues by volume:
-{{range .TopIssues}}  #{{.ID}}  {{.Title}}  ({{.EventCount}} events, {{.Status}})
-{{end}}{{- end}}{{- if .PublicURL}}
+  Top issues:
+{{range .TopIssues}}  · {{.Title}}  ({{.EventCount}} events, {{.Status}}){{if .URL}} — {{.URL}}{{end}}
+{{end}}{{- end}}{{end}}{{- if .PublicURL}}
 View all issues: {{.PublicURL}}
 {{- end}}`))
 
 var htmlTmpl = template.Must(template.New("html").Parse(`<!DOCTYPE html>
 <html>
-<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px">
-<h2 style="color:#1a1a1a">BugBarn weekly digest — {{.Project}}</h2>
-<p style="color:#555">{{.Start}} – {{.End}} UTC</p>
+<body style="font-family:sans-serif;max-width:640px;margin:0 auto;padding:24px">
+<h2 style="color:#1a1a1a">BugBarn weekly digest</h2>
+<p style="color:#555;margin-top:0">{{.Start}} – {{.End}} UTC</p>
+
 <table style="border-collapse:collapse;width:100%;margin:16px 0">
 <tr>
 <td style="padding:12px 16px;background:#f5f5f5;text-align:center">
@@ -138,23 +141,29 @@ var htmlTmpl = template.Must(template.New("html").Parse(`<!DOCTYPE html>
 </td>
 </tr>
 </table>
+
+{{range .Projects}}
+<h3 style="color:#1a1a1a;margin-top:28px;margin-bottom:4px;border-bottom:2px solid #eee;padding-bottom:6px">{{.Project}}</h3>
+<p style="color:#555;font-size:13px;margin:4px 0 8px">
+  {{.Stats.TotalEvents}} events &nbsp;·&nbsp; {{.Stats.NewIssues}} new &nbsp;·&nbsp; {{.Stats.ResolvedIssues}} resolved &nbsp;·&nbsp; {{.Stats.Regressions}} regressions
+</p>
 {{- if .TopIssues}}
-<h3 style="color:#1a1a1a;margin-top:24px">Top issues by volume</h3>
-<table style="border-collapse:collapse;width:100%">
+<table style="border-collapse:collapse;width:100%;margin-bottom:8px">
 <thead><tr style="background:#f5f5f5">
-  <th style="padding:8px 12px;text-align:left;font-size:12px;color:#555">Issue</th>
-  <th style="padding:8px 12px;text-align:right;font-size:12px;color:#555">Events</th>
-  <th style="padding:8px 12px;text-align:left;font-size:12px;color:#555">Status</th>
+  <th style="padding:6px 10px;text-align:left;font-size:12px;color:#555">Issue</th>
+  <th style="padding:6px 10px;text-align:right;font-size:12px;color:#555">Events</th>
+  <th style="padding:6px 10px;text-align:left;font-size:12px;color:#555">Status</th>
 </tr></thead>
 <tbody>
 {{range .TopIssues}}<tr style="border-top:1px solid #eee">
-  <td style="padding:8px 12px">{{if .URL}}<a href="{{.URL}}" style="color:#0066cc">{{.Title}}</a>{{else}}{{.Title}}{{end}}</td>
-  <td style="padding:8px 12px;text-align:right">{{.EventCount}}</td>
-  <td style="padding:8px 12px;color:#555">{{.Status}}</td>
+  <td style="padding:6px 10px;font-size:13px">{{if .URL}}<a href="{{.URL}}" style="color:#0066cc">{{.Title}}</a>{{else}}{{.Title}}{{end}}</td>
+  <td style="padding:6px 10px;text-align:right;font-size:13px">{{.EventCount}}</td>
+  <td style="padding:6px 10px;color:#555;font-size:13px">{{.Status}}</td>
 </tr>
 {{end}}</tbody>
 </table>
 {{- end}}
+{{end}}
 {{- if .PublicURL}}
 <p style="margin-top:24px"><a href="{{.PublicURL}}" style="color:#0066cc">View all issues →</a></p>
 {{- end}}
@@ -167,19 +176,19 @@ func sendEmailDigest(mc MailConfig, p payload, since, now time.Time) error {
 	}
 
 	d := mailData{
-		Project:        p.Project,
-		Start:          since.Format("Jan 2"),
-		End:            now.Format("Jan 2 2006"),
-		TotalEvents:    p.Stats.TotalEvents,
-		NewIssues:      p.Stats.NewIssues,
-		ResolvedIssues: p.Stats.ResolvedIssues,
-		Regressions:    p.Stats.Regressions,
-		TopIssues:      p.TopIssues,
-		PublicURL:      p.PublicURL,
+		Start:     since.Format("Jan 2"),
+		End:       now.Format("Jan 2 2006"),
+		Projects:  p.Projects,
+		PublicURL: p.PublicURL,
+	}
+	for _, sec := range p.Projects {
+		d.TotalEvents += sec.Stats.TotalEvents
+		d.NewIssues += sec.Stats.NewIssues
+		d.ResolvedIssues += sec.Stats.ResolvedIssues
+		d.Regressions += sec.Stats.Regressions
 	}
 
-	subject := fmt.Sprintf("[BugBarn] Weekly digest — %s — %s–%s",
-		p.Project, since.Format("Jan 2"), now.Format("Jan 2 2006"))
+	subject := fmt.Sprintf("[BugBarn] Weekly digest — %s–%s", since.Format("Jan 2"), now.Format("Jan 2 2006"))
 
 	var plain, html bytes.Buffer
 	if err := plainTmpl.Execute(&plain, d); err != nil {

--- a/internal/logstream/hub.go
+++ b/internal/logstream/hub.go
@@ -47,18 +47,28 @@ func (h *Hub) Subscribe(projectID int64) (<-chan storage.LogEntry, func()) {
 	return ch, cancel
 }
 
-// Publish sends an entry to all current subscribers for that project.
+// Publish sends an entry to all current subscribers for that project,
+// and also to all-projects subscribers (those subscribed with projectID=0).
 // Uses non-blocking sends so slow consumers do not block the publisher.
 func (h *Hub) Publish(projectID int64, entry storage.LogEntry) {
 	h.mu.RLock()
 	chans := h.subs[projectID]
+	var allChans []chan storage.LogEntry
+	if projectID != 0 {
+		allChans = h.subs[0]
+	}
 	h.mu.RUnlock()
 
 	for _, ch := range chans {
 		select {
 		case ch <- entry:
 		default:
-			// slow consumer; drop entry
+		}
+	}
+	for _, ch := range allChans {
+		select {
+		case ch <- entry:
+		default:
 		}
 	}
 }

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -333,26 +333,34 @@ func (s *Store) GetAlert(ctx context.Context, alertID string) (Alert, error) {
 	if !ok {
 		projectID = s.defaultProjectID
 	}
-	row := s.db.QueryRowContext(ctx, `
+
+	const sel = `
 SELECT
-	id,
-	name,
-	enabled,
-	severity,
-	rule_json,
-	webhook_url,
-	condition,
-	threshold,
-	cooldown_minutes,
-	last_fired_at,
-	created_at,
-	updated_at
-FROM alerts
-WHERE project_id = ? AND id = ?`,
-		projectID,
-		rowID,
-	)
-	return scanAlert(row)
+	a.id,
+	a.name,
+	a.enabled,
+	a.severity,
+	a.rule_json,
+	a.webhook_url,
+	a.condition,
+	a.threshold,
+	a.cooldown_minutes,
+	a.last_fired_at,
+	a.created_at,
+	a.updated_at,
+	COALESCE(p.slug, '') AS project_slug
+FROM alerts a
+LEFT JOIN projects p ON p.id = a.project_id`
+
+	var row *sql.Row
+	if projectID != 0 {
+		row = s.db.QueryRowContext(ctx, sel+`
+WHERE a.project_id = ? AND a.id = ?`, projectID, rowID)
+	} else {
+		row = s.db.QueryRowContext(ctx, sel+`
+WHERE a.id = ?`, rowID)
+	}
+	return scanAlertWithProject(row)
 }
 
 func (s *Store) CreateAlert(ctx context.Context, alert Alert) (Alert, error) {

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -61,15 +61,26 @@ func (s *Store) setIssueStatus(ctx context.Context, issueID, status string) (Iss
 	defer tx.Rollback()
 
 	now := formatTime(time.Now().UTC())
-	query := `
+	var execErr error
+	if projectID != 0 {
+		_, execErr = tx.ExecContext(ctx, `
 UPDATE issues
 SET status = ?,
 	resolved_at = CASE WHEN ? = 'resolved' THEN ? ELSE resolved_at END,
 	reopened_at = CASE WHEN ? = 'unresolved' THEN ? ELSE reopened_at END,
 	updated_at = CURRENT_TIMESTAMP
-WHERE id = ? AND project_id = ?`
-	if _, err := tx.ExecContext(ctx, query, status, status, now, status, now, rowID, projectID); err != nil {
-		return Issue{}, err
+WHERE id = ? AND project_id = ?`, status, status, now, status, now, rowID, projectID)
+	} else {
+		_, execErr = tx.ExecContext(ctx, `
+UPDATE issues
+SET status = ?,
+	resolved_at = CASE WHEN ? = 'resolved' THEN ? ELSE resolved_at END,
+	reopened_at = CASE WHEN ? = 'unresolved' THEN ? ELSE reopened_at END,
+	updated_at = CURRENT_TIMESTAMP
+WHERE id = ?`, status, status, now, status, now, rowID)
+	}
+	if execErr != nil {
+		return Issue{}, execErr
 	}
 	if err := tx.Commit(); err != nil {
 		return Issue{}, err
@@ -252,25 +263,51 @@ func (s *Store) ListAlerts(ctx context.Context) ([]Alert, error) {
 		projectID = s.defaultProjectID
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	var query string
+	var args []any
+	if projectID != 0 {
+		query = `
 SELECT
-	id,
-	name,
-	enabled,
-	severity,
-	rule_json,
-	webhook_url,
-	condition,
-	threshold,
-	cooldown_minutes,
-	last_fired_at,
-	created_at,
-	updated_at
-FROM alerts
-WHERE project_id = ?
-ORDER BY id DESC`,
-		projectID,
-	)
+	a.id,
+	a.name,
+	a.enabled,
+	a.severity,
+	a.rule_json,
+	a.webhook_url,
+	a.condition,
+	a.threshold,
+	a.cooldown_minutes,
+	a.last_fired_at,
+	a.created_at,
+	a.updated_at,
+	COALESCE(p.slug, '') AS project_slug
+FROM alerts a
+LEFT JOIN projects p ON p.id = a.project_id
+WHERE a.project_id = ?
+ORDER BY a.id DESC`
+		args = []any{projectID}
+	} else {
+		query = `
+SELECT
+	a.id,
+	a.name,
+	a.enabled,
+	a.severity,
+	a.rule_json,
+	a.webhook_url,
+	a.condition,
+	a.threshold,
+	a.cooldown_minutes,
+	a.last_fired_at,
+	a.created_at,
+	a.updated_at,
+	COALESCE(p.slug, '') AS project_slug
+FROM alerts a
+LEFT JOIN projects p ON p.id = a.project_id
+ORDER BY a.id DESC`
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +315,7 @@ ORDER BY id DESC`,
 
 	var alerts []Alert
 	for rows.Next() {
-		item, err := scanAlert(rows)
+		item, err := scanAlertWithProject(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -651,6 +688,51 @@ func scanAlert(scanner interface {
 		&lastFiredAt,
 		&createdAt,
 		&updatedAt,
+	); err != nil {
+		return Alert{}, err
+	}
+	item.ID = formatID(alertIDPrefix, id)
+	item.Enabled = enabled != 0
+	item.LastFiredAt, _ = parseTime(lastFiredAt)
+	item.CreatedAt, _ = parseTime(createdAt)
+	item.UpdatedAt, _ = parseTime(updatedAt)
+	if len(ruleRaw) > 0 {
+		if err := json.Unmarshal(ruleRaw, &item.Rule); err != nil {
+			return Alert{}, err
+		}
+	}
+	if item.Rule == nil {
+		item.Rule = map[string]any{}
+	}
+	return item, nil
+}
+
+func scanAlertWithProject(scanner interface {
+	Scan(dest ...any) error
+}) (Alert, error) {
+	var (
+		id          int64
+		item        Alert
+		ruleRaw     []byte
+		lastFiredAt string
+		createdAt   string
+		updatedAt   string
+		enabled     int
+	)
+	if err := scanner.Scan(
+		&id,
+		&item.Name,
+		&enabled,
+		&item.Severity,
+		&ruleRaw,
+		&item.WebhookURL,
+		&item.Condition,
+		&item.Threshold,
+		&item.CooldownMinutes,
+		&lastFiredAt,
+		&createdAt,
+		&updatedAt,
+		&item.ProjectSlug,
 	); err != nil {
 		return Alert{}, err
 	}

--- a/internal/storage/context.go
+++ b/internal/storage/context.go
@@ -2,14 +2,22 @@ package storage
 
 import "context"
 
-// WithProjectID returns a context carrying the given project ID for use by Store methods.
+type ctxProjectKey struct{}
+
+// projectIDVal wraps an int64 so that WithProjectID(ctx, 0) (all-projects) is
+// distinguishable from a context that carries no project at all.
+type projectIDVal struct{ id int64 }
+
+// WithProjectID returns a context carrying the given project ID for use by Store
+// methods. Pass 0 to signal "all projects" (session-based reads only).
 func WithProjectID(ctx context.Context, id int64) context.Context {
-	return context.WithValue(ctx, ctxProjectKey{}, id)
+	return context.WithValue(ctx, ctxProjectKey{}, projectIDVal{id: id})
 }
 
-// ProjectIDFromContext extracts the project ID stored by WithProjectID.
-// Returns (id, true) when a positive project ID is present, (0, false) otherwise.
+// ProjectIDFromContext extracts the project ID set by WithProjectID.
+// Returns (id, true) when a project was explicitly set (id may be 0 = all projects).
+// Returns (0, false) when no project was set at all (callers should fall back to defaultProjectID).
 func ProjectIDFromContext(ctx context.Context) (int64, bool) {
-	id, ok := ctx.Value(ctxProjectKey{}).(int64)
-	return id, ok && id > 0
+	val, ok := ctx.Value(ctxProjectKey{}).(projectIDVal)
+	return val.id, ok
 }

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -32,22 +32,42 @@ func (s *Store) ListIssueEvents(ctx context.Context, issueID string, limit int, 
 	fetch := limit + 1
 
 	var rows *sql.Rows
-	if beforeID > 0 {
-		rows, err = s.db.QueryContext(ctx, `
+	if projectID != 0 {
+		if beforeID > 0 {
+			rows, err = s.db.QueryContext(ctx, `
 SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
        received_at, observed_at, severity, message, regressed, event_json
 FROM events
 WHERE project_id = ? AND issue_id = ? AND id < ?
 ORDER BY id DESC LIMIT ?`,
-			projectID, rowID, beforeID, fetch)
-	} else {
-		rows, err = s.db.QueryContext(ctx, `
+				projectID, rowID, beforeID, fetch)
+		} else {
+			rows, err = s.db.QueryContext(ctx, `
 SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
        received_at, observed_at, severity, message, regressed, event_json
 FROM events
 WHERE project_id = ? AND issue_id = ?
 ORDER BY id DESC LIMIT ?`,
-			projectID, rowID, fetch)
+				projectID, rowID, fetch)
+		}
+	} else {
+		if beforeID > 0 {
+			rows, err = s.db.QueryContext(ctx, `
+SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
+       received_at, observed_at, severity, message, regressed, event_json
+FROM events
+WHERE issue_id = ? AND id < ?
+ORDER BY id DESC LIMIT ?`,
+				rowID, beforeID, fetch)
+		} else {
+			rows, err = s.db.QueryContext(ctx, `
+SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
+       received_at, observed_at, severity, message, regressed, event_json
+FROM events
+WHERE issue_id = ?
+ORDER BY id DESC LIMIT ?`,
+				rowID, fetch)
+		}
 	}
 	if err != nil {
 		return nil, false, err

--- a/internal/storage/facets.go
+++ b/internal/storage/facets.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -195,11 +196,22 @@ func (s *Store) PersistFacets(ctx context.Context, eventID int64, issueID int64,
 }
 
 // ListFacetKeys returns all distinct facet keys observed for a project.
+// Pass projectID=0 to query across all projects.
 func (s *Store) ListFacetKeys(ctx context.Context, projectID int64) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT DISTINCT facet_key FROM event_facets WHERE project_id = ? ORDER BY facet_key ASC`,
-		projectID,
+	var (
+		rows *sql.Rows
+		err  error
 	)
+	if projectID != 0 {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT facet_key FROM event_facets WHERE project_id = ? ORDER BY facet_key ASC`,
+			projectID,
+		)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT facet_key FROM event_facets ORDER BY facet_key ASC`,
+		)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -217,11 +229,23 @@ func (s *Store) ListFacetKeys(ctx context.Context, projectID int64) ([]string, e
 }
 
 // ListFacetValues returns all distinct values observed for a facet key in a project.
+// Pass projectID=0 to query across all projects.
 func (s *Store) ListFacetValues(ctx context.Context, projectID int64, key string) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT DISTINCT facet_value FROM event_facets WHERE project_id = ? AND facet_key = ? ORDER BY facet_value ASC`,
-		projectID, key,
+	var (
+		rows *sql.Rows
+		err  error
 	)
+	if projectID != 0 {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT facet_value FROM event_facets WHERE project_id = ? AND facet_key = ? ORDER BY facet_value ASC`,
+			projectID, key,
+		)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT facet_value FROM event_facets WHERE facet_key = ? ORDER BY facet_value ASC`,
+			key,
+		)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -21,11 +21,11 @@ func (s *Store) ListIssuesFiltered(ctx context.Context, filter IssueFilter) ([]I
 	var orderBy string
 	switch filter.Sort {
 	case "first_seen":
-		orderBy = "first_seen DESC, id DESC"
+		orderBy = "i.first_seen DESC, i.id DESC"
 	case "event_count":
-		orderBy = "event_count DESC, id DESC"
+		orderBy = "i.event_count DESC, i.id DESC"
 	default:
-		orderBy = "last_seen DESC, id DESC"
+		orderBy = "i.last_seen DESC, i.id DESC"
 	}
 
 	// Collect non-empty facet filters.
@@ -41,9 +41,14 @@ func (s *Store) ListIssuesFiltered(ctx context.Context, filter IssueFilter) ([]I
 	if !ok {
 		projectID = s.defaultProjectID
 	}
+	allProjects := projectID == 0
 
-	conditions := []string{"i.project_id = ?"}
-	whereArgs := []any{projectID}
+	var conditions []string
+	var whereArgs []any
+	if !allProjects {
+		conditions = append(conditions, "i.project_id = ?")
+		whereArgs = append(whereArgs, projectID)
+	}
 
 	switch filter.Status {
 	case "open":
@@ -70,14 +75,20 @@ func (s *Store) ListIssuesFiltered(ctx context.Context, filter IssueFilter) ([]I
 		// matching issue_ids. The join enforces AND semantics across all filters.
 		var subqueries []string
 		for _, f := range facetFilters {
-			subqueries = append(subqueries,
-				`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
-			fromArgs = append(fromArgs, projectID, f.k, f.v)
+			if !allProjects {
+				subqueries = append(subqueries,
+					`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
+				fromArgs = append(fromArgs, projectID, f.k, f.v)
+			} else {
+				subqueries = append(subqueries,
+					`SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`)
+				fromArgs = append(fromArgs, f.k, f.v)
+			}
 		}
-		fromClause = fmt.Sprintf(`issues i INNER JOIN (%s) ef ON i.id = ef.issue_id`,
+		fromClause = fmt.Sprintf(`issues i INNER JOIN (%s) ef ON i.id = ef.issue_id LEFT JOIN projects p ON p.id = i.project_id`,
 			strings.Join(subqueries, " INTERSECT "))
 	} else {
-		fromClause = "issues i"
+		fromClause = "issues i LEFT JOIN projects p ON p.id = i.project_id"
 	}
 
 	// Combine: subquery bindings first (appear in FROM clause), then WHERE bindings.
@@ -101,10 +112,15 @@ SELECT
 	i.first_seen,
 	i.last_seen,
 	i.event_count,
-	i.representative_event_json
-FROM ` + fromClause + `
-WHERE ` + strings.Join(conditions, " AND ") + `
-ORDER BY i.` + orderBy
+	i.representative_event_json,
+	COALESCE(p.slug, '') AS project_slug
+FROM ` + fromClause
+	if len(conditions) > 0 {
+		sqlQuery += `
+WHERE ` + strings.Join(conditions, " AND ")
+	}
+	sqlQuery += `
+ORDER BY ` + orderBy
 
 	rows, err := s.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
@@ -137,30 +153,37 @@ func (s *Store) GetIssue(ctx context.Context, issueID string) (Issue, error) {
 		projectID = s.defaultProjectID
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	const sel = `
 SELECT
-	id,
-	fingerprint,
-	fingerprint_material,
-	fingerprint_explanation_json,
-	title,
-	normalized_title,
-	exception_type,
-	status,
-	mute_mode,
-	resolved_at,
-	reopened_at,
-	last_regressed_at,
-	regression_count,
-	first_seen,
-	last_seen,
-	event_count,
-	representative_event_json
-FROM issues
-WHERE project_id = ? AND id = ?`,
-		projectID,
-		rowID,
-	)
+	i.id,
+	i.fingerprint,
+	i.fingerprint_material,
+	i.fingerprint_explanation_json,
+	i.title,
+	i.normalized_title,
+	i.exception_type,
+	i.status,
+	i.mute_mode,
+	i.resolved_at,
+	i.reopened_at,
+	i.last_regressed_at,
+	i.regression_count,
+	i.first_seen,
+	i.last_seen,
+	i.event_count,
+	i.representative_event_json,
+	COALESCE(p.slug, '') AS project_slug
+FROM issues i
+LEFT JOIN projects p ON p.id = i.project_id`
+
+	var row *sql.Row
+	if projectID != 0 {
+		row = s.db.QueryRowContext(ctx, sel+`
+WHERE i.project_id = ? AND i.id = ?`, projectID, rowID)
+	} else {
+		row = s.db.QueryRowContext(ctx, sel+`
+WHERE i.id = ?`, rowID)
+	}
 
 	return scanIssue(row)
 }
@@ -449,6 +472,7 @@ func scanIssue(scanner interface {
 		&lastSeen,
 		&issue.EventCount,
 		&representativeRaw,
+		&issue.ProjectSlug,
 	); err != nil {
 		return Issue{}, err
 	}
@@ -489,12 +513,16 @@ func (s *Store) MuteIssue(ctx context.Context, issueID string, muteMode string) 
 	if !ok {
 		projectID = s.defaultProjectID
 	}
-	if _, err := s.db.ExecContext(ctx, `
-UPDATE issues
-SET status = 'muted', mute_mode = ?, updated_at = CURRENT_TIMESTAMP
-WHERE id = ? AND project_id = ?`,
-		muteMode, rowID, projectID,
-	); err != nil {
+	if projectID != 0 {
+		_, err = s.db.ExecContext(ctx, `
+UPDATE issues SET status = 'muted', mute_mode = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND project_id = ?`,
+			muteMode, rowID, projectID)
+	} else {
+		_, err = s.db.ExecContext(ctx, `
+UPDATE issues SET status = 'muted', mute_mode = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			muteMode, rowID)
+	}
+	if err != nil {
 		return Issue{}, err
 	}
 	return s.GetIssue(ctx, issueID)
@@ -510,13 +538,18 @@ func (s *Store) UnmuteIssue(ctx context.Context, issueID string) (Issue, error) 
 	if !ok {
 		projectID = s.defaultProjectID
 	}
-	if _, err := s.db.ExecContext(ctx, `
-UPDATE issues
-SET status = 'unresolved', mute_mode = '', updated_at = CURRENT_TIMESTAMP
-WHERE id = ? AND project_id = ?`,
-		rowID, projectID,
-	); err != nil {
-		return Issue{}, err
+	var err2 error
+	if projectID != 0 {
+		_, err2 = s.db.ExecContext(ctx, `
+UPDATE issues SET status = 'unresolved', mute_mode = '', updated_at = CURRENT_TIMESTAMP WHERE id = ? AND project_id = ?`,
+			rowID, projectID)
+	} else {
+		_, err2 = s.db.ExecContext(ctx, `
+UPDATE issues SET status = 'unresolved', mute_mode = '', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			rowID)
+	}
+	if err2 != nil {
+		return Issue{}, err2
 	}
 	return s.GetIssue(ctx, issueID)
 }
@@ -536,20 +569,26 @@ func (s *Store) HourlyEventCounts(ctx context.Context, issueIDs []int64) (map[in
 
 	// Build placeholder list.
 	placeholders := make([]string, len(issueIDs))
-	args := []any{projectID}
+	var args []any
+	if projectID != 0 {
+		args = append(args, projectID)
+	}
 	for i, id := range issueIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
 
+	var projectFilter string
+	if projectID != 0 {
+		projectFilter = "project_id = ? AND "
+	}
 	query := `
 SELECT
 	issue_id,
 	strftime('%Y-%m-%dT%H', observed_at) AS hour_bucket,
 	COUNT(*) AS cnt
 FROM events
-WHERE project_id = ?
-  AND issue_id IN (` + strings.Join(placeholders, ",") + `)
+WHERE ` + projectFilter + `issue_id IN (` + strings.Join(placeholders, ",") + `)
   AND observed_at >= datetime('now', '-24 hours')
 GROUP BY issue_id, hour_bucket`
 

--- a/internal/storage/logs.go
+++ b/internal/storage/logs.go
@@ -69,34 +69,43 @@ func (s *Store) InsertLogEntries(ctx context.Context, entries []LogEntry) error 
 	return tx.Commit()
 }
 
-// ListLogEntries returns up to limit entries for a project, newest first.
+// ListLogEntries returns up to limit entries for a project (or all projects when projectID=0), newest first.
 // Optional filters: levelMin (numeric pino level, 0 = no filter), q (substring match on message),
 // beforeID (cursor, 0 = no cursor).
 func (s *Store) ListLogEntries(ctx context.Context, projectID int64, levelMin int, q string, limit int, beforeID int64) ([]LogEntry, error) {
-	args := []any{projectID}
+	var args []any
 	var conditions []string
-	conditions = append(conditions, "project_id = ?")
 
+	if projectID != 0 {
+		conditions = append(conditions, "le.project_id = ?")
+		args = append(args, projectID)
+	}
 	if levelMin > 0 {
-		conditions = append(conditions, "level_num >= ?")
+		conditions = append(conditions, "le.level_num >= ?")
 		args = append(args, levelMin)
 	}
 	if q != "" {
-		conditions = append(conditions, "message LIKE ?")
+		conditions = append(conditions, "le.message LIKE ?")
 		args = append(args, fmt.Sprintf("%%%s%%", q))
 	}
 	if beforeID > 0 {
-		conditions = append(conditions, "id < ?")
+		conditions = append(conditions, "le.id < ?")
 		args = append(args, beforeID)
 	}
 
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
 	query := fmt.Sprintf(`
-		SELECT id, project_id, received_at, level_num, level, message, data_json
-		FROM log_entries
-		WHERE %s
-		ORDER BY id DESC
+		SELECT le.id, le.project_id, le.received_at, le.level_num, le.level, le.message, le.data_json, COALESCE(p.slug, '') AS project_slug
+		FROM log_entries le
+		LEFT JOIN projects p ON p.id = le.project_id
+		%s
+		ORDER BY le.id DESC
 		LIMIT ?
-	`, strings.Join(conditions, " AND "))
+	`, whereClause)
 	args = append(args, limit)
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -110,7 +119,7 @@ func (s *Store) ListLogEntries(ctx context.Context, projectID int64, levelMin in
 		var e LogEntry
 		var receivedAt string
 		var dataJSON string
-		if err := rows.Scan(&e.ID, &e.ProjectID, &receivedAt, &e.LevelNum, &e.Level, &e.Message, &dataJSON); err != nil {
+		if err := rows.Scan(&e.ID, &e.ProjectID, &receivedAt, &e.LevelNum, &e.Level, &e.Message, &dataJSON, &e.ProjectSlug); err != nil {
 			return nil, err
 		}
 		if t, err := time.Parse(time.RFC3339Nano, receivedAt); err == nil {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -13,8 +13,6 @@ type Store struct {
 	defaultProjectID int64
 }
 
-type ctxProjectKey struct{}
-
 // Issue represents a grouped error occurrence.
 type Issue struct {
 	ID                     string
@@ -34,6 +32,7 @@ type Issue struct {
 	LastSeen               time.Time
 	EventCount             int
 	RepresentativeEvent    event.Event
+	ProjectSlug            string `json:"project_slug,omitempty"`
 }
 
 // IssueHourlyCounts holds per-issue 24-hour event frequency data.
@@ -136,6 +135,7 @@ type Alert struct {
 	LastFiredAt     time.Time      `json:"last_fired_at,omitempty"`
 	CreatedAt       time.Time      `json:"created_at,omitempty"`
 	UpdatedAt       time.Time      `json:"updated_at,omitempty"`
+	ProjectSlug     string         `json:"project_slug,omitempty"`
 }
 
 // Setting represents a project setting row.
@@ -154,11 +154,12 @@ type facetRow struct {
 
 // LogEntry represents a single structured log line stored per project.
 type LogEntry struct {
-	ID         int64          `json:"id"`
-	ProjectID  int64          `json:"project_id,omitempty"`
-	ReceivedAt time.Time      `json:"received_at"`
-	LevelNum   int            `json:"level_num"`
-	Level      string         `json:"level"`
-	Message    string         `json:"message"`
-	Data       map[string]any `json:"data,omitempty"`
+	ID          int64          `json:"id"`
+	ProjectID   int64          `json:"project_id,omitempty"`
+	ProjectSlug string         `json:"project_slug,omitempty"`
+	ReceivedAt  time.Time      `json:"received_at"`
+	LevelNum    int            `json:"level_num"`
+	Level       string         `json:"level"`
+	Message     string         `json:"message"`
+	Data        map[string]any `json:"data,omitempty"`
 }

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -30,7 +30,7 @@ const state: AppState = {
   authenticated: false,
   username: "",
   projects: [],
-  currentProject: localStorage.getItem(projectKey) ?? "default",
+  currentProject: (() => { const v = localStorage.getItem(projectKey); return (v && v !== "default") ? v : "__all"; })(),
   currentEnv: localStorage.getItem(envKey) ?? "",
   currentRoute: "issues",
   issues: [],
@@ -474,15 +474,17 @@ async function loadProjects(): Promise<void> {
 function renderProjectSwitcher(): void {
   if (!projectSelect) return;
   const current = state.currentProject;
-  projectSelect.innerHTML = state.projects
-    .map((p) => {
-      const slug = String(p.slug ?? p.Slug ?? "default");
-      const name = String(p.name ?? p.Name ?? slug);
-      const selected = slug === current ? ' selected' : '';
-      return `<option value="${escapeHtml(slug)}"${selected}>${escapeHtml(name)}</option>`;
-    })
-    .join("");
-  projectSelect.hidden = state.projects.length <= 1;
+  const allSelected = (current === "__all" || !current) ? ' selected' : '';
+  projectSelect.innerHTML = `<option value="__all"${allSelected}>All projects</option>` +
+    state.projects
+      .map((p) => {
+        const slug = String(p.slug ?? p.Slug ?? "default");
+        const name = String(p.name ?? p.Name ?? slug);
+        const selected = slug === current ? ' selected' : '';
+        return `<option value="${escapeHtml(slug)}"${selected}>${escapeHtml(name)}</option>`;
+      })
+      .join("");
+  projectSelect.hidden = state.projects.length === 0;
 }
 
 async function loadEnvironments(): Promise<void> {
@@ -629,7 +631,7 @@ async function fetchJson(path: string, allowMissing = false): Promise<unknown> {
   }
 
   const headers: Record<string, string> = { Accept: "application/json" };
-  if (state.currentProject && state.currentProject !== "default") {
+  if (state.currentProject && state.currentProject !== "default" && state.currentProject !== "__all") {
     headers["X-BugBarn-Project"] = state.currentProject;
   }
   const request = fetch(url, { credentials: "include", headers }).then(async (response) => {
@@ -1214,7 +1216,7 @@ async function apiFetch(path: string, init: RequestInit = {}): Promise<Response>
   if (csrf) {
     headers["X-BugBarn-CSRF"] = csrf;
   }
-  if (state.currentProject && state.currentProject !== "default") {
+  if (state.currentProject && state.currentProject !== "default" && state.currentProject !== "__all") {
     headers["X-BugBarn-Project"] = state.currentProject;
   }
   return fetch(apiUrl(path), { credentials: "include", ...init, headers });

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -186,7 +186,12 @@ projectSelect?.addEventListener("change", () => {
   localStorage.setItem(projectKey, slug);
   state.currentEnv = "";
   localStorage.removeItem(envKey);
-  void Promise.all([loadEnvironments(), refreshAll()]);
+  if (slug === "__all") {
+    renderEnvSwitcher([]);
+    void refreshAll();
+  } else {
+    void Promise.all([loadEnvironments(), refreshAll()]);
+  }
 });
 
 envSelect?.addEventListener("change", () => {
@@ -234,7 +239,8 @@ async function start(): Promise<void> {
     renderLogin();
     return;
   }
-  await Promise.all([loadProjects(), loadEnvironments(), refreshAll()]);
+  const envLoad = state.currentProject !== "__all" ? loadEnvironments() : Promise.resolve();
+  await Promise.all([loadProjects(), envLoad, refreshAll()]);
 }
 
 function byId<T extends HTMLElement>(id: string): T {

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -63,6 +63,7 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
         const active = id && String(id) === String(selectedIssueId) ? "active" : "";
         const severity = issueSeverity(issue);
         const severityClass = severity === "error" || severity === "fatal" ? "bad" : severity === "warning" ? "warn" : "";
+        const projectSlug = issue.project_slug ? String(issue.project_slug) : "";
         return `
           <button class="item issue-row ${active}" type="button" data-issue-id="${escapeAttr(id)}">
             <div class="item-title"><span class="status-dot"></span>${escapeHtml(title)}</div>
@@ -74,6 +75,7 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
             <span class="issue-cell">${renderSparkline(issue.hourly_counts)}</span>
             <div class="item-meta">
               <span>${escapeHtml(issueExceptionType(issue) || "Error")}</span>
+              ${projectSlug ? `<span class="chip" style="font-size:0.65rem;opacity:0.7">${escapeHtml(projectSlug)}</span>` : ""}
               <span>${escapeHtml(id)}</span>
             </div>
           </button>
@@ -866,11 +868,13 @@ function renderAlertList(alerts: ApiAlert[]): string {
           const cooldown = alert.cooldown_minutes ?? 0;
           const enabled = Boolean(alert.enabled);
           const lastFiredAt = formatTime(alert.last_fired_at) || "never";
+          const projectSlug = alert.project_slug ? String(alert.project_slug) : "";
           return `
             <article class="route-item">
               <div class="route-item-head">
                 <strong>${escapeHtml(title)}</strong>
                 <span class="chip ${enabled ? "" : "bad"}">${escapeHtml(enabled ? "enabled" : "disabled")}</span>
+                ${projectSlug ? `<span class="chip" style="font-size:0.65rem;opacity:0.7">${escapeHtml(projectSlug)}</span>` : ""}
                 ${webhookBadge(webhookUrl)}
               </div>
               <div class="route-item-meta">
@@ -1164,11 +1168,13 @@ export function renderLogRow(entry: ApiLogEntry): string {
   const dataExpanded = hasData
     ? `<div class="log-data-expanded"><pre>${escapeHtml(JSON.stringify(entry.data, null, 2))}</pre></div>`
     : "";
+  const projectBadge = entry.project_slug ? `<span class="chip" style="font-size:0.65rem;opacity:0.7;margin-left:0.25rem">${escapeHtml(entry.project_slug)}</span>` : "";
   return `
     <div class="log-row log-row-${escapeAttr(entry.level)}" data-log-id="${escapeAttr(String(entry.id))}">
       <span class="log-time">${escapeHtml(formatTime(entry.received_at))}</span>
       <span class="log-level log-level-${escapeAttr(entry.level)}">${escapeHtml(entry.level.toUpperCase())}</span>
       <span class="log-msg">${escapeHtml(entry.message)}</span>
+      ${projectBadge}
       ${dataInline}
       ${dataExpanded}
     </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -46,6 +46,7 @@ export interface ApiIssue extends RawRecord {
   fingerprint_debug?: RawRecord;
   hourly_counts?: number[];
   mute_mode?: string;
+  project_slug?: string;
 }
 
 export interface ApiEvent extends RawRecord {
@@ -113,6 +114,7 @@ export interface ApiAlert extends RawRecord {
   cooldown_minutes?: number;
   last_fired_at?: string;
   created_at?: string;
+  project_slug?: string;
 }
 
 export interface ApiApiKey extends RawRecord {
@@ -146,6 +148,7 @@ export interface ApiLogEntry {
   level: string
   message: string
   data?: Record<string, unknown>
+  project_slug?: string
 }
 
 export interface ApiSettings extends RawRecord {


### PR DESCRIPTION
## Summary

- Adds an **"All projects"** option to the project switcher (now the default on first load, replacing the old hard-coded "default" fallback)
- Backend GET requests with no explicit project header now return data across all projects — storage queries for issues, events, logs, and alerts all handle `projectID=0` as "no filter"
- Each returned item carries a `project_slug` field; the UI renders a small chip on issue rows, alert items, and log rows so you can tell items apart at a glance
- Log stream (`Hub.Publish`) now fans out to all-projects subscribers, so the live log tail works in all-projects mode too
- Non-GET writes (create, resolve, mute, etc.) still default to the "default" project when no project header is sent — no change in write behaviour

## Changes

| Layer | What changed |
|---|---|
| `storage/context.go` | Wraps project ID in a struct so `WithProjectID(ctx, 0)` is distinguishable from "no value set" |
| `storage/types.go` | Adds `ProjectSlug` to `Issue`, `Alert`, `LogEntry` |
| `storage/issues.go` | All query paths support `projectID=0`; joins `projects` to include slug |
| `storage/admin.go` | `ListAlerts` and issue mutations support `projectID=0` |
| `storage/events.go` | `ListIssueEvents` supports `projectID=0` |
| `storage/logs.go` | `ListLogEntries` supports `projectID=0`; joins `projects` for slug |
| `api/server.go` | GET requests without project header resolve to `0` (all); writes stay on "default" |
| `api/logs.go` | Removes "project required" guard; `0` passes through to storage |
| `logstream/hub.go` | `Publish` fans out to project-0 subscribers after project-specific ones |
| `web/src/app.ts` | Adds `__all` sentinel; project switcher always visible; header omitted when `__all` |
| `web/src/components.ts` | Project slug chips on issue rows, alert items, log rows |
| `web/src/types.ts` | `project_slug` added to `ApiIssue`, `ApiAlert`, `ApiLogEntry` |

## Test plan

- [ ] Select "All projects" in the switcher — issue list shows issues from all projects, each with a project chip
- [ ] Select a specific project — project chip disappears, only that project's issues shown
- [ ] Live log tail in all-projects mode receives entries from every project
- [ ] Resolve / mute an issue from all-projects view — write succeeds
- [ ] Alert list in all-projects mode shows alerts from all projects with chips