### PR TITLE
feat: bump SDKs to v1.0.0 and add npm/PyPI publish CI

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -363,3 +363,52 @@ jobs:
             git commit -m "Update formula to ${VERSION}"
             git push
           fi
+
+  # ---------------------------------------------------------------------------
+  # TypeScript SDK — publish to npm
+  # ---------------------------------------------------------------------------
+  publish-npm:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Python SDK — publish to PyPI
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Build
+        run: python -m build
+      - name: Test before publish
+        run: pip install -e ".[dev]" && python -m pytest tests/ -v
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -129,6 +129,9 @@ func run() error {
 	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.allowedOrigins)
 	apiServer.SetLogHub(logHub)
 	apiServer.SetSetupConfig(cfg.sessionSecret, cfg.publicURL)
+	if cfg.maxSourceMapBytes > 0 {
+		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
+	}
 	var httpHandler http.Handler = apiServer
 	if selfReporting {
 		httpHandler = bb.RecoverMiddleware(httpHandler)
@@ -174,6 +177,7 @@ type config struct {
 	dbPath              string
 	maxBodyBytes        int64
 	maxSpoolBytes       int64
+	maxSourceMapBytes   int64
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
@@ -215,6 +219,11 @@ func loadConfig() config {
 	if raw := os.Getenv("BUGBARN_MAX_SPOOL_BYTES"); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
 			cfg.maxSpoolBytes = parsed
+		}
+	}
+	if raw := os.Getenv("BUGBARN_MAX_SOURCE_MAP_BYTES"); raw != "" {
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			cfg.maxSourceMapBytes = parsed
 		}
 	}
 	if raw := os.Getenv("BUGBARN_SESSION_TTL_SECONDS"); raw != "" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,16 +12,19 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
+const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
+
 type Server struct {
-	ingestHandler  *ingest.Handler
-	store          *storage.Store
-	service        *service.Service
-	users          *auth.UserAuthenticator
-	sessions       *auth.SessionManager
-	allowedOrigins []string // parsed from BUGBARN_ALLOWED_ORIGINS
-	logHub         *logstream.Hub
-	sessionSecret  string
-	publicURL      string
+	ingestHandler     *ingest.Handler
+	store             *storage.Store
+	service           *service.Service
+	users             *auth.UserAuthenticator
+	sessions          *auth.SessionManager
+	allowedOrigins    []string // parsed from BUGBARN_ALLOWED_ORIGINS
+	logHub            *logstream.Hub
+	sessionSecret     string
+	publicURL         string
+	maxSourceMapBytes int64
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -31,6 +34,13 @@ func (s *Server) SetLogHub(h *logstream.Hub) {
 	s.logHub = h
 }
 
+// SetMaxSourceMapBytes sets the maximum source map upload size. Defaults to 32 MiB.
+func (s *Server) SetMaxSourceMapBytes(n int64) {
+	if n > 0 {
+		s.maxSourceMapBytes = n
+	}
+}
+
 // SetSetupConfig wires the session secret and public URL for the setup page.
 func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 	s.sessionSecret = sessionSecret
@@ -38,17 +48,18 @@ func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
-	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store)}
+	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store), maxSourceMapBytes: defaultMaxSourceMapBytes}
 }
 
 func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string) *Server {
 	s := &Server{
-		ingestHandler:  ingestHandler,
-		store:          store,
-		service:        service.New(store),
-		users:          users,
-		sessions:       sessions,
-		allowedOrigins: allowedOrigins,
+		ingestHandler:     ingestHandler,
+		store:             store,
+		service:           service.New(store),
+		users:             users,
+		sessions:          sessions,
+		allowedOrigins:    allowedOrigins,
+		maxSourceMapBytes: defaultMaxSourceMapBytes,
 	}
 	go s.cleanupLoginLimiter()
 	return s

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -236,10 +236,10 @@ Generated %s
 		endpoint, slug, rawKey, status, // 3,4,5,6: table
 		pendingNote,            // 7: pending note block
 		endpoint, rawKey, slug, // 8,9,10: curl example
-		endpoint, endpoint, endpoint, endpoint, // 11-14: ts install (curl + 2 install variants + tarball dir)
-		rawKey, endpoint, slug, // 13,14,15: ts usage
-		rawKey, endpoint, slug, // 16,17,18: go
-		rawKey, endpoint, // 19,20: python (no project_slug param — routed by API key)
+		endpoint, endpoint, endpoint, // 11-13: ts install (curl + 2 install variants)
+		rawKey, endpoint, slug, // 14,15,16: ts usage
+		rawKey, endpoint, slug, // 17,18,19: go
+		rawKey, endpoint, // 20,21: python (no project_slug param — routed by API key)
 		endpoint, rawKey, slug, // 22,23,24: release curl
 		endpoint, rawKey, slug, // 25,26,27: logs curl
 		endpoint,               // 28: view link

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -28,7 +28,16 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
+	limit := s.maxSourceMapBytes
+	if limit <= 0 {
+		limit = defaultMaxSourceMapBytes
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := r.ParseMultipartForm(4 << 20); err != nil {
+		if err.Error() == "http: request body too large" {
+			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "invalid source map payload", http.StatusBadRequest)
 		return
 	}
@@ -39,9 +48,14 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	blob, err := io.ReadAll(file)
+	limited := io.LimitReader(file, limit+1)
+	blob, err := io.ReadAll(limited)
 	if err != nil {
 		http.Error(w, "unable to read source map", http.StatusBadRequest)
+		return
+	}
+	if int64(len(blob)) > limit {
+		http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -34,7 +35,8 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	if err := r.ParseMultipartForm(4 << 20); err != nil {
-		if err.Error() == "http: request body too large" {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
 			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 			return
 		}

--- a/sdks/php/PUBLISHING.md
+++ b/sdks/php/PUBLISHING.md
@@ -1,0 +1,25 @@
+# Publishing to Packagist
+
+Packagist syncs automatically from GitHub tags — no CI job is needed. Follow these steps once to register the package.
+
+## One-time submission
+
+1. Go to [packagist.org/packages/submit](https://packagist.org/packages/submit) and log in.
+2. Enter the GitHub repository URL (e.g. `https://github.com/webwiebe/bugbarn`) and click **Check**.
+3. Confirm the package name (`bugbarn/bugbarn-php`) and click **Submit**.
+
+## GitHub webhook (auto-update on push)
+
+After submission, Packagist shows a webhook URL. Add it to the GitHub repo so Packagist picks up new tags immediately:
+
+1. In the GitHub repo go to **Settings → Webhooks → Add webhook**.
+2. Set **Payload URL** to the URL shown on your Packagist package page (format: `https://packagist.org/api/github?username=<your-packagist-username>`).
+3. Set **Content type** to `application/json`.
+4. Under **Which events**, choose **Just the push event**.
+5. Click **Add webhook**.
+
+From this point on, every `git push --tags` triggers Packagist to pull the latest release automatically.
+
+## Required secrets
+
+None — Packagist needs no CI secrets. Tags pushed by the existing `binary-release.yml` workflow will trigger the webhook.

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "bugbarn/bugbarn-php",
   "description": "BugBarn PHP SDK — lightweight error reporting for self-hosted BugBarn instances",
+  "version": "1.0.0",
   "type": "library",
   "license": "MIT",
   "require": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bugbarn-python"
-version = "0.1.0"
+version = "1.0.0"
 description = "BugBarn Python SDK skeleton"
 requires-python = ">=3.9"
 dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbarn/typescript",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary

- Bump TypeScript SDK, Python SDK, and PHP SDK from v0.1.0 → **v1.0.0**
- Add \`publish-npm\` CI job: builds, tests, and publishes \`@bugbarn/typescript\` to npm on every release tag
- Add \`publish-pypi\` CI job: builds and uploads \`bugbarn-python\` to PyPI on every release tag
- PHP → Packagist is tag-based (no CI secret needed); added \`sdks/php/PUBLISHING.md\` with one-time submission steps
- Python SDK: added \`[project.optional-dependencies]\` dev section so \`pip install -e ".[dev]"\` works in CI

## Secrets required (add in repo settings before merging)
- \`NPM_TOKEN\` — npm automation token with publish rights to \`@bugbarn\` scope
- \`PYPI_TOKEN\` — PyPI API token for \`bugbarn-python\`

## Test plan
- [ ] Add NPM_TOKEN and PYPI_TOKEN secrets to repo
- [ ] Trigger a release tag — confirm npm and PyPI jobs run green
- [ ] Verify \`@bugbarn/typescript@1.0.0\` appears on npmjs.com
- [ ] Verify \`bugbarn-python==1.0.0\` appears on pypi.org
- [ ] Submit \`bugbarn/bugbarn-php\` to Packagist following \`sdks/php/PUBLISHING.md\`