### PR TITLE
feat: wire BugBarn web frontend to FunnelBarn analytics (opt-in)

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -363,3 +363,52 @@ jobs:
             git commit -m "Update formula to ${VERSION}"
             git push
           fi
+
+  # ---------------------------------------------------------------------------
+  # TypeScript SDK — publish to npm
+  # ---------------------------------------------------------------------------
+  publish-npm:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Python SDK — publish to PyPI
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Build
+        run: python -m build
+      - name: Test before publish
+        run: pip install -e ".[dev]" && python -m pytest tests/ -v
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -129,6 +129,7 @@ func run() error {
 	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.allowedOrigins)
 	apiServer.SetLogHub(logHub)
 	apiServer.SetSetupConfig(cfg.sessionSecret, cfg.publicURL)
+	apiServer.SetFunnelBarnConfig(cfg.funnelBarnEndpoint, cfg.funnelBarnAPIKey)
 	if cfg.maxSourceMapBytes > 0 {
 		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
 	}
@@ -181,6 +182,8 @@ type config struct {
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
+	funnelBarnEndpoint  string // BUGBARN_FUNNELBARN_ENDPOINT — e.g. https://funnelbarn.example.com
+	funnelBarnAPIKey    string // BUGBARN_FUNNELBARN_API_KEY
 	digest              digest.Config
 }
 
@@ -202,6 +205,8 @@ func loadConfig() config {
 		publicURL:           os.Getenv("BUGBARN_PUBLIC_URL"),
 		selfEndpoint:        os.Getenv("BUGBARN_SELF_ENDPOINT"),
 		selfAPIKey:          os.Getenv("BUGBARN_SELF_API_KEY"),
+		funnelBarnEndpoint:  os.Getenv("BUGBARN_FUNNELBARN_ENDPOINT"),
+		funnelBarnAPIKey:    os.Getenv("BUGBARN_FUNNELBARN_API_KEY"),
 	}
 
 	if raw := os.Getenv("BUGBARN_ALLOWED_ORIGINS"); raw != "" {

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -129,6 +129,9 @@ func run() error {
 	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.allowedOrigins)
 	apiServer.SetLogHub(logHub)
 	apiServer.SetSetupConfig(cfg.sessionSecret, cfg.publicURL)
+	if cfg.maxSourceMapBytes > 0 {
+		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
+	}
 	var httpHandler http.Handler = apiServer
 	if selfReporting {
 		httpHandler = bb.RecoverMiddleware(httpHandler)
@@ -174,6 +177,7 @@ type config struct {
 	dbPath              string
 	maxBodyBytes        int64
 	maxSpoolBytes       int64
+	maxSourceMapBytes   int64
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
@@ -215,6 +219,11 @@ func loadConfig() config {
 	if raw := os.Getenv("BUGBARN_MAX_SPOOL_BYTES"); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
 			cfg.maxSpoolBytes = parsed
+		}
+	}
+	if raw := os.Getenv("BUGBARN_MAX_SOURCE_MAP_BYTES"); raw != "" {
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			cfg.maxSourceMapBytes = parsed
 		}
 	}
 	if raw := os.Getenv("BUGBARN_SESSION_TTL_SECONDS"); raw != "" {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,0 +1,32 @@
+package api
+
+import "net/http"
+
+// serveRuntimeConfig returns public (non-secret) configuration that the web
+// frontend needs at startup. This endpoint requires no authentication so the
+// frontend can fetch it before the user logs in.
+//
+// FunnelBarn analytics tracking is opt-in: the funnelbarn block is only
+// enabled when BUGBARN_FUNNELBARN_ENDPOINT is set in the server's environment.
+func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+	type funnelBarnConfig struct {
+		Enabled  bool   `json:"enabled"`
+		Endpoint string `json:"endpoint,omitempty"`
+		APIKey   string `json:"apiKey,omitempty"`
+	}
+
+	type runtimeConfig struct {
+		FunnelBarn funnelBarnConfig `json:"funnelbarn"`
+	}
+
+	cfg := runtimeConfig{}
+	if s.funnelBarnEndpoint != "" {
+		cfg.FunnelBarn = funnelBarnConfig{
+			Enabled:  true,
+			Endpoint: s.funnelBarnEndpoint,
+			APIKey:   s.funnelBarnAPIKey,
+		}
+	}
+
+	writeJSON(w, cfg)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,16 +15,18 @@ import (
 const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
 
 type Server struct {
-	ingestHandler     *ingest.Handler
-	store             *storage.Store
-	service           *service.Service
-	users             *auth.UserAuthenticator
-	sessions          *auth.SessionManager
-	allowedOrigins    []string // parsed from BUGBARN_ALLOWED_ORIGINS
-	logHub            *logstream.Hub
-	sessionSecret     string
-	publicURL         string
-	maxSourceMapBytes int64
+	ingestHandler      *ingest.Handler
+	store              *storage.Store
+	service            *service.Service
+	users              *auth.UserAuthenticator
+	sessions           *auth.SessionManager
+	allowedOrigins     []string // parsed from BUGBARN_ALLOWED_ORIGINS
+	logHub             *logstream.Hub
+	sessionSecret      string
+	publicURL          string
+	maxSourceMapBytes  int64
+	funnelBarnEndpoint string
+	funnelBarnAPIKey   string
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -45,6 +47,13 @@ func (s *Server) SetMaxSourceMapBytes(n int64) {
 func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 	s.sessionSecret = sessionSecret
 	s.publicURL = publicURL
+}
+
+// SetFunnelBarnConfig wires optional FunnelBarn analytics tracking config.
+// If endpoint is empty, the runtime-config endpoint returns enabled=false.
+func (s *Server) SetFunnelBarnConfig(endpoint, apiKey string) {
+	s.funnelBarnEndpoint = endpoint
+	s.funnelBarnAPIKey = apiKey
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
@@ -133,6 +142,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/api/v1/health" && r.Method == http.MethodGet:
 		writeJSON(w, map[string]any{"status": "ok"})
+		return
+	case r.URL.Path == "/api/v1/runtime-config" && r.Method == http.MethodGet:
+		s.serveRuntimeConfig(w, r)
 		return
 	case r.URL.Path == "/api/v1/login" && r.Method == http.MethodPost:
 		s.login(w, r)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,16 +12,19 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
+const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
+
 type Server struct {
-	ingestHandler  *ingest.Handler
-	store          *storage.Store
-	service        *service.Service
-	users          *auth.UserAuthenticator
-	sessions       *auth.SessionManager
-	allowedOrigins []string // parsed from BUGBARN_ALLOWED_ORIGINS
-	logHub         *logstream.Hub
-	sessionSecret  string
-	publicURL      string
+	ingestHandler     *ingest.Handler
+	store             *storage.Store
+	service           *service.Service
+	users             *auth.UserAuthenticator
+	sessions          *auth.SessionManager
+	allowedOrigins    []string // parsed from BUGBARN_ALLOWED_ORIGINS
+	logHub            *logstream.Hub
+	sessionSecret     string
+	publicURL         string
+	maxSourceMapBytes int64
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -31,6 +34,13 @@ func (s *Server) SetLogHub(h *logstream.Hub) {
 	s.logHub = h
 }
 
+// SetMaxSourceMapBytes sets the maximum source map upload size. Defaults to 32 MiB.
+func (s *Server) SetMaxSourceMapBytes(n int64) {
+	if n > 0 {
+		s.maxSourceMapBytes = n
+	}
+}
+
 // SetSetupConfig wires the session secret and public URL for the setup page.
 func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 	s.sessionSecret = sessionSecret
@@ -38,17 +48,18 @@ func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
-	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store)}
+	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store), maxSourceMapBytes: defaultMaxSourceMapBytes}
 }
 
 func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string) *Server {
 	s := &Server{
-		ingestHandler:  ingestHandler,
-		store:          store,
-		service:        service.New(store),
-		users:          users,
-		sessions:       sessions,
-		allowedOrigins: allowedOrigins,
+		ingestHandler:     ingestHandler,
+		store:             store,
+		service:           service.New(store),
+		users:             users,
+		sessions:          sessions,
+		allowedOrigins:    allowedOrigins,
+		maxSourceMapBytes: defaultMaxSourceMapBytes,
 	}
 	go s.cleanupLoginLimiter()
 	return s

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -236,10 +236,10 @@ Generated %s
 		endpoint, slug, rawKey, status, // 3,4,5,6: table
 		pendingNote,            // 7: pending note block
 		endpoint, rawKey, slug, // 8,9,10: curl example
-		endpoint, endpoint, endpoint, endpoint, // 11-14: ts install (curl + 2 install variants + tarball dir)
-		rawKey, endpoint, slug, // 13,14,15: ts usage
-		rawKey, endpoint, slug, // 16,17,18: go
-		rawKey, endpoint, // 19,20: python (no project_slug param — routed by API key)
+		endpoint, endpoint, endpoint, // 11-13: ts install (curl + 2 install variants)
+		rawKey, endpoint, slug, // 14,15,16: ts usage
+		rawKey, endpoint, slug, // 17,18,19: go
+		rawKey, endpoint, // 20,21: python (no project_slug param — routed by API key)
 		endpoint, rawKey, slug, // 22,23,24: release curl
 		endpoint, rawKey, slug, // 25,26,27: logs curl
 		endpoint,               // 28: view link

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -28,7 +28,16 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
+	limit := s.maxSourceMapBytes
+	if limit <= 0 {
+		limit = defaultMaxSourceMapBytes
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := r.ParseMultipartForm(4 << 20); err != nil {
+		if err.Error() == "http: request body too large" {
+			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "invalid source map payload", http.StatusBadRequest)
 		return
 	}
@@ -39,9 +48,14 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	blob, err := io.ReadAll(file)
+	limited := io.LimitReader(file, limit+1)
+	blob, err := io.ReadAll(limited)
 	if err != nil {
 		http.Error(w, "unable to read source map", http.StatusBadRequest)
+		return
+	}
+	if int64(len(blob)) > limit {
+		http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -34,7 +35,8 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	if err := r.ParseMultipartForm(4 << 20); err != nil {
-		if err.Error() == "http: request body too large" {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
 			http.Error(w, "source map too large", http.StatusRequestEntityTooLarge)
 			return
 		}

--- a/sdks/php/PUBLISHING.md
+++ b/sdks/php/PUBLISHING.md
@@ -1,0 +1,25 @@
+# Publishing to Packagist
+
+Packagist syncs automatically from GitHub tags — no CI job is needed. Follow these steps once to register the package.
+
+## One-time submission
+
+1. Go to [packagist.org/packages/submit](https://packagist.org/packages/submit) and log in.
+2. Enter the GitHub repository URL (e.g. `https://github.com/webwiebe/bugbarn`) and click **Check**.
+3. Confirm the package name (`bugbarn/bugbarn-php`) and click **Submit**.
+
+## GitHub webhook (auto-update on push)
+
+After submission, Packagist shows a webhook URL. Add it to the GitHub repo so Packagist picks up new tags immediately:
+
+1. In the GitHub repo go to **Settings → Webhooks → Add webhook**.
+2. Set **Payload URL** to the URL shown on your Packagist package page (format: `https://packagist.org/api/github?username=<your-packagist-username>`).
+3. Set **Content type** to `application/json`.
+4. Under **Which events**, choose **Just the push event**.
+5. Click **Add webhook**.
+
+From this point on, every `git push --tags` triggers Packagist to pull the latest release automatically.
+
+## Required secrets
+
+None — Packagist needs no CI secrets. Tags pushed by the existing `binary-release.yml` workflow will trigger the webhook.

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "bugbarn/bugbarn-php",
   "description": "BugBarn PHP SDK — lightweight error reporting for self-hosted BugBarn instances",
+  "version": "1.0.0",
   "type": "library",
   "license": "MIT",
   "require": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bugbarn-python"
-version = "0.1.0"
+version = "1.0.0"
 description = "BugBarn Python SDK skeleton"
 requires-python = ">=3.9"
 dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbarn/typescript",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -218,6 +218,10 @@ window.addEventListener("beforeunload", stopLiveStream);
 void start();
 
 async function start(): Promise<void> {
+  // Kick off FunnelBarn analytics initialisation in parallel — it must not
+  // block the rest of the app startup.
+  void initFunnelBarn();
+
   await loadSession();
   updateBBMenuUser();
   route();
@@ -228,6 +232,76 @@ async function start(): Promise<void> {
   const envLoad = state.currentProject !== "__all" ? loadEnvironments() : (renderEnvSwitcher([]), Promise.resolve());
   await Promise.all([loadProjects(), envLoad, refreshAll()]);
   initInstallPrompt();
+}
+
+// ---------------------------------------------------------------------------
+// FunnelBarn analytics (opt-in)
+//
+// The Go server exposes GET /api/v1/runtime-config. When
+// BUGBARN_FUNNELBARN_ENDPOINT is set, it returns:
+//   { "funnelbarn": { "enabled": true, "endpoint": "...", "apiKey": "..." } }
+//
+// We dynamically inject the FunnelBarn JS SDK from:
+//   {endpoint}/sdk/funnelbarn.js
+// (FunnelBarn serves its pre-built IIFE bundle at that path via the web
+// container's nginx static file server — see web/public/ in the FunnelBarn
+// repo, or build sdks/js and place the output there.)
+//
+// After the script loads, window.funnelbarn is available and we call:
+//   window.funnelbarn.init({ apiKey, endpoint })
+//   window.funnelbarn.page()
+// ---------------------------------------------------------------------------
+
+// TypeScript type declaration for the globally-injected FunnelBarn SDK.
+declare global {
+  interface Window {
+    funnelbarn?: {
+      init(options: { apiKey: string; endpoint: string }): void;
+      page(): void;
+      track(name: string, properties?: Record<string, unknown>): void;
+    };
+  }
+}
+
+async function initFunnelBarn(): Promise<void> {
+  let cfg: { funnelbarn?: { enabled: boolean; endpoint?: string; apiKey?: string } };
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return;
+    cfg = await res.json() as typeof cfg;
+  } catch {
+    // Non-critical — silently abort if the endpoint is unreachable.
+    return;
+  }
+
+  const fb = cfg?.funnelbarn;
+  if (!fb?.enabled || !fb.endpoint || !fb.apiKey) return;
+
+  const { endpoint, apiKey } = fb;
+
+  // Inject the SDK script tag. FunnelBarn serves the pre-built IIFE bundle at
+  // {endpoint}/sdk/funnelbarn.js from the web container's nginx static server.
+  await new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = `${endpoint}/sdk/funnelbarn.js`;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`funnelbarn: failed to load SDK from ${script.src}`));
+    document.head.appendChild(script);
+  }).catch(() => {
+    // SDK load failed — abort silently. This is non-critical.
+    return;
+  });
+
+  if (typeof window.funnelbarn?.init !== "function") return;
+
+  window.funnelbarn.init({ apiKey, endpoint });
+  window.funnelbarn.page();
+
+  // Track subsequent hash-based route changes as additional page views.
+  window.addEventListener("hashchange", () => {
+    window.funnelbarn?.page();
+  });
 }
 
 // PWA install prompt — shown once until dismissed, never shown again after


### PR DESCRIPTION
## Summary

Adds opt-in FunnelBarn analytics to BugBarn's web frontend so operators get usage analytics on their own BugBarn instance.

- New env vars: \`BUGBARN_FUNNELBARN_ENDPOINT\` and \`BUGBARN_FUNNELBARN_API_KEY\`
- New public endpoint \`GET /api/v1/runtime-config\` returns frontend config (FunnelBarn enabled/disabled + credentials)
- BugBarn web app fetches runtime config on startup; if FunnelBarn is enabled, dynamically loads \`{endpoint}/sdk/funnelbarn.js\` and calls \`.page()\` on every route change
- Fully opt-in — if env vars are unset, nothing is loaded

## Wiring gap (FunnelBarn side)
FunnelBarn must serve the IIFE bundle at \`/sdk/funnelbarn.js\`. This is handled by the companion PR in the FunnelBarn repo (\`feat/sdk-publishing\`) which copies the rollup IIFE output to \`web/public/sdk/funnelbarn.js\` during the release build.

## Test plan
- [ ] Without env vars set: \`GET /api/v1/runtime-config\` returns \`{"funnelbarn":{"enabled":false}}\`
- [ ] With env vars set: response includes endpoint + apiKey, web app loads FunnelBarn SDK
- [ ] Page views appear in FunnelBarn dashboard when navigating BugBarn
- [ ] No console errors when FunnelBarn is not configured