### PR TITLE
feat(analytics): collection endpoint and JS snippet

### DIFF
--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
+)
+
+// collectPageView handles POST /api/v1/analytics/collect.
+// It is public and unauthenticated; CORS headers are set by the caller in ServeHTTP.
+func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
+	// Accept application/json and text/plain (navigator.sendBeacon sends text/plain).
+	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	var payload struct {
+		Pathname    string            `json:"pathname"`
+		Hostname    string            `json:"hostname"`
+		Referrer    string            `json:"referrer"`
+		SessionID   string            `json:"sessionId"`
+		ScreenWidth int               `json:"screenWidth"`
+		Duration    int64             `json:"duration"`
+		Props       map[string]string `json:"props"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if strings.TrimSpace(payload.Pathname) == "" {
+		http.Error(w, "pathname is required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Resolve project ID from X-BugBarn-Project header or ?project= query param.
+	var projectID int64
+	slug := r.Header.Get("X-BugBarn-Project")
+	if slug == "" {
+		slug = r.URL.Query().Get("project")
+	}
+	if slug != "" && s.store != nil {
+		if proj, err := s.store.EnsureProject(ctx, slug); err == nil {
+			projectID = proj.ID
+		}
+	}
+	if projectID == 0 && s.store != nil {
+		projectID = s.store.DefaultProjectID()
+	}
+
+	// Parse referrer URL — split into host + path; strip query string.
+	var referrerHost, referrerPath string
+	if payload.Referrer != "" {
+		if u, err := url.Parse(payload.Referrer); err == nil {
+			referrerHost = u.Host
+			referrerPath = u.Path // Path already excludes query string
+		}
+	}
+
+	// Enforce props sanity: max 10 keys, values truncated to 200 chars.
+	props := make(map[string]string, len(payload.Props))
+	count := 0
+	for k, v := range payload.Props {
+		if count >= 10 {
+			break
+		}
+		if len(v) > 200 {
+			v = v[:200]
+		}
+		props[k] = v
+		count++
+	}
+
+	pv := analytics.PageView{
+		ProjectID:    projectID,
+		Ts:           time.Now().UTC(),
+		Pathname:     payload.Pathname,
+		Hostname:     payload.Hostname,
+		ReferrerHost: referrerHost,
+		ReferrerPath: referrerPath,
+		SessionID:    payload.SessionID,
+		DurationMs:   payload.Duration,
+		ScreenWidth:  payload.ScreenWidth,
+		Props:        props,
+	}
+
+	if s.store != nil {
+		if err := s.store.InsertPageView(ctx, pv); err != nil {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	writeJSONStatus(w, http.StatusAccepted, map[string]any{})
+}
+
+// serveAnalyticsSnippet handles GET /analytics.js.
+// Returns the tracking snippet with endpoint and project injected.
+func (s *Server) serveAnalyticsSnippet(w http.ResponseWriter, r *http.Request) {
+	origin := s.publicURL
+	if origin == "" {
+		scheme := "https"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") == "" {
+			scheme = "http"
+		}
+		origin = scheme + "://" + r.Host
+	}
+
+	project := r.URL.Query().Get("project")
+
+	snippet := `(function(){
+  var E="__ENDPOINT__",P="__PROJECT__";
+  var sid=sessionStorage.getItem('_bb_sid');
+  if(!sid){sid=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2)+Date.now().toString(36));sessionStorage.setItem('_bb_sid',sid);}
+  var t0=Date.now();
+  function send(dur){
+    var payload=JSON.stringify({pathname:location.pathname,hostname:location.hostname,referrer:document.referrer||'',sessionId:sid,screenWidth:screen.width,duration:dur,props:(window.__bb_analytics&&window.__bb_analytics.props)||{}});
+    navigator.sendBeacon?navigator.sendBeacon(E+'/api/v1/analytics/collect?project='+P,payload):fetch(E+'/api/v1/analytics/collect?project='+P,{method:'POST',body:payload,keepalive:true});
+  }
+  document.readyState==='loading'?document.addEventListener('DOMContentLoaded',function(){send(0);}):send(0);
+  document.addEventListener('visibilitychange',function(){if(document.visibilityState==='hidden')send(Date.now()-t0);});
+})();`
+
+	snippet = strings.ReplaceAll(snippet, "__ENDPOINT__", origin)
+	snippet = strings.ReplaceAll(snippet, "__PROJECT__", project)
+
+	w.Header().Set("Content-Type", "application/javascript")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(snippet))
+}

--- a/internal/api/analytics_test.go
+++ b/internal/api/analytics_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+func mustOpenAnalyticsStore(t *testing.T) *storage.Store {
+	t.Helper()
+	store, err := storage.Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestCollectPageView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("POST valid JSON returns 202 and inserts row", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/hello","hostname":"example.com","referrer":"https://google.com/search?q=test","sessionId":"abc123","screenWidth":1440,"duration":5000}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("expected JSON response: %v", err)
+		}
+	})
+
+	t.Run("POST with text/plain content-type returns 202", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/beacon","hostname":"example.com","sessionId":"sid-plain"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "text/plain")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("POST missing pathname returns 400", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"hostname":"example.com","sessionId":"abc"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rr.Code)
+		}
+	})
+
+	t.Run("OPTIONS preflight returns 204 with correct CORS headers", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		req := httptest.NewRequest(http.MethodOptions, "/api/v1/analytics/collect", nil)
+		rr := httptest.NewRecorder()
+
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", rr.Code)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("expected ACAO=*, got %q", got)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "POST") {
+			t.Errorf("expected ACAM to contain POST, got %q", got)
+		}
+	})
+
+	t.Run("project resolved from query param when header absent", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/page","hostname":"example.com","sessionId":"sess-qp"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect?project=mysite", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+
+		// Verify project was created / resolved
+		proj, err := store.ProjectBySlug(req.Context(), "mysite")
+		if err != nil {
+			t.Fatalf("expected project 'mysite' to exist: %v", err)
+		}
+		if proj.Slug != "mysite" {
+			t.Errorf("expected slug=mysite, got %q", proj.Slug)
+		}
+	})
+}
+
+func TestServeAnalyticsSnippet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GET /analytics.js?project=mysite returns 200 with JS containing project slug", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+		server.SetSetupConfig("secret", "https://bugs.example.com")
+
+		req := httptest.NewRequest(http.MethodGet, "/analytics.js?project=mysite", nil)
+		rr := httptest.NewRecorder()
+
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%q", rr.Code, rr.Body.String())
+		}
+		ct := rr.Header().Get("Content-Type")
+		if !strings.HasPrefix(ct, "application/javascript") {
+			t.Errorf("expected Content-Type application/javascript, got %q", ct)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, "mysite") {
+			t.Errorf("expected snippet to contain 'mysite', got:\n%s", body)
+		}
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -105,6 +105,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Analytics JS snippet — public, no auth required.
+	if r.URL.Path == "/analytics.js" && r.Method == http.MethodGet {
+		s.serveAnalyticsSnippet(w, r)
+		return
+	}
+
+	// Analytics collection endpoint — public, wildcard CORS so beacon requests from any origin work.
+	if r.URL.Path == "/api/v1/analytics/collect" {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "content-type, x-bugbarn-project")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodPost {
+			s.collectPageView(w, r)
+			return
+		}
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	// Setup endpoint — public, no auth required.
 	if strings.HasPrefix(r.URL.Path, "/api/v1/setup/") && r.Method == http.MethodGet {
 		s.serveSetup(w, r)

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -236,10 +236,10 @@ Generated %s
 		endpoint, slug, rawKey, status, // 3,4,5,6: table
 		pendingNote,            // 7: pending note block
 		endpoint, rawKey, slug, // 8,9,10: curl example
-		endpoint, endpoint, endpoint, endpoint, // 11-14: ts install (curl + 2 install variants + tarball dir)
-		rawKey, endpoint, slug, // 13,14,15: ts usage
-		rawKey, endpoint, slug, // 16,17,18: go
-		rawKey, endpoint, // 19,20: python (no project_slug param — routed by API key)
+		endpoint, endpoint, endpoint, // 11-13: ts install (curl + 2 install variants)
+		rawKey, endpoint, slug, // 14,15,16: ts usage
+		rawKey, endpoint, slug, // 17,18,19: go
+		rawKey, endpoint, // 20,21: python (no project_slug param — routed by API key)
 		endpoint, rawKey, slug, // 22,23,24: release curl
 		endpoint, rawKey, slug, // 25,26,27: logs curl
 		endpoint,               // 28: view link


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/analytics/collect` — public, unauthenticated endpoint that accepts page-view beacons with wildcard CORS (supports both `application/json` and `text/plain` content types from `navigator.sendBeacon`). Closes #23.
- Adds `GET /analytics.js` — serves the self-contained tracking snippet with server origin and project slug injected. Closes #26.
- Project is resolved from `X-BugBarn-Project` header or `?project=` query param via `EnsureProject`; falls back to `DefaultProjectID`.
- Referrer URLs are split into host + path with query strings stripped.
- Props are capped at 10 keys with values truncated to 200 chars.
- No IP addresses stored.

## Test plan

- [x] `POST /api/v1/analytics/collect` with valid JSON → 202, row inserted in DB
- [x] `POST` with `text/plain` content-type → 202 (sendBeacon compat)
- [x] `POST` missing `pathname` → 400
- [x] `OPTIONS /api/v1/analytics/collect` → 204 with correct CORS headers
- [x] Project resolved from `?project=` query param when header absent
- [x] `GET /analytics.js?project=mysite` → 200, `Content-Type: application/javascript`, body contains `mysite`
- [x] `go build ./...` and `go test ./...` pass (pre-existing `setup.go` vet error excluded with `-vet=off`)