### PR TITLE
fix: enforce hard size limit on source map uploads (#12)

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -135,6 +135,9 @@ func run() error {
 	if len(cfg.trustedProxies) > 0 {
 		apiServer.SetTrustedProxies(cfg.trustedProxies)
 	}
+	if cfg.maxSourceMapBytes > 0 {
+		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
+	}
 	var httpHandler http.Handler = apiServer
 	if selfReporting {
 		httpHandler = bb.RecoverMiddleware(httpHandler)
@@ -181,6 +184,7 @@ type config struct {
 	dbPath              string
 	maxBodyBytes        int64
 	maxSpoolBytes       int64
+	maxSourceMapBytes   int64
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
@@ -237,6 +241,11 @@ func loadConfig() config {
 	if raw := os.Getenv("BUGBARN_MAX_SPOOL_BYTES"); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
 			cfg.maxSpoolBytes = parsed
+		}
+	}
+	if raw := os.Getenv("BUGBARN_MAX_SOURCE_MAP_BYTES"); raw != "" {
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			cfg.maxSourceMapBytes = parsed
 		}
 	}
 	if raw := os.Getenv("BUGBARN_SESSION_TTL_SECONDS"); raw != "" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,17 +13,20 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
+const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
+
 type Server struct {
-	ingestHandler  *ingest.Handler
-	store          *storage.Store
-	service        *service.Service
-	users          *auth.UserAuthenticator
-	sessions       *auth.SessionManager
-	allowedOrigins []string // parsed from BUGBARN_ALLOWED_ORIGINS
-	trustedProxies []*net.IPNet
-	logHub         *logstream.Hub
-	sessionSecret  string
-	publicURL      string
+	ingestHandler     *ingest.Handler
+	store             *storage.Store
+	service           *service.Service
+	users             *auth.UserAuthenticator
+	sessions          *auth.SessionManager
+	allowedOrigins    []string // parsed from BUGBARN_ALLOWED_ORIGINS
+	trustedProxies    []*net.IPNet
+	logHub            *logstream.Hub
+	sessionSecret     string
+	publicURL         string
+	maxSourceMapBytes int64
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -31,6 +34,13 @@ type Server struct {
 // SetTrustedProxies sets the CIDRs from which X-Forwarded-For is trusted.
 func (s *Server) SetTrustedProxies(cidrs []*net.IPNet) {
 	s.trustedProxies = cidrs
+}
+
+// SetMaxSourceMapBytes sets the maximum source map upload size. Defaults to 32 MiB.
+func (s *Server) SetMaxSourceMapBytes(n int64) {
+	if n > 0 {
+		s.maxSourceMapBytes = n
+	}
 }
 
 // SetLogHub wires the in-memory log streaming hub into the server.
@@ -45,17 +55,18 @@ func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
-	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store)}
+	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store), maxSourceMapBytes: defaultMaxSourceMapBytes}
 }
 
 func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string) *Server {
 	s := &Server{
-		ingestHandler:  ingestHandler,
-		store:          store,
-		service:        service.New(store),
-		users:          users,
-		sessions:       sessions,
-		allowedOrigins: allowedOrigins,
+		ingestHandler:     ingestHandler,
+		store:             store,
+		service:           service.New(store),
+		users:             users,
+		sessions:          sessions,
+		allowedOrigins:    allowedOrigins,
+		maxSourceMapBytes: defaultMaxSourceMapBytes,
 	}
 	go s.cleanupLoginLimiter()
 	return s

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -28,7 +28,16 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
+	limit := s.maxSourceMapBytes
+	if limit <= 0 {
+		limit = defaultMaxSourceMapBytes
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := r.ParseMultipartForm(4 << 20); err != nil {
+		if err.Error() == "http: request body too large" {
+			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "invalid source map payload", http.StatusBadRequest)
 		return
 	}
@@ -39,9 +48,14 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	blob, err := io.ReadAll(file)
+	limited := io.LimitReader(file, limit+1)
+	blob, err := io.ReadAll(limited)
 	if err != nil {
 		http.Error(w, "unable to read source map", http.StatusBadRequest)
+		return
+	}
+	if int64(len(blob)) > limit {
+		http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -34,7 +35,8 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	if err := r.ParseMultipartForm(4 << 20); err != nil {
-		if err.Error() == "http: request body too large" {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
 			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 			return
 		}


### PR DESCRIPTION
## Summary

- `ParseMultipartForm(32 << 20)` only limits in-memory multipart buffering; large files spill to disk temp files and were still read fully into memory via `io.ReadAll`.
- Now wraps `r.Body` with `http.MaxBytesReader` before parsing, and reads the file through `io.LimitReader(file, limit+1)` so no unbounded read can occur.
- Oversized uploads get `413 Payload Too Large` before any significant memory is allocated.
- Default is 32 MiB; override with `BUGBARN_MAX_SOURCE_MAP_BYTES`.

## Changes
- `internal/api/sourcemaps.go`: `MaxBytesReader` + `LimitReader` guards in `uploadSourceMap`
- `internal/api/server.go`: `maxSourceMapBytes` field + `SetMaxSourceMapBytes` setter + 32 MiB default constant
- `cmd/bugbarn/main.go`: `BUGBARN_MAX_SOURCE_MAP_BYTES` env var wired to server

## Testing
- `go build ./...` passes

Closes #12