### PR TITLE
feat(dist): binary distribution via APT and Homebrew

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,0 +1,364 @@
+name: Binary Release
+
+# Builds and publishes bugbarn binaries on every push to main.
+# Publishes to:
+#   - APT repository:      https://webwiebe.nl/apt/  (via rapid-root centralized workflow)
+#   - Homebrew tap (MinIO): https://webwiebe.nl/brew/bugbarn-darwin-*.tar.gz
+#   - Homebrew tap (GitHub): wiebe-xyz/homebrew-buddy-tools Formula/bugbarn.rb
+#   - GitHub Releases:     attached .deb and .tar.gz files
+#
+# APT publishing is delegated to wiebe-xyz/rapid-root via repository_dispatch —
+# no MinIO credentials or GPG keys needed here for APT.
+# Brew tarballs are uploaded directly to MinIO (bucket: webwiebe-apt-repository,
+# under the brew/ prefix). No --delete flag is ever used, so other apps' files
+# in the shared bucket are never touched.
+#
+# Required GitHub secrets:
+#   RAPID_ROOT_DISPATCH_TOKEN  — PAT with repo scope on wiebe-xyz/rapid-root
+#   MINIO_ACCESS_KEY           — MinIO user: webwiebe-apt
+#   MINIO_SECRET_KEY           — MinIO password for webwiebe-apt
+#   MINIO_ENDPOINT             — https://s3.wiebe.xyz
+#   MINIO_BUCKET               — webwiebe-apt-repository
+#   TAP_GITHUB_TOKEN           — PAT with repo scope on wiebe-xyz/homebrew-buddy-tools
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.next_version.outputs.version }}
+      version_num: ${{ steps.next_version.outputs.version_num }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+          echo "Latest tag: ${LATEST_TAG}"
+
+      - name: Calculate next version
+        id: next_version
+        run: |
+          LATEST_TAG=${{ steps.latest_tag.outputs.tag }}
+          VERSION=${LATEST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          PATCH=$((PATCH + 1))
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_num=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
+          echo "Next version: ${NEW_VERSION}"
+
+      - name: Create tag
+        run: |
+          NEW_VERSION=${{ steps.next_version.outputs.version }}
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
+          git push origin "${NEW_VERSION}"
+
+  # ---------------------------------------------------------------------------
+  # Linux: build binaries and .deb packages
+  # ---------------------------------------------------------------------------
+  build-debs:
+    name: Build .deb Packages (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    needs: tag
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build binary
+        env:
+          GOOS: linux
+          VERSION: ${{ needs.tag.outputs.version_num }}
+        run: |
+          GOARCH="${{ matrix.arch }}"
+          export GOARCH
+          BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-X main.Version=v${VERSION} -X main.BuildTime=${BUILD_TIME}"
+          mkdir -p dist
+          go build -ldflags "${LDFLAGS}" -o dist/bugbarn-linux-${GOARCH} ./cmd/bugbarn
+
+      - name: Build .deb package
+        env:
+          VERSION: ${{ needs.tag.outputs.version_num }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p debs
+          envsubst < nfpm-bugbarn.yaml > nfpm-bugbarn-processed.yaml
+          nfpm package \
+            --config nfpm-bugbarn-processed.yaml \
+            --packager deb \
+            --target debs/
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debs-${{ matrix.arch }}
+          path: debs/*.deb
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # macOS: build versioned tarballs
+  # ---------------------------------------------------------------------------
+  build-darwin-tarballs:
+    name: Build macOS Tarballs (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    needs: tag
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Build macOS binary
+        env:
+          GOOS: darwin
+          GOARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.tag.outputs.version_num }}
+        run: |
+          BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-X main.Version=v${VERSION} -X main.BuildTime=${BUILD_TIME}"
+          mkdir -p dist
+          go build -ldflags "${LDFLAGS}" -o dist/bugbarn ./cmd/bugbarn
+          TARBALL="bugbarn-darwin-${{ matrix.arch }}-${VERSION}.tar.gz"
+          tar -czvf dist/${TARBALL} -C dist bugbarn
+          rm dist/bugbarn
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          for f in *.tar.gz; do sha256sum "$f" > "${f}.sha256"; done
+
+      - name: Upload tarball artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-${{ matrix.arch }}
+          path: dist/*.tar.gz*
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Attach release assets to GitHub Release, then trigger rapid-root APT update
+  # ---------------------------------------------------------------------------
+  attach-debs-to-release:
+    name: Attach .deb to Release
+    runs-on: ubuntu-latest
+    needs: [tag, build-debs]
+    steps:
+      - name: Download all .deb artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: debs-download
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          find debs-download -name "*.deb" -exec cp {} release/ \;
+          cd release && sha256sum *.deb > checksums-deb.txt
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.tag.outputs.version }}
+          files: release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger rapid-root APT repository update
+        env:
+          GH_TOKEN: ${{ secrets.RAPID_ROOT_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/wiebe-xyz/rapid-root/dispatches \
+            --method POST \
+            --field event_type=apt-package-update \
+            --field 'client_payload[repo]=wiebe-xyz/bugbarn' \
+            --field 'client_payload[tag]=${{ needs.tag.outputs.version }}' \
+            --field 'client_payload[asset_pattern]=*.deb'
+
+  attach-tarballs-to-release:
+    name: Attach macOS Tarballs to Release
+    runs-on: ubuntu-latest
+    needs: [tag, build-darwin-tarballs]
+    steps:
+      - name: Download all darwin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: darwin-*
+          path: darwin-download
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          find darwin-download -name "*.tar.gz" -exec cp {} release/ \;
+          find darwin-download -name "*.sha256" -exec cp {} release/ \;
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.tag.outputs.version }}
+          files: release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # macOS: publish tarballs + formula to MinIO and GitHub Homebrew tap
+  # ---------------------------------------------------------------------------
+  update-brew-repo:
+    name: Update Homebrew Tap (MinIO)
+    runs-on: ubuntu-latest
+    needs: [tag, build-darwin-tarballs]
+    steps:
+      - name: Download all darwin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: darwin-*
+          path: darwin-download
+
+      - name: Prepare brew repository
+        env:
+          VERSION: ${{ needs.tag.outputs.version_num }}
+        run: |
+          mkdir -p brew-repo/Formula
+          find darwin-download -name "*.tar.gz" -exec cp {} brew-repo/ \;
+          find darwin-download -name "*.sha256" -exec cp {} brew-repo/ \;
+
+          AMD64_SHA=$(cat brew-repo/bugbarn-darwin-amd64-${VERSION}.tar.gz.sha256 | awk '{print $1}')
+          ARM64_SHA=$(cat brew-repo/bugbarn-darwin-arm64-${VERSION}.tar.gz.sha256 | awk '{print $1}')
+
+          cat > brew-repo/Formula/bugbarn.rb << EOF
+          class Bugbarn < Formula
+            desc "Self-hosted error tracking server"
+            homepage "https://github.com/wiebe-xyz/bugbarn"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.intel?
+                url "https://webwiebe.nl/brew/bugbarn-darwin-amd64-${VERSION}.tar.gz"
+                sha256 "${AMD64_SHA}"
+              elsif Hardware::CPU.arm?
+                url "https://webwiebe.nl/brew/bugbarn-darwin-arm64-${VERSION}.tar.gz"
+                sha256 "${ARM64_SHA}"
+              end
+            end
+
+            def install
+              bin.install "bugbarn"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/bugbarn version")
+            end
+          end
+          EOF
+
+      - name: Deploy to MinIO (brew/ prefix — only adds bugbarn files)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
+        run: |
+          pip install awscli
+          # No --delete: existing files from other apps are never touched.
+          aws --endpoint-url "$AWS_ENDPOINT_URL" s3 sync \
+            brew-repo/ \
+            s3://${MINIO_BUCKET}/brew/ \
+            --cache-control "public, max-age=3600, must-revalidate"
+
+  update-homebrew-tap:
+    name: Update GitHub Tap Repository
+    runs-on: ubuntu-latest
+    needs: [tag, update-brew-repo]
+    steps:
+      - name: Download darwin artifacts for checksums
+        uses: actions/download-artifact@v4
+        with:
+          pattern: darwin-*
+          path: darwin-download
+
+      - name: Generate formula and push to tap
+        env:
+          VERSION: ${{ needs.tag.outputs.version_num }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$TAP_GITHUB_TOKEN" ]; then
+            echo "ERROR: TAP_GITHUB_TOKEN secret is required"
+            exit 1
+          fi
+
+          AMD64_SHA=$(cat darwin-download/darwin-amd64/bugbarn-darwin-amd64-${VERSION}.tar.gz.sha256 | awk '{print $1}')
+          ARM64_SHA=$(cat darwin-download/darwin-arm64/bugbarn-darwin-arm64-${VERSION}.tar.gz.sha256 | awk '{print $1}')
+
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/wiebe-xyz/homebrew-buddy-tools.git tap-repo
+          cd tap-repo
+          mkdir -p Formula
+
+          cat > Formula/bugbarn.rb << EOF
+          class Bugbarn < Formula
+            desc "Self-hosted error tracking server"
+            homepage "https://github.com/wiebe-xyz/bugbarn"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.intel?
+                url "https://webwiebe.nl/brew/bugbarn-darwin-amd64-${VERSION}.tar.gz"
+                sha256 "${AMD64_SHA}"
+              elsif Hardware::CPU.arm?
+                url "https://webwiebe.nl/brew/bugbarn-darwin-arm64-${VERSION}.tar.gz"
+                sha256 "${ARM64_SHA}"
+              end
+            end
+
+            def install
+              bin.install "bugbarn"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/bugbarn version")
+            end
+          end
+          EOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/bugbarn.rb
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update bugbarn formula to ${VERSION}"
+            git push
+          fi

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -36,6 +38,12 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/worker"
 )
 
+// Version and BuildTime are injected at build time via -ldflags.
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+)
+
 var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
 func main() {
@@ -50,6 +58,9 @@ func run() error {
 
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
+		case "version", "--version", "-v":
+			fmt.Printf("bugbarn %s (built %s)\n", Version, BuildTime)
+			return nil
 		case "worker-once":
 			return runWorkerOnce(cfg)
 		case "user":
@@ -169,6 +180,8 @@ type config struct {
 }
 
 func loadConfig() config {
+	loadConfigFiles()
+
 	cfg := config{
 		addr:                getenv("BUGBARN_ADDR", ":8080"),
 		apiKey:              os.Getenv("BUGBARN_API_KEY"),
@@ -561,4 +574,58 @@ func getenv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// loadConfigFiles applies KEY=VALUE config files to the process environment.
+// Files are read in order: system-wide first, then user-specific. Values from
+// later files win over earlier ones, but env vars already set in the environment
+// always take precedence over values in any file.
+//
+// Supported locations:
+//   - /etc/bugbarn/bugbarn.conf          (Linux system-wide, read by systemd EnvironmentFile)
+//   - ~/.config/bugbarn/bugbarn.conf     (XDG user config, Linux + macOS)
+func loadConfigFiles() {
+	candidates := []string{
+		"/etc/bugbarn/bugbarn.conf",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".config", "bugbarn", "bugbarn.conf"))
+	}
+	for _, path := range candidates {
+		if err := applyConfigFile(path); err != nil && !os.IsNotExist(err) {
+			log.Printf("warning: reading config file %s: %v", path, err)
+		}
+	}
+}
+
+// applyConfigFile reads KEY=VALUE pairs and sets them as environment variables
+// for keys not already set. Blank lines and # comments are ignored.
+// Values may optionally be wrapped in single or double quotes.
+func applyConfigFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, '=')
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
+			val = val[1 : len(val)-1]
+		}
+		if key != "" && os.Getenv(key) == "" {
+			os.Setenv(key, val) //nolint:errcheck
+		}
+	}
+	return scanner.Err()
 }

--- a/deploy/deb/postinstall.sh
+++ b/deploy/deb/postinstall.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Create system user and group if they don't exist.
+if ! getent group bugbarn > /dev/null 2>&1; then
+    groupadd --system bugbarn
+fi
+if ! getent passwd bugbarn > /dev/null 2>&1; then
+    useradd --system --gid bugbarn --no-create-home \
+        --home-dir /var/lib/bugbarn \
+        --shell /usr/sbin/nologin \
+        --comment "BugBarn service account" bugbarn
+fi
+
+# Ensure state directory exists with correct ownership.
+install -d -o bugbarn -g bugbarn -m 0750 /var/lib/bugbarn
+install -d -o bugbarn -g bugbarn -m 0750 /var/lib/bugbarn/spool
+
+# Ensure config directory exists.
+install -d -m 0755 /etc/bugbarn
+
+# Drop a sample config if no config exists yet.
+if [ ! -f /etc/bugbarn/bugbarn.conf ]; then
+    cp /etc/bugbarn/bugbarn.conf.example /etc/bugbarn/bugbarn.conf
+    chmod 0640 /etc/bugbarn/bugbarn.conf
+    chown root:bugbarn /etc/bugbarn/bugbarn.conf
+    echo "BugBarn: sample config installed at /etc/bugbarn/bugbarn.conf — edit before starting."
+fi
+
+# Reload systemd and enable the service.
+if command -v systemctl > /dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl enable bugbarn.service || true
+    echo "BugBarn: service enabled. Start with: sudo systemctl start bugbarn"
+fi

--- a/deploy/deb/preremove.sh
+++ b/deploy/deb/preremove.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if command -v systemctl > /dev/null 2>&1; then
+    systemctl stop bugbarn.service || true
+    systemctl disable bugbarn.service || true
+    systemctl daemon-reload || true
+fi

--- a/deploy/etc/bugbarn.conf.example
+++ b/deploy/etc/bugbarn.conf.example
@@ -1,0 +1,69 @@
+# BugBarn configuration file
+# Copy this file to /etc/bugbarn/bugbarn.conf and edit as needed.
+# For user-specific installs, place it at ~/.config/bugbarn/bugbarn.conf.
+#
+# Environment variables already set in the process always take precedence
+# over values in this file. The systemd unit reads this file via EnvironmentFile.
+#
+# Lines starting with # are comments. Values may optionally be quoted.
+
+# Address to listen on (default: :8080)
+#BUGBARN_ADDR=:8080
+
+# Path to the SQLite database file (default: .data/bugbarn.db)
+# When running as a system service the recommended path is:
+BUGBARN_DB_PATH=/var/lib/bugbarn/bugbarn.db
+
+# Spool directory for durable pre-processing queue (default: .data/spool)
+BUGBARN_SPOOL_DIR=/var/lib/bugbarn/spool
+
+# Public URL used in alert notifications and digest emails
+#BUGBARN_PUBLIC_URL=https://bugs.example.com
+
+# Admin credentials for the web UI (use BUGBARN_ADMIN_PASSWORD_BCRYPT in production)
+#BUGBARN_ADMIN_USERNAME=admin
+#BUGBARN_ADMIN_PASSWORD=changeme
+#BUGBARN_ADMIN_PASSWORD_BCRYPT=
+
+# Session secret — generate with: openssl rand -hex 32
+#BUGBARN_SESSION_SECRET=
+
+# Allowed CORS origins, comma-separated (default: same-origin only)
+#BUGBARN_ALLOWED_ORIGINS=https://app.example.com
+
+# Maximum ingest body size in bytes (default: 1048576 = 1 MiB)
+#BUGBARN_MAX_BODY_BYTES=1048576
+
+# Maximum spool size in bytes; 0 = unlimited (default: 0)
+#BUGBARN_MAX_SPOOL_BYTES=0
+
+# Session TTL in seconds (default: 43200 = 12 hours)
+#BUGBARN_SESSION_TTL_SECONDS=43200
+
+# --- Digest / alert delivery ---
+
+# Weekly digest: day of week 0=Sunday … 6=Saturday (default: 0)
+#BUGBARN_DIGEST_DAY=0
+
+# Hour of day to send the digest, 0–23 (default: 8)
+#BUGBARN_DIGEST_HOUR=8
+
+# Recipient email address for the weekly digest
+#BUGBARN_DIGEST_TO=you@example.com
+
+# Set to "true" to enable email delivery for the digest
+#BUGBARN_DIGEST_ENABLED=false
+
+# Webhook URL to POST digest JSON to (optional)
+#BUGBARN_DIGEST_WEBHOOK_URL=
+
+# SMTP settings for email delivery
+#SMTP_HOST=smtp.example.com
+#SMTP_PORT=587
+#SMTP_USER=bugbarn@example.com
+#SMTP_PASS=
+#SMTP_FROM=bugbarn@example.com
+
+# --- Self-reporting (send errors to another BugBarn instance) ---
+#BUGBARN_SELF_ENDPOINT=https://bugs.example.com
+#BUGBARN_SELF_API_KEY=

--- a/deploy/systemd/bugbarn.service
+++ b/deploy/systemd/bugbarn.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=BugBarn error tracking service
+Documentation=https://github.com/wiebe-xyz/bugbarn
+After=network.target
+
+[Service]
+Type=simple
+User=bugbarn
+Group=bugbarn
+# The leading '-' means systemd won't fail if the file doesn't exist.
+EnvironmentFile=-/etc/bugbarn/bugbarn.conf
+ExecStart=/usr/bin/bugbarn
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bugbarn
+WorkingDirectory=/var/lib/bugbarn
+
+[Install]
+WantedBy=multi-user.target

--- a/nfpm-bugbarn.yaml
+++ b/nfpm-bugbarn.yaml
@@ -1,0 +1,43 @@
+name: bugbarn
+arch: "${GOARCH}"
+platform: linux
+version: "${VERSION}"
+maintainer: "Wiebe Zweers <bugbarn@wiebe.xyz>"
+description: |
+  BugBarn - Self-hosted error tracking server.
+  Lightweight error aggregation, alerting and a web UI.
+vendor: "BugBarn"
+homepage: "https://github.com/wiebe-xyz/bugbarn"
+license: "MIT"
+
+contents:
+  - src: ./dist/bugbarn-linux-${GOARCH}
+    dst: /usr/bin/bugbarn
+    file_info:
+      mode: 0755
+  - src: ./deploy/systemd/bugbarn.service
+    dst: /lib/systemd/system/bugbarn.service
+    file_info:
+      mode: 0644
+  - src: ./deploy/etc/bugbarn.conf.example
+    dst: /etc/bugbarn/bugbarn.conf.example
+    file_info:
+      mode: 0644
+  # Ensure directories exist with correct permissions.
+  - dst: /var/lib/bugbarn
+    type: dir
+    file_info:
+      mode: 0750
+      owner: bugbarn
+      group: bugbarn
+  - dst: /etc/bugbarn
+    type: dir
+    file_info:
+      mode: 0755
+
+scripts:
+  postinstall: ./deploy/deb/postinstall.sh
+  preremove: ./deploy/deb/preremove.sh
+
+deb:
+  compression: gzip


### PR DESCRIPTION
## Summary

- **Binary release workflow** (`binary-release.yml`): auto-tags a patch version on every push to main, builds linux/amd64 + linux/arm64 .deb packages and darwin/amd64 + darwin/arm64 tarballs, attaches them to a GitHub Release, then dispatches to rapid-root for APT publishing and uploads brew tarballs + formula to MinIO/homebrew-buddy-tools tap
- **Config file support**: `loadConfigFiles()` reads `/etc/bugbarn/bugbarn.conf` then `~/.config/bugbarn/bugbarn.conf` before reading env vars — env vars always win; compatible with systemd `EnvironmentFile=`
- **Version injection**: `Version`/`BuildTime` vars set via ldflags; `bugbarn version` subcommand (needed by Homebrew formula test)
- **nfpm packaging**: `nfpm-bugbarn.yaml` packages the binary, systemd unit, and sample config into a .deb; postinstall creates the `bugbarn` system user and enables the service
- **Supporting files**: `deploy/systemd/bugbarn.service`, `deploy/etc/bugbarn.conf.example`, `deploy/deb/postinstall.sh`, `deploy/deb/preremove.sh`

## Required secrets (already set on this repo)

`RAPID_ROOT_DISPATCH_TOKEN`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_ENDPOINT`, `MINIO_BUCKET`, `TAP_GITHUB_TOKEN`

## Known issue — TAP_GITHUB_TOKEN

The current PAT is a fine-grained token with lifetime > 366 days, which the `wiebe-xyz` org rejects. The `update-homebrew-tap` job will fail until `TAP_GITHUB_TOKEN` is replaced with a classic PAT or a shorter-lived fine-grained token that has write access to `wiebe-xyz/homebrew-buddy-tools`. The brew tarballs and MinIO formula will still publish correctly.

## Install (after merge + first workflow run)

**Linux (APT):**
```bash
curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash
sudo apt install bugbarn
```

**macOS (Homebrew):**
```bash
brew tap wiebe-xyz/buddy-tools
brew install bugbarn
```