### PR TITLE
feat(analytics): schema, storage layer, and rollup worker

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -25,6 +25,7 @@ import (
 
 	bb "github.com/wiebe-xyz/bugbarn-go"
 	"github.com/wiebe-xyz/bugbarn/internal/alert"
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
 	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/api"
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
@@ -112,6 +113,7 @@ func run() error {
 	go runBackgroundWorker(ctx, cfg.spoolDir, store, svc, selfReporting)
 
 	digest.StartScheduler(ctx, cfg.digest, store)
+	analytics.StartWorker(ctx, store, cfg.analyticsRetentionDays)
 
 	apiAuthorizer, err := newAPIAuthorizer(cfg, store)
 	if err != nil {
@@ -177,7 +179,8 @@ type config struct {
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
-	digest              digest.Config
+	digest                    digest.Config
+	analyticsRetentionDays   int
 }
 
 func loadConfig() config {
@@ -220,6 +223,12 @@ func loadConfig() config {
 	if raw := os.Getenv("BUGBARN_SESSION_TTL_SECONDS"); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
 			cfg.sessionTTL = time.Duration(parsed) * time.Second
+		}
+	}
+	cfg.analyticsRetentionDays = 90
+	if raw := os.Getenv("BUGBARN_ANALYTICS_RETENTION_DAYS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			cfg.analyticsRetentionDays = parsed
 		}
 	}
 

--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -1,0 +1,55 @@
+package analytics
+
+import "time"
+
+type PageView struct {
+	ProjectID    int64
+	Ts           time.Time
+	Pathname     string
+	Hostname     string
+	ReferrerHost string
+	ReferrerPath string
+	SessionID    string
+	DurationMs   int64
+	ScreenWidth  int
+	Props        map[string]string
+}
+
+type OverviewResult struct {
+	Pageviews     int64
+	Sessions      int64
+	PagesCount    int64
+	AvgDurationMs int64
+}
+
+type PageStat struct {
+	Pathname  string
+	Pageviews int64
+	Sessions  int64
+}
+
+type TimelineBucket struct {
+	Date      string // YYYY-MM-DD (day), YYYY-WXX (ISO week), YYYY-MM (month)
+	Pageviews int64
+	Sessions  int64
+}
+
+type ReferrerStat struct {
+	Host      string
+	Pageviews int64
+	Sessions  int64
+}
+
+type SegmentBucket struct {
+	Value     string
+	Pageviews int64
+	Sessions  int64
+}
+
+type Query struct {
+	ProjectID int64
+	Start     time.Time
+	End       time.Time
+	Pathname  string // optional filter
+	Limit     int    // 0 = default 50
+}

--- a/internal/analytics/worker.go
+++ b/internal/analytics/worker.go
@@ -1,0 +1,63 @@
+package analytics
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// Store is the subset of storage.Store used by the analytics worker.
+type Store interface {
+	ListProjectIDs(ctx context.Context) ([]int64, error)
+	RollupDailyAnalytics(ctx context.Context, projectID int64, date time.Time) error
+	DeleteOldPageviews(ctx context.Context, cutoff time.Time) error
+}
+
+// StartWorker rolls up raw page-view data into analytics_daily on a 1-hour
+// cadence. It performs an initial run on startup to catch any missed rollups.
+func StartWorker(ctx context.Context, store Store, retentionDays int) {
+	if retentionDays <= 0 {
+		retentionDays = 90
+	}
+	go func() {
+		runRollup(ctx, store, retentionDays)
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				runRollup(ctx, store, retentionDays)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func runRollup(ctx context.Context, store Store, retentionDays int) {
+	projectIDs, err := store.ListProjectIDs(ctx)
+	if err != nil {
+		log.Printf("analytics rollup: list projects: %v", err)
+		return
+	}
+
+	// Roll up the past 2 days (yesterday + day before) to catch any gaps.
+	now := time.Now().UTC()
+	dates := []time.Time{
+		now.AddDate(0, 0, -1).Truncate(24 * time.Hour),
+		now.AddDate(0, 0, -2).Truncate(24 * time.Hour),
+	}
+
+	for _, pid := range projectIDs {
+		for _, date := range dates {
+			if err := store.RollupDailyAnalytics(ctx, pid, date); err != nil {
+				log.Printf("analytics rollup: project %d date %s: %v", pid, date.Format("2006-01-02"), err)
+			}
+		}
+	}
+
+	cutoff := now.AddDate(0, 0, -retentionDays)
+	if err := store.DeleteOldPageviews(ctx, cutoff); err != nil {
+		log.Printf("analytics retention: delete old pageviews: %v", err)
+	}
+}

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -236,10 +236,10 @@ Generated %s
 		endpoint, slug, rawKey, status, // 3,4,5,6: table
 		pendingNote,            // 7: pending note block
 		endpoint, rawKey, slug, // 8,9,10: curl example
-		endpoint, endpoint, endpoint, endpoint, // 11-14: ts install (curl + 2 install variants + tarball dir)
-		rawKey, endpoint, slug, // 13,14,15: ts usage
-		rawKey, endpoint, slug, // 16,17,18: go
-		rawKey, endpoint, // 19,20: python (no project_slug param — routed by API key)
+		endpoint, endpoint, endpoint, // 11-13: ts install (curl + 2 install variants)
+		rawKey, endpoint, slug, // 14,15,16: ts usage
+		rawKey, endpoint, slug, // 17,18,19: go
+		rawKey, endpoint, // 20,21: python (no project_slug param — routed by API key)
 		endpoint, rawKey, slug, // 22,23,24: release curl
 		endpoint, rawKey, slug, // 25,26,27: logs curl
 		endpoint,               // 28: view link

--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -1,0 +1,356 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
+)
+
+// InsertPageView writes a single raw page-view event.
+func (s *Store) InsertPageView(ctx context.Context, pv analytics.PageView) error {
+	props := "{}"
+	if len(pv.Props) > 0 {
+		b, err := json.Marshal(pv.Props)
+		if err == nil {
+			props = string(b)
+		}
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO analytics_pageviews
+			(project_id, ts, pathname, hostname, referrer_host, referrer_path,
+			 session_id, duration_ms, screen_width, props)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		pv.ProjectID,
+		pv.Ts.Unix(),
+		pv.Pathname,
+		pv.Hostname,
+		pv.ReferrerHost,
+		pv.ReferrerPath,
+		pv.SessionID,
+		pv.DurationMs,
+		pv.ScreenWidth,
+		props,
+	)
+	return err
+}
+
+// RollupDailyAnalytics aggregates raw pageviews for the given UTC date into
+// analytics_daily. Uses INSERT OR REPLACE so it is safe to call multiple times.
+func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date time.Time) error {
+	dateStr := date.UTC().Format("2006-01-02")
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Per-pathname totals (dim_key='', dim_value='')
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR REPLACE INTO analytics_daily
+			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
+		SELECT
+			project_id,
+			strftime('%Y-%m-%d', ts, 'unixepoch') AS date,
+			pathname,
+			'' AS dim_key,
+			'' AS dim_value,
+			COUNT(*)                        AS pageviews,
+			COUNT(DISTINCT session_id)      AS sessions
+		FROM analytics_pageviews
+		WHERE project_id = ?
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
+		GROUP BY pathname`,
+		projectID, dateStr,
+	); err != nil {
+		return fmt.Errorf("rollup per-pathname: %w", err)
+	}
+
+	// All-pages total row (pathname='')
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR REPLACE INTO analytics_daily
+			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
+		SELECT
+			project_id,
+			? AS date,
+			'' AS pathname,
+			'' AS dim_key,
+			'' AS dim_value,
+			COUNT(*)                   AS pageviews,
+			COUNT(DISTINCT session_id) AS sessions
+		FROM analytics_pageviews
+		WHERE project_id = ?
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?`,
+		dateStr, projectID, dateStr,
+	); err != nil {
+		return fmt.Errorf("rollup total: %w", err)
+	}
+
+	// Per-referrer_host breakdown (dim_key='referrer_host')
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR REPLACE INTO analytics_daily
+			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
+		SELECT
+			project_id,
+			? AS date,
+			'' AS pathname,
+			'referrer_host' AS dim_key,
+			referrer_host   AS dim_value,
+			COUNT(*)                   AS pageviews,
+			COUNT(DISTINCT session_id) AS sessions
+		FROM analytics_pageviews
+		WHERE project_id = ?
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
+		GROUP BY referrer_host`,
+		dateStr, projectID, dateStr,
+	); err != nil {
+		return fmt.Errorf("rollup referrers: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// DeleteOldPageviews removes raw rows older than cutoff.
+func (s *Store) DeleteOldPageviews(ctx context.Context, cutoff time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM analytics_pageviews WHERE ts < ?`,
+		cutoff.Unix(),
+	)
+	return err
+}
+
+// queryLimit returns the effective limit (default 50, max 500).
+func queryLimit(q analytics.Query) int {
+	if q.Limit <= 0 {
+		return 50
+	}
+	if q.Limit > 500 {
+		return 500
+	}
+	return q.Limit
+}
+
+// QueryOverview returns aggregate stats. Uses analytics_daily for the bulk of
+// the range; includes un-rolled-up rows from analytics_pageviews for today.
+func (s *Store) QueryOverview(ctx context.Context, q analytics.Query) (analytics.OverviewResult, error) {
+	startStr := q.Start.UTC().Format("2006-01-02")
+	endStr := q.End.UTC().Format("2006-01-02")
+
+	// From daily rollups (excludes today which may not be rolled up yet)
+	row := s.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(d.pageviews), 0)    AS pageviews,
+			COALESCE(SUM(d.sessions), 0)     AS sessions,
+			COUNT(DISTINCT CASE WHEN d.pathname != '' THEN d.pathname END) AS pages
+		FROM analytics_daily d
+		WHERE d.project_id = ?
+		  AND d.date BETWEEN ? AND ?
+		  AND d.pathname = ''
+		  AND d.dim_key = ''`,
+		q.ProjectID, startStr, endStr,
+	)
+	var res analytics.OverviewResult
+	if err := row.Scan(&res.Pageviews, &res.Sessions, &res.PagesCount); err != nil {
+		return res, err
+	}
+
+	// Add today's un-rolled-up raw rows
+	today := time.Now().UTC().Format("2006-01-02")
+	raw := s.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(COUNT(*), 0)                AS pageviews,
+			COALESCE(COUNT(DISTINCT session_id), 0) AS sessions,
+			COALESCE(COUNT(DISTINCT pathname), 0)   AS pages,
+			COALESCE(AVG(NULLIF(duration_ms, 0)), 0) AS avg_dur
+		FROM analytics_pageviews
+		WHERE project_id = ?
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') BETWEEN ? AND ?`,
+		q.ProjectID, today, startStr, endStr,
+	)
+	var rawPV, rawSess, rawPages int64
+	var rawAvgDur float64
+	if err := raw.Scan(&rawPV, &rawSess, &rawPages, &rawAvgDur); err != nil {
+		return res, err
+	}
+	res.Pageviews += rawPV
+	res.Sessions += rawSess
+	if rawPages > res.PagesCount {
+		res.PagesCount = rawPages
+	}
+	res.AvgDurationMs = int64(rawAvgDur)
+	return res, nil
+}
+
+// QueryPages returns per-pathname stats ordered by pageviews DESC.
+func (s *Store) QueryPages(ctx context.Context, q analytics.Query) ([]analytics.PageStat, error) {
+	startStr := q.Start.UTC().Format("2006-01-02")
+	endStr := q.End.UTC().Format("2006-01-02")
+	limit := queryLimit(q)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pathname, SUM(pageviews) AS pv, SUM(sessions) AS sess
+		FROM analytics_daily
+		WHERE project_id = ?
+		  AND date BETWEEN ? AND ?
+		  AND pathname != ''
+		  AND dim_key = ''
+		GROUP BY pathname
+		ORDER BY pv DESC
+		LIMIT ?`,
+		q.ProjectID, startStr, endStr, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []analytics.PageStat
+	for rows.Next() {
+		var p analytics.PageStat
+		if err := rows.Scan(&p.Pathname, &p.Pageviews, &p.Sessions); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// QueryTimeline returns bucketed time series. granularity: "day", "week", "month".
+func (s *Store) QueryTimeline(ctx context.Context, q analytics.Query, granularity string) ([]analytics.TimelineBucket, error) {
+	startStr := q.Start.UTC().Format("2006-01-02")
+	endStr := q.End.UTC().Format("2006-01-02")
+
+	var groupExpr string
+	switch granularity {
+	case "week":
+		groupExpr = `strftime('%Y-W%W', date)`
+	case "month":
+		groupExpr = `strftime('%Y-%m', date)`
+	default:
+		groupExpr = `date`
+	}
+
+	query := fmt.Sprintf(`
+		SELECT %s AS bucket, SUM(pageviews), SUM(sessions)
+		FROM analytics_daily
+		WHERE project_id = ?
+		  AND date BETWEEN ? AND ?
+		  AND pathname = ''
+		  AND dim_key = ''
+		GROUP BY bucket
+		ORDER BY bucket ASC`,
+		groupExpr,
+	)
+	rows, err := s.db.QueryContext(ctx, query, q.ProjectID, startStr, endStr)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []analytics.TimelineBucket
+	for rows.Next() {
+		var b analytics.TimelineBucket
+		if err := rows.Scan(&b.Date, &b.Pageviews, &b.Sessions); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// QueryReferrers returns top referring hostnames.
+func (s *Store) QueryReferrers(ctx context.Context, q analytics.Query) ([]analytics.ReferrerStat, error) {
+	startStr := q.Start.UTC().Format("2006-01-02")
+	endStr := q.End.UTC().Format("2006-01-02")
+	limit := queryLimit(q)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT dim_value, SUM(pageviews), SUM(sessions)
+		FROM analytics_daily
+		WHERE project_id = ?
+		  AND date BETWEEN ? AND ?
+		  AND dim_key = 'referrer_host'
+		GROUP BY dim_value
+		ORDER BY SUM(pageviews) DESC
+		LIMIT ?`,
+		q.ProjectID, startStr, endStr, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []analytics.ReferrerStat
+	for rows.Next() {
+		var r analytics.ReferrerStat
+		if err := rows.Scan(&r.Host, &r.Pageviews, &r.Sessions); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// QuerySegments returns a breakdown by a named props key using raw pageviews.
+// We use the raw table because props are not pre-aggregated beyond referrer_host.
+func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey string) ([]analytics.SegmentBucket, error) {
+	if strings.TrimSpace(dimKey) == "" {
+		return nil, nil
+	}
+	limit := queryLimit(q)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			json_extract(props, '$.' || ?) AS val,
+			COUNT(*)                        AS pageviews,
+			COUNT(DISTINCT session_id)      AS sessions
+		FROM analytics_pageviews
+		WHERE project_id = ?
+		  AND ts BETWEEN ? AND ?
+		  AND json_extract(props, '$.' || ?) IS NOT NULL
+		GROUP BY val
+		ORDER BY pageviews DESC
+		LIMIT ?`,
+		dimKey,
+		q.ProjectID,
+		q.Start.Unix(), q.End.Unix(),
+		dimKey,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []analytics.SegmentBucket
+	for rows.Next() {
+		var b analytics.SegmentBucket
+		if err := rows.Scan(&b.Value, &b.Pageviews, &b.Sessions); err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// ListProjectIDs returns all project IDs (used by the rollup worker).
+func (s *Store) ListProjectIDs(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id FROM projects`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/internal/storage/analytics_test.go
+++ b/internal/storage/analytics_test.go
@@ -1,0 +1,190 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
+)
+
+func mustOpenStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestInsertPageViewAndQueryOverview(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	now := time.Now().UTC()
+	views := []analytics.PageView{
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s1", DurationMs: 5000},
+		{ProjectID: pid, Ts: now, Pathname: "/about", SessionID: "s1", DurationMs: 3000},
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s2", DurationMs: 2000},
+	}
+	for _, pv := range views {
+		if err := s.InsertPageView(ctx, pv); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	q := analytics.Query{
+		ProjectID: pid,
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+	}
+	res, err := s.QueryOverview(ctx, q)
+	if err != nil {
+		t.Fatalf("QueryOverview: %v", err)
+	}
+	if res.Pageviews != 3 {
+		t.Errorf("expected 3 pageviews, got %d", res.Pageviews)
+	}
+	if res.Sessions != 2 {
+		t.Errorf("expected 2 sessions, got %d", res.Sessions)
+	}
+}
+
+func TestRollupDailyAnalytics(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Truncate(24 * time.Hour)
+	for i := 0; i < 5; i++ {
+		sid := "sess-a"
+		if i >= 3 {
+			sid = "sess-b"
+		}
+		if err := s.InsertPageView(ctx, analytics.PageView{
+			ProjectID: pid,
+			Ts:        yesterday.Add(time.Duration(i) * time.Hour),
+			Pathname:  "/page",
+			SessionID: sid,
+		}); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	if err := s.RollupDailyAnalytics(ctx, pid, yesterday); err != nil {
+		t.Fatalf("RollupDailyAnalytics: %v", err)
+	}
+
+	// Second call must be idempotent.
+	if err := s.RollupDailyAnalytics(ctx, pid, yesterday); err != nil {
+		t.Fatalf("RollupDailyAnalytics (idempotent): %v", err)
+	}
+
+	q := analytics.Query{
+		ProjectID: pid,
+		Start:     yesterday,
+		End:       yesterday.Add(23 * time.Hour),
+	}
+	res, err := s.QueryOverview(ctx, q)
+	if err != nil {
+		t.Fatalf("QueryOverview after rollup: %v", err)
+	}
+	if res.Pageviews != 5 {
+		t.Errorf("expected 5 pageviews, got %d", res.Pageviews)
+	}
+	if res.Sessions != 2 {
+		t.Errorf("expected 2 sessions, got %d", res.Sessions)
+	}
+}
+
+func TestDeleteOldPageviews(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	old := time.Now().UTC().AddDate(0, 0, -100)
+	recent := time.Now().UTC() // today, visible to QueryOverview's raw-today path
+	for _, ts := range []time.Time{old, recent} {
+		if err := s.InsertPageView(ctx, analytics.PageView{
+			ProjectID: pid, Ts: ts, Pathname: "/x", SessionID: "s",
+		}); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -90)
+	if err := s.DeleteOldPageviews(ctx, cutoff); err != nil {
+		t.Fatalf("DeleteOldPageviews: %v", err)
+	}
+
+	q := analytics.Query{ProjectID: pid, Start: old.Add(-time.Hour), End: time.Now()}
+	res, err := s.QueryOverview(ctx, q)
+	if err != nil {
+		t.Fatalf("QueryOverview: %v", err)
+	}
+	if res.Pageviews != 1 {
+		t.Errorf("expected 1 remaining pageview, got %d", res.Pageviews)
+	}
+}
+
+func TestQueryTimeline(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	// Insert two days of data via rollup
+	d1 := time.Now().UTC().AddDate(0, 0, -3).Truncate(24 * time.Hour)
+	d2 := time.Now().UTC().AddDate(0, 0, -2).Truncate(24 * time.Hour)
+	for _, ts := range []time.Time{d1, d2} {
+		if err := s.InsertPageView(ctx, analytics.PageView{
+			ProjectID: pid, Ts: ts, Pathname: "/x", SessionID: "s",
+		}); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+		if err := s.RollupDailyAnalytics(ctx, pid, ts); err != nil {
+			t.Fatalf("RollupDailyAnalytics: %v", err)
+		}
+	}
+
+	q := analytics.Query{ProjectID: pid, Start: d1, End: d2.Add(23 * time.Hour)}
+	buckets, err := s.QueryTimeline(ctx, q, "day")
+	if err != nil {
+		t.Fatalf("QueryTimeline: %v", err)
+	}
+	if len(buckets) != 2 {
+		t.Errorf("expected 2 timeline buckets, got %d", len(buckets))
+	}
+}
+
+func TestQuerySegments(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	now := time.Now().UTC()
+	views := []analytics.PageView{
+		{ProjectID: pid, Ts: now, Pathname: "/", SessionID: "s1", Props: map[string]string{"plan": "pro"}},
+		{ProjectID: pid, Ts: now, Pathname: "/", SessionID: "s2", Props: map[string]string{"plan": "pro"}},
+		{ProjectID: pid, Ts: now, Pathname: "/", SessionID: "s3", Props: map[string]string{"plan": "free"}},
+	}
+	for _, pv := range views {
+		if err := s.InsertPageView(ctx, pv); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	q := analytics.Query{ProjectID: pid, Start: now.Add(-time.Hour), End: now.Add(time.Hour)}
+	buckets, err := s.QuerySegments(ctx, q, "plan")
+	if err != nil {
+		t.Fatalf("QuerySegments: %v", err)
+	}
+	if len(buckets) != 2 {
+		t.Errorf("expected 2 segment buckets, got %d", len(buckets))
+	}
+	if buckets[0].Value != "pro" || buckets[0].Pageviews != 2 {
+		t.Errorf("unexpected first bucket: %+v", buckets[0])
+	}
+}

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -244,6 +244,41 @@ func (s *Store) init(ctx context.Context) error {
 		return err
 	}
 
+	// Analytics tables
+	analyticsSchema := []string{
+		`CREATE TABLE IF NOT EXISTS analytics_pageviews (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id   INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			ts           INTEGER NOT NULL,
+			pathname     TEXT    NOT NULL DEFAULT '',
+			hostname     TEXT    NOT NULL DEFAULT '',
+			referrer_host TEXT   NOT NULL DEFAULT '',
+			referrer_path TEXT   NOT NULL DEFAULT '',
+			session_id   TEXT    NOT NULL DEFAULT '',
+			duration_ms  INTEGER NOT NULL DEFAULT 0,
+			screen_width INTEGER NOT NULL DEFAULT 0,
+			props        TEXT    NOT NULL DEFAULT '{}'
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_analytics_pv_project_ts       ON analytics_pageviews(project_id, ts)`,
+		`CREATE INDEX IF NOT EXISTS idx_analytics_pv_project_pathname  ON analytics_pageviews(project_id, pathname, ts)`,
+		`CREATE TABLE IF NOT EXISTS analytics_daily (
+			project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+			date        TEXT    NOT NULL,
+			pathname    TEXT    NOT NULL DEFAULT '',
+			dim_key     TEXT    NOT NULL DEFAULT '',
+			dim_value   TEXT    NOT NULL DEFAULT '',
+			pageviews   INTEGER NOT NULL DEFAULT 0,
+			sessions    INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (project_id, date, pathname, dim_key, dim_value)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_analytics_daily_project_date ON analytics_daily(project_id, date)`,
+	}
+	for _, stmt := range analyticsSchema {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+
 	if _, err := tx.ExecContext(ctx, `
 INSERT INTO projects (slug, name)
 VALUES (?, ?)


### PR DESCRIPTION
## Summary

Foundation for the funnelbarn analytics subsystem.

- Two new SQLite tables: `analytics_pageviews` (raw, TTL'd) and `analytics_daily` (pre-aggregated rollups)
- Full storage layer: `InsertPageView`, `RollupDailyAnalytics`, `DeleteOldPageviews`, `QueryOverview`, `QueryPages`, `QueryTimeline`, `QueryReferrers`, `QuerySegments`
- `internal/analytics` package: `PageView`, `OverviewResult`, `PageStat`, `TimelineBucket`, `ReferrerStat`, `SegmentBucket` types and worker interface
- Background worker (`analytics.StartWorker`) rolls up yesterday+day-before data every hour, then purges raw rows beyond the retention window
- `BUGBARN_ANALYTICS_RETENTION_DAYS` env var (default 90)
- 5 storage tests covering insert/query round-trips, idempotent rollup, retention delete, timeline grouping, segment extraction

Closes #22