### PR TITLE
feat(analytics): funnelbarn — query API, UI, collection endpoint, JS snippet

### DIFF
--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -1,0 +1,359 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+const analyticsMaxDays = 366
+
+// parseAnalyticsQuery parses common analytics query parameters from the request.
+// Defaults to the last 30 days. Clamps to max 366 days. Returns 400 if start > end.
+func parseAnalyticsQuery(r *http.Request, projectID int64) (analytics.Query, error) {
+	now := time.Now().UTC()
+	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	start := end.AddDate(0, 0, -30)
+
+	if s := r.URL.Query().Get("start"); s != "" {
+		t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+		if err != nil {
+			return analytics.Query{}, fmt.Errorf("invalid start date: %w", err)
+		}
+		start = t
+	}
+	if e := r.URL.Query().Get("end"); e != "" {
+		t, err := time.ParseInLocation("2006-01-02", e, time.UTC)
+		if err != nil {
+			return analytics.Query{}, fmt.Errorf("invalid end date: %w", err)
+		}
+		end = t
+	}
+
+	if start.After(end) {
+		return analytics.Query{}, fmt.Errorf("start must not be after end")
+	}
+
+	// Clamp to max 366 days.
+	if end.Sub(start) > analyticsMaxDays*24*time.Hour {
+		start = end.AddDate(0, 0, -analyticsMaxDays)
+	}
+
+	return analytics.Query{
+		ProjectID: projectID,
+		Start:     start,
+		End:       end,
+	}, nil
+}
+
+// resolveAnalyticsProjectID resolves the project ID for analytics requests using
+// the same logic as other protected routes.
+func (s *Server) resolveAnalyticsProjectID(r *http.Request) int64 {
+	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.store != nil {
+		if proj, err := s.store.EnsureProject(r.Context(), slug); err == nil {
+			return proj.ID
+		}
+	}
+	if id, ok := storage.ProjectIDFromContext(r.Context()); ok && id > 0 {
+		return id
+	}
+	return s.store.DefaultProjectID()
+}
+
+// serveAnalyticsQuery handles all GET /api/v1/analytics/* endpoints.
+func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	projectID := s.resolveAnalyticsProjectID(r)
+
+	q, err := parseAnalyticsQuery(r, projectID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/analytics/")
+
+	ctx := r.Context()
+
+	switch tail {
+	case "overview":
+		result, err := s.store.QueryOverview(ctx, q)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"pageviews":     result.Pageviews,
+			"sessions":      result.Sessions,
+			"pages":         result.PagesCount,
+			"avgDurationMs": result.AvgDurationMs,
+		})
+
+	case "pages":
+		pages, err := s.store.QueryPages(ctx, q)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		if pages == nil {
+			pages = []analytics.PageStat{}
+		}
+		writeJSON(w, map[string]any{"pages": pages})
+
+	case "timeline":
+		granularity := r.URL.Query().Get("granularity")
+		if granularity == "" {
+			granularity = "day"
+		}
+		switch granularity {
+		case "day", "week", "month":
+			// valid
+		default:
+			granularity = "day"
+		}
+
+		buckets, err := s.store.QueryTimeline(ctx, q, granularity)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+
+		buckets = zeroFillTimeline(buckets, q.Start, q.End, granularity)
+
+		writeJSON(w, map[string]any{
+			"granularity": granularity,
+			"buckets":     buckets,
+		})
+
+	case "referrers":
+		refs, err := s.store.QueryReferrers(ctx, q)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		if refs == nil {
+			refs = []analytics.ReferrerStat{}
+		}
+		writeJSON(w, map[string]any{"referrers": refs})
+
+	case "segments":
+		dim := r.URL.Query().Get("dim")
+		segs, err := s.store.QuerySegments(ctx, q, dim)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		if segs == nil {
+			segs = []analytics.SegmentBucket{}
+		}
+		writeJSON(w, map[string]any{
+			"dim":     dim,
+			"buckets": segs,
+		})
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// zeroFillTimeline inserts zero-value buckets for any dates missing from the
+// DB results so the client always gets a contiguous series.
+func zeroFillTimeline(buckets []analytics.TimelineBucket, start, end time.Time, granularity string) []analytics.TimelineBucket {
+	// Build a lookup from the DB results.
+	have := make(map[string]analytics.TimelineBucket, len(buckets))
+	for _, b := range buckets {
+		have[b.Date] = b
+	}
+
+	var keys []string
+	switch granularity {
+	case "week":
+		// Iterate by week from start to end.
+		cur := weekStart(start)
+		for !cur.After(end) {
+			key := cur.UTC().Format("2006-W") + fmt.Sprintf("%02d", isoWeekNumber(cur))
+			keys = append(keys, key)
+			cur = cur.AddDate(0, 0, 7)
+		}
+	case "month":
+		cur := time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, time.UTC)
+		endMonth := time.Date(end.Year(), end.Month(), 1, 0, 0, 0, 0, time.UTC)
+		for !cur.After(endMonth) {
+			keys = append(keys, cur.Format("2006-01"))
+			cur = cur.AddDate(0, 1, 0)
+		}
+	default: // day
+		cur := start
+		for !cur.After(end) {
+			keys = append(keys, cur.Format("2006-01-02"))
+			cur = cur.AddDate(0, 0, 1)
+		}
+	}
+
+	out := make([]analytics.TimelineBucket, 0, len(keys))
+	for _, key := range keys {
+		if b, ok := have[key]; ok {
+			out = append(out, b)
+		} else {
+			out = append(out, analytics.TimelineBucket{Date: key})
+		}
+	}
+	return out
+}
+
+// weekStart returns the Monday of the week containing t (matching strftime %W
+// which counts weeks starting on Sunday, but we align on Monday for ISO feel).
+// We use Go's time.Weekday with Sunday=0, Monday=1, …
+// strftime('%Y-W%W', date) in SQLite uses Sunday as the first day of the week.
+// So we align our iteration to match SQLite's Sunday-based week numbers.
+func weekStart(t time.Time) time.Time {
+	// Go's time.Sunday == 0, time.Monday == 1, …
+	offset := int(t.Weekday()) // 0 for Sunday
+	return time.Date(t.Year(), t.Month(), t.Day()-offset, 0, 0, 0, 0, time.UTC)
+}
+
+// isoWeekNumber returns the SQLite strftime('%W', …) week number (0-53),
+// where weeks start on Sunday.
+func isoWeekNumber(t time.Time) int {
+	// Jan 1 of the year
+	jan1 := time.Date(t.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	// Day-of-year (0-based)
+	dayOfYear := t.YearDay() - 1
+	// Day of week of Jan 1 (Sunday=0)
+	jan1DOW := int(jan1.Weekday())
+	// SQLite %W: number of Sundays before this date / week of year
+	return (dayOfYear + jan1DOW) / 7
+}
+
+// collectPageView handles POST /api/v1/analytics/collect.
+// It is public and unauthenticated; CORS headers are set by the caller in ServeHTTP.
+func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	var payload struct {
+		Pathname    string            `json:"pathname"`
+		Hostname    string            `json:"hostname"`
+		Referrer    string            `json:"referrer"`
+		SessionID   string            `json:"sessionId"`
+		ScreenWidth int               `json:"screenWidth"`
+		Duration    int64             `json:"duration"`
+		Props       map[string]string `json:"props"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if strings.TrimSpace(payload.Pathname) == "" {
+		http.Error(w, "pathname is required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	var projectID int64
+	slug := r.Header.Get("X-BugBarn-Project")
+	if slug == "" {
+		slug = r.URL.Query().Get("project")
+	}
+	if slug != "" && s.store != nil {
+		if proj, err := s.store.EnsureProject(ctx, slug); err == nil {
+			projectID = proj.ID
+		}
+	}
+	if projectID == 0 && s.store != nil {
+		projectID = s.store.DefaultProjectID()
+	}
+
+	var referrerHost, referrerPath string
+	if payload.Referrer != "" {
+		if u, err := url.Parse(payload.Referrer); err == nil {
+			referrerHost = u.Host
+			referrerPath = u.Path
+		}
+	}
+
+	props := make(map[string]string, len(payload.Props))
+	count := 0
+	for k, v := range payload.Props {
+		if count >= 10 {
+			break
+		}
+		if len(v) > 200 {
+			v = v[:200]
+		}
+		props[k] = v
+		count++
+	}
+
+	pv := analytics.PageView{
+		ProjectID:    projectID,
+		Ts:           time.Now().UTC(),
+		Pathname:     payload.Pathname,
+		Hostname:     payload.Hostname,
+		ReferrerHost: referrerHost,
+		ReferrerPath: referrerPath,
+		SessionID:    payload.SessionID,
+		DurationMs:   payload.Duration,
+		ScreenWidth:  payload.ScreenWidth,
+		Props:        props,
+	}
+
+	if s.store != nil {
+		if err := s.store.InsertPageView(ctx, pv); err != nil {
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	writeJSONStatus(w, http.StatusAccepted, map[string]any{})
+}
+
+// serveAnalyticsSnippet handles GET /analytics.js.
+func (s *Server) serveAnalyticsSnippet(w http.ResponseWriter, r *http.Request) {
+	origin := s.publicURL
+	if origin == "" {
+		scheme := "https"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") == "" {
+			scheme = "http"
+		}
+		origin = scheme + "://" + r.Host
+	}
+
+	project := r.URL.Query().Get("project")
+
+	snippet := `(function(){
+  var E="__ENDPOINT__",P="__PROJECT__";
+  var sid=sessionStorage.getItem('_bb_sid');
+  if(!sid){sid=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2)+Date.now().toString(36));sessionStorage.setItem('_bb_sid',sid);}
+  var t0=Date.now();
+  function send(dur){
+    var payload=JSON.stringify({pathname:location.pathname,hostname:location.hostname,referrer:document.referrer||'',sessionId:sid,screenWidth:screen.width,duration:dur,props:(window.__bb_analytics&&window.__bb_analytics.props)||{}});
+    navigator.sendBeacon?navigator.sendBeacon(E+'/api/v1/analytics/collect?project='+P,payload):fetch(E+'/api/v1/analytics/collect?project='+P,{method:'POST',body:payload,keepalive:true});
+  }
+  document.readyState==='loading'?document.addEventListener('DOMContentLoaded',function(){send(0);}):send(0);
+  document.addEventListener('visibilitychange',function(){if(document.visibilityState==='hidden')send(Date.now()-t0);});
+})();`
+
+	snippet = strings.ReplaceAll(snippet, "__ENDPOINT__", origin)
+	snippet = strings.ReplaceAll(snippet, "__PROJECT__", project)
+
+	w.Header().Set("Content-Type", "application/javascript")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_, _ = w.Write([]byte(snippet))
+}

--- a/internal/api/analytics_query_test.go
+++ b/internal/api/analytics_query_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/auth"
+)
+
+func TestAnalyticsOverviewEmptyProject(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/overview", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Pageviews     int64 `json:"pageviews"`
+		Sessions      int64 `json:"sessions"`
+		Pages         int64 `json:"pages"`
+		AvgDurationMs int64 `json:"avgDurationMs"`
+	}
+	decodeResponse(t, rr, &resp)
+
+	if resp.Pageviews != 0 {
+		t.Errorf("expected 0 pageviews, got %d", resp.Pageviews)
+	}
+	if resp.Sessions != 0 {
+		t.Errorf("expected 0 sessions, got %d", resp.Sessions)
+	}
+	if resp.Pages != 0 {
+		t.Errorf("expected 0 pages, got %d", resp.Pages)
+	}
+	if resp.AvgDurationMs != 0 {
+		t.Errorf("expected 0 avgDurationMs, got %d", resp.AvgDurationMs)
+	}
+}
+
+func TestAnalyticsTimelineDayGranularityZeroFills(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store)
+
+	// Request exactly 3 days: 2026-04-01 to 2026-04-03.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/timeline?start=2026-04-01&end=2026-04-03&granularity=day", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Granularity string `json:"granularity"`
+		Buckets     []struct {
+			Date      string `json:"Date"`
+			Pageviews int64  `json:"Pageviews"`
+			Sessions  int64  `json:"Sessions"`
+		} `json:"buckets"`
+	}
+	decodeResponse(t, rr, &resp)
+
+	if resp.Granularity != "day" {
+		t.Errorf("expected granularity=day, got %q", resp.Granularity)
+	}
+
+	// Zero-fill should produce exactly 3 buckets for the 3-day range.
+	if len(resp.Buckets) != 3 {
+		t.Errorf("expected 3 buckets, got %d", len(resp.Buckets))
+	}
+	want := []string{"2026-04-01", "2026-04-02", "2026-04-03"}
+	for i, b := range resp.Buckets {
+		if i >= len(want) {
+			break
+		}
+		if b.Date != want[i] {
+			t.Errorf("bucket[%d]: expected date %q, got %q", i, want[i], b.Date)
+		}
+		if b.Pageviews != 0 {
+			t.Errorf("bucket[%d]: expected 0 pageviews, got %d", i, b.Pageviews)
+		}
+	}
+}
+
+func TestAnalyticsSegmentsUnknownDimReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/segments?dim=nonexistent_dimension", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Dim     string `json:"dim"`
+		Buckets []any  `json:"buckets"`
+	}
+	decodeResponse(t, rr, &resp)
+
+	if resp.Dim != "nonexistent_dimension" {
+		t.Errorf("expected dim=nonexistent_dimension, got %q", resp.Dim)
+	}
+	if len(resp.Buckets) != 0 {
+		t.Errorf("expected empty buckets, got %d", len(resp.Buckets))
+	}
+}
+
+func TestAnalyticsUnauthenticatedReturns401(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	userAuth, err := auth.NewUserAuthenticator("admin", "secret", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions := auth.NewSessionManager("test-secret", time.Hour)
+	server := NewServerWithAuth(nil, store, userAuth, sessions, nil)
+
+	endpoints := []string{
+		"/api/v1/analytics/overview",
+		"/api/v1/analytics/pages",
+		"/api/v1/analytics/timeline",
+		"/api/v1/analytics/referrers",
+		"/api/v1/analytics/segments",
+	}
+
+	for _, path := range endpoints {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("%s: expected 401, got %d", path, rr.Code)
+		}
+	}
+}
+
+func TestAnalyticsStartAfterEndReturns400(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/overview?start=2026-04-10&end=2026-04-01", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/api/analytics_test.go
+++ b/internal/api/analytics_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+func mustOpenAnalyticsStore(t *testing.T) *storage.Store {
+	t.Helper()
+	store, err := storage.Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestCollectPageView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("POST valid JSON returns 202 and inserts row", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/hello","hostname":"example.com","referrer":"https://google.com/search?q=test","sessionId":"abc123","screenWidth":1440,"duration":5000}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+		var resp map[string]any
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("expected JSON response: %v", err)
+		}
+	})
+
+	t.Run("POST with text/plain content-type returns 202", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/beacon","hostname":"example.com","sessionId":"sid-plain"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "text/plain")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("POST missing pathname returns 400", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"hostname":"example.com","sessionId":"abc"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rr.Code)
+		}
+	})
+
+	t.Run("OPTIONS preflight returns 204 with correct CORS headers", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		req := httptest.NewRequest(http.MethodOptions, "/api/v1/analytics/collect", nil)
+		rr := httptest.NewRecorder()
+
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d", rr.Code)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("expected ACAO=*, got %q", got)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "POST") {
+			t.Errorf("expected ACAM to contain POST, got %q", got)
+		}
+	})
+
+	t.Run("project resolved from query param when header absent", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+
+		body := `{"pathname":"/page","hostname":"example.com","sessionId":"sess-qp"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect?project=mysite", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+
+		server.collectPageView(rr, req)
+
+		if rr.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+		}
+
+		// Verify project was created / resolved
+		proj, err := store.ProjectBySlug(req.Context(), "mysite")
+		if err != nil {
+			t.Fatalf("expected project 'mysite' to exist: %v", err)
+		}
+		if proj.Slug != "mysite" {
+			t.Errorf("expected slug=mysite, got %q", proj.Slug)
+		}
+	})
+}
+
+func TestServeAnalyticsSnippet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GET /analytics.js?project=mysite returns 200 with JS containing project slug", func(t *testing.T) {
+		store := mustOpenAnalyticsStore(t)
+		defer store.Close()
+		server := NewServer(nil, store)
+		server.SetSetupConfig("secret", "https://bugs.example.com")
+
+		req := httptest.NewRequest(http.MethodGet, "/analytics.js?project=mysite", nil)
+		rr := httptest.NewRecorder()
+
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%q", rr.Code, rr.Body.String())
+		}
+		ct := rr.Header().Get("Content-Type")
+		if !strings.HasPrefix(ct, "application/javascript") {
+			t.Errorf("expected Content-Type application/javascript, got %q", ct)
+		}
+		body := rr.Body.String()
+		if !strings.Contains(body, "mysite") {
+			t.Errorf("expected snippet to contain 'mysite', got:\n%s", body)
+		}
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,6 +111,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Analytics JS snippet — public, no auth required.
+	if r.URL.Path == "/analytics.js" && r.Method == http.MethodGet {
+		s.serveAnalyticsSnippet(w, r)
+		return
+	}
+
+	// Analytics collection — public, wildcard CORS for sendBeacon from any origin.
+	if r.URL.Path == "/api/v1/analytics/collect" {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "content-type, x-bugbarn-project")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodPost {
+			s.collectPageView(w, r)
+			return
+		}
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 	if r.Method == http.MethodOptions {
@@ -236,6 +259,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.deleteAPIKey(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/facets") && r.Method == http.MethodGet:
 		s.serveFacetsRoute(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/v1/analytics/") && r.Method == http.MethodGet:
+		s.serveAnalyticsQuery(w, r)
 	default:
 		http.NotFound(w, r)
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,10 @@
             <span class="nav-icon" aria-hidden="true">≡</span>
             <span class="nav-label">Logs</span>
           </a>
+          <a href="#/analytics" data-route="analytics">
+            <span class="nav-icon" aria-hidden="true">◎</span>
+            <span class="nav-label">Analytics</span>
+          </a>
           <a href="#/settings" data-route="settings">
             <span class="nav-icon" aria-hidden="true">⚙</span>
             <span class="nav-label">Settings</span>
@@ -159,6 +163,14 @@
             <line x1="3" y1="18" x2="3.01" y2="18"/>
           </svg>
           <span>Logs</span>
+        </a>
+        <a href="#/analytics" data-route="analytics" class="mobile-tab">
+          <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="18" y1="20" x2="18" y2="10"/>
+            <line x1="12" y1="20" x2="12" y2="4"/>
+            <line x1="6" y1="20" x2="6" y2="14"/>
+          </svg>
+          <span>Analytics</span>
         </a>
         <a href="#/settings" data-route="settings" class="mobile-tab">
           <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1,5 +1,6 @@
 import {
   renderAlertsViewMarkup,
+  renderAnalyticsViewMarkup,
   renderEmptyIssues,
   renderErrorDetailMarkup,
   renderEventDetailMarkup,
@@ -13,10 +14,10 @@ import {
   renderSettingsViewMarkup,
   renderSetupGuide,
 } from "./components.js";
-import { normalizeList, normalizeObject, readString } from "./data.js";
+import { fetchAnalyticsOverview, fetchAnalyticsPages, fetchAnalyticsReferrers, fetchAnalyticsSegments, fetchAnalyticsTimeline, normalizeList, normalizeObject, readString } from "./data.js";
 import { eventIssueId, eventTimestamp, eventTitle, firstIdentifier, issueTitle } from "./domain.js";
 import { escapeHtml, errorMessage } from "./format.js";
-import type { ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, AppElements, AppState, IssueSort, IssueStatus, RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, AppElements, AppState, IssueSort, IssueStatus, RawRecord } from "./types.js";
 
 const httpUnauthorized = 401;
 const liveWindowMinutes = 15;
@@ -57,6 +58,15 @@ const state: AppState = {
   logSearch: "",
   logSSE: null,
 };
+
+// Analytics module-level state (not in AppState to avoid large interface churn)
+let analyticsRangeDays = 30;
+let analyticsSegmentDim = "";
+let analyticsOverview: AnalyticsOverview | null = null;
+let analyticsPages: AnalyticsPage[] = [];
+let analyticsTimeline: AnalyticsBucket[] = [];
+let analyticsReferrers: AnalyticsReferrer[] = [];
+let analyticsSegments: AnalyticsSegmentBucket[] = [];
 
 const elements: AppElements = {
   refreshAll: byId<HTMLButtonElement>("refresh-all"),
@@ -376,6 +386,10 @@ function route(): void {
     state.currentRoute = "settings";
     setPageTitle("Settings");
     setRouteChip("Settings");
+  } else if (kind === "analytics") {
+    state.currentRoute = "analytics";
+    setPageTitle("Analytics");
+    setRouteChip("Analytics");
   } else {
     state.currentRoute = "issues";
     setPageTitle("Issues");
@@ -399,6 +413,8 @@ function renderCurrentRoute(): void {
     renderLogsView();
   } else if (state.currentRoute === "settings") {
     renderSettingsView();
+  } else if (state.currentRoute === "analytics") {
+    renderAnalyticsView();
   } else if (state.selectedEventId) {
     setDetailLoading(`Event ${state.selectedEventId}`);
   } else if (state.selectedIssueId) {
@@ -491,6 +507,10 @@ async function loadCurrentRouteData(): Promise<void> {
   if (state.currentRoute === "settings") {
     await loadSettings();
     loadSdkInfo();
+    return;
+  }
+  if (state.currentRoute === "analytics") {
+    await loadAnalytics();
     return;
   }
   if (state.selectedEventId) {
@@ -1629,6 +1649,76 @@ function wireLogsView(): void {
   if (state.logSSE && state.logSSE.readyState === EventSource.OPEN) {
     dot?.classList.add("connected");
   }
+}
+
+function analyticsDateRange(): { start: string; end: string } {
+  const end = new Date();
+  const start = new Date(end.getTime() - analyticsRangeDays * 24 * 60 * 60 * 1000);
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+async function loadAnalytics(error: unknown = null): Promise<void> {
+  if (state.currentRoute !== "analytics") return;
+  const project = state.currentProject;
+  const { start, end } = analyticsDateRange();
+  try {
+    const [ov, pg, tl, rf] = await Promise.all([
+      fetchAnalyticsOverview(project, start, end).catch(() => null),
+      fetchAnalyticsPages(project, start, end).catch(() => []),
+      fetchAnalyticsTimeline(project, start, end).catch(() => []),
+      fetchAnalyticsReferrers(project, start, end).catch(() => []),
+    ]);
+    analyticsOverview = ov;
+    analyticsPages = pg;
+    analyticsTimeline = tl;
+    analyticsReferrers = rf;
+    if (analyticsSegmentDim) {
+      analyticsSegments = await fetchAnalyticsSegments(project, start, end, analyticsSegmentDim).catch(() => []);
+    } else {
+      analyticsSegments = [];
+    }
+    renderAnalyticsView(error);
+  } catch (err) {
+    renderAnalyticsView(err);
+  }
+}
+
+function renderAnalyticsView(error: unknown = null): void {
+  setActiveView("overview");
+  elements.detailTitle.textContent = "Analytics";
+  elements.detailBody.innerHTML = "";
+  elements.overviewView.innerHTML = renderAnalyticsViewMarkup(
+    analyticsOverview,
+    analyticsPages,
+    analyticsTimeline,
+    analyticsReferrers,
+    analyticsSegments,
+    analyticsRangeDays,
+    analyticsSegmentDim,
+    error,
+  );
+  wireAnalyticsView();
+}
+
+function wireAnalyticsView(): void {
+  elements.overviewView.querySelectorAll<HTMLButtonElement>("[data-analytics-range]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const days = Number(btn.dataset["analyticsRange"]);
+      if (days && days !== analyticsRangeDays) {
+        analyticsRangeDays = days;
+        void loadAnalytics();
+      }
+    });
+  });
+
+  const dimSelect = document.getElementById("analytics-segment-dim") as HTMLSelectElement | null;
+  dimSelect?.addEventListener("change", () => {
+    analyticsSegmentDim = dimSelect.value;
+    void loadAnalytics();
+  });
 }
 
 function setActiveView(view: "overview" | "detail"): void {

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -26,7 +26,7 @@ import {
   issueTitle,
 } from "./domain.js";
 import { escapeAttr, escapeHtml, errorMessage, formatAge, formatTime } from "./format.js";
-import type { ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, BreadcrumbEntry, RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, BreadcrumbEntry, RawRecord } from "./types.js";
 
 const nearbyReleaseWindowMs = 72 * 60 * 60 * 1000; // 72 hours
 const maxNearbyReleases = 5;
@@ -1305,6 +1305,216 @@ export function renderLogsViewMarkup(logs: ApiLogEntry[], level: string, search:
     </div>
     <div id="log-list" class="log-list">
       ${listContent}
+    </div>
+  `;
+}
+
+export function renderAnalyticsViewMarkup(
+  overview: AnalyticsOverview | null,
+  pages: AnalyticsPage[],
+  timeline: AnalyticsBucket[],
+  referrers: AnalyticsReferrer[],
+  segments: AnalyticsSegmentBucket[],
+  rangeDays: number,
+  segmentDim: string,
+  error: unknown = null,
+): string {
+  return `
+    <div class="view-head">
+      <div>
+        <p class="eyebrow">Analytics</p>
+        <h2>Web analytics</h2>
+      </div>
+      <div class="view-actions">
+        <div class="analytics-range-bar" role="group" aria-label="Date range">
+          <button class="tab${rangeDays === 7 ? " active" : ""}" data-analytics-range="7">7d</button>
+          <button class="tab${rangeDays === 30 ? " active" : ""}" data-analytics-range="30">30d</button>
+          <button class="tab${rangeDays === 90 ? " active" : ""}" data-analytics-range="90">90d</button>
+        </div>
+      </div>
+    </div>
+    ${error ? `<div class="error">Analytics unavailable. ${escapeHtml(errorMessage(error))}</div>` : ""}
+    ${renderAnalyticsOverviewCards(overview)}
+    ${renderAnalyticsTimeline(timeline)}
+    <div class="analytics-tables">
+      ${renderAnalyticsPagesTable(pages)}
+      ${renderAnalyticsReferrersTable(referrers)}
+    </div>
+    ${renderAnalyticsSegmentSection(segments, segmentDim)}
+  `;
+}
+
+function renderAnalyticsOverviewCards(overview: AnalyticsOverview | null): string {
+  const pv = overview?.pageviews ?? 0;
+  const sv = overview?.sessions ?? 0;
+  const pg = overview?.pages ?? 0;
+  return `
+    <div class="analytics-cards">
+      <div class="analytics-card">
+        <span class="analytics-card-label">Pageviews</span>
+        <strong class="analytics-card-value">${escapeHtml(String(pv))}</strong>
+      </div>
+      <div class="analytics-card">
+        <span class="analytics-card-label">Sessions</span>
+        <strong class="analytics-card-value">${escapeHtml(String(sv))}</strong>
+      </div>
+      <div class="analytics-card">
+        <span class="analytics-card-label">Pages</span>
+        <strong class="analytics-card-value">${escapeHtml(String(pg))}</strong>
+      </div>
+    </div>
+  `;
+}
+
+function renderAnalyticsTimeline(buckets: AnalyticsBucket[]): string {
+  if (!buckets.length) {
+    return `<div class="section"><div class="empty">No timeline data available.</div></div>`;
+  }
+
+  const maxPv = buckets.reduce((m, b) => Math.max(m, b.pageviews), 1);
+  const w = 800;
+  const h = 120;
+  const padTop = 8;
+  const padBottom = 8;
+  const innerH = h - padTop - padBottom;
+  const step = w / Math.max(buckets.length - 1, 1);
+
+  const points = buckets.map((b, i) => {
+    const x = Math.round(i * step);
+    const y = Math.round(padTop + innerH - (b.pageviews / maxPv) * innerH);
+    return `${x},${y}`;
+  }).join(" ");
+
+  // Vertical grid lines at each bucket (only if few buckets, else every ~7)
+  const gridInterval = buckets.length > 14 ? 7 : 1;
+  const gridLines = buckets
+    .filter((_, i) => i % gridInterval === 0)
+    .map((_, idx) => {
+      const i = idx * gridInterval;
+      const x = Math.round(i * step);
+      return `<line x1="${x}" y1="${padTop}" x2="${x}" y2="${h - padBottom}" stroke="var(--line,#21262d)" stroke-width="1"/>`;
+    })
+    .join("");
+
+  // Date labels — first and last
+  const firstLabel = buckets[0]?.date ?? "";
+  const lastLabel = buckets[buckets.length - 1]?.date ?? "";
+  const lastX = Math.round((buckets.length - 1) * step);
+
+  return `
+    <div class="section analytics-timeline-section">
+      <h3>Pageviews over time</h3>
+      <div class="analytics-chart" style="position:relative">
+        <svg viewBox="0 0 ${w} ${h}" width="100%" height="${h}" aria-label="Pageviews timeline" role="img" style="display:block;overflow:visible">
+          ${gridLines}
+          <polyline points="${escapeAttr(points)}" fill="none" stroke="#d4a054" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+        </svg>
+        <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--muted,#8b949e);margin-top:2px">
+          <span>${escapeHtml(firstLabel)}</span>
+          <span>${escapeHtml(lastLabel)}</span>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderAnalyticsPagesTable(pages: AnalyticsPage[]): string {
+  if (!pages.length) {
+    return `
+      <div class="section" style="flex:1;min-width:0">
+        <h3>Top pages</h3>
+        <div class="empty">
+          <p>No page data yet.</p>
+          <p class="muted">Install the BugBarn snippet on your site to track pageviews.</p>
+        </div>
+      </div>
+    `;
+  }
+  const rows = pages.map((p) => `
+    <tr>
+      <td class="url-truncate">${escapeHtml(p.pathname)}</td>
+      <td>${escapeHtml(String(p.pageviews))}</td>
+      <td>${escapeHtml(String(p.sessions))}</td>
+    </tr>
+  `).join("");
+  return `
+    <div class="section" style="flex:1;min-width:0">
+      <h3>Top pages</h3>
+      <table class="data-table">
+        <thead><tr><th>Path</th><th>Views</th><th>Sessions</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderAnalyticsReferrersTable(referrers: AnalyticsReferrer[]): string {
+  if (!referrers.length) {
+    return `
+      <div class="section" style="flex:1;min-width:0">
+        <h3>Referrers</h3>
+        <div class="empty"><p>No referrer data yet.</p></div>
+      </div>
+    `;
+  }
+  const rows = referrers.map((r) => `
+    <tr>
+      <td class="url-truncate">${escapeHtml(r.host || "(direct)")}</td>
+      <td>${escapeHtml(String(r.pageviews))}</td>
+      <td>${escapeHtml(String(r.sessions))}</td>
+    </tr>
+  `).join("");
+  return `
+    <div class="section" style="flex:1;min-width:0">
+      <h3>Referrers</h3>
+      <table class="data-table">
+        <thead><tr><th>Host</th><th>Views</th><th>Sessions</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderAnalyticsSegmentSection(segments: AnalyticsSegmentBucket[], dim: string): string {
+  const dimOptions = [
+    { value: "", label: "-- none --" },
+    { value: "referrer_host", label: "Referrer host" },
+    { value: "screen_width", label: "Screen width" },
+  ];
+  const selectHtml = `
+    <select id="analytics-segment-dim" aria-label="Breakdown dimension">
+      ${dimOptions.map((o) => `<option value="${escapeAttr(o.value)}"${o.value === dim ? " selected" : ""}>${escapeHtml(o.label)}</option>`).join("")}
+    </select>
+  `;
+  if (!dim) {
+    return `
+      <div class="section">
+        <h3>Breakdown</h3>
+        ${selectHtml}
+      </div>
+    `;
+  }
+  let tableHtml = `<div class="empty"><p>No segment data.</p></div>`;
+  if (segments.length) {
+    const rows = segments.map((s) => `
+      <tr>
+        <td>${escapeHtml(s.value || "(unknown)")}</td>
+        <td>${escapeHtml(String(s.pageviews))}</td>
+        <td>${escapeHtml(String(s.sessions))}</td>
+      </tr>
+    `).join("");
+    tableHtml = `
+      <table class="data-table">
+        <thead><tr><th>${escapeHtml(dim)}</th><th>Views</th><th>Sessions</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  }
+  return `
+    <div class="section">
+      <h3>Breakdown</h3>
+      ${selectHtml}
+      ${tableHtml}
     </div>
   `;
 }

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -1,4 +1,4 @@
-import type { RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, RawRecord } from "./types.js";
 
 export function normalizeList<T extends RawRecord = RawRecord>(payload: unknown, key: string): T[] {
   if (!payload) {
@@ -80,4 +80,53 @@ export function collectKeyValues(source: RawRecord, omitKeys: string[] = []): Ra
     acc[key] = value;
     return acc;
   }, {});
+}
+
+async function apiFetchJson(url: string, project: string): Promise<unknown> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (project && project !== "default" && project !== "__all") {
+    headers["X-BugBarn-Project"] = project;
+  }
+  const response = await fetch(url, { credentials: "include", headers });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`.trim());
+  }
+  const text = await response.text();
+  return text ? JSON.parse(text) as unknown : null;
+}
+
+export async function fetchAnalyticsOverview(project: string, start: string, end: string): Promise<AnalyticsOverview> {
+  const qs = new URLSearchParams({ start, end }).toString();
+  const data = await apiFetchJson(`/api/v1/analytics/overview?${qs}`, project);
+  const r = isRecord(data) ? data : {};
+  return {
+    pageviews: typeof r["pageviews"] === "number" ? r["pageviews"] : 0,
+    sessions: typeof r["sessions"] === "number" ? r["sessions"] : 0,
+    pages: typeof r["pages"] === "number" ? r["pages"] : 0,
+    avgDurationMs: typeof r["avgDurationMs"] === "number" ? r["avgDurationMs"] : 0,
+  };
+}
+
+export async function fetchAnalyticsPages(project: string, start: string, end: string): Promise<AnalyticsPage[]> {
+  const qs = new URLSearchParams({ start, end }).toString();
+  const data = await apiFetchJson(`/api/v1/analytics/pages?${qs}`, project);
+  return normalizeList<AnalyticsPage>(data, "pages");
+}
+
+export async function fetchAnalyticsTimeline(project: string, start: string, end: string): Promise<AnalyticsBucket[]> {
+  const qs = new URLSearchParams({ start, end }).toString();
+  const data = await apiFetchJson(`/api/v1/analytics/timeline?${qs}`, project);
+  return normalizeList<AnalyticsBucket>(data, "buckets");
+}
+
+export async function fetchAnalyticsReferrers(project: string, start: string, end: string): Promise<AnalyticsReferrer[]> {
+  const qs = new URLSearchParams({ start, end }).toString();
+  const data = await apiFetchJson(`/api/v1/analytics/referrers?${qs}`, project);
+  return normalizeList<AnalyticsReferrer>(data, "referrers");
+}
+
+export async function fetchAnalyticsSegments(project: string, start: string, end: string, dim: string): Promise<AnalyticsSegmentBucket[]> {
+  const qs = new URLSearchParams({ start, end, dim }).toString();
+  const data = await apiFetchJson(`/api/v1/analytics/segments?${qs}`, project);
+  return normalizeList<AnalyticsSegmentBucket>(data, "buckets");
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -180,6 +180,18 @@ export interface ApiSettings extends RawRecord {
   stacktrace_context_lines?: number;
 }
 
+export interface AnalyticsOverview {
+  pageviews: number;
+  sessions: number;
+  pages: number;
+  avgDurationMs: number;
+}
+
+export interface AnalyticsPage extends RawRecord { pathname: string; pageviews: number; sessions: number; }
+export interface AnalyticsBucket extends RawRecord { date: string; pageviews: number; sessions: number; }
+export interface AnalyticsReferrer extends RawRecord { host: string; pageviews: number; sessions: number; }
+export interface AnalyticsSegmentBucket extends RawRecord { value: string; pageviews: number; sessions: number; }
+
 export type IssueSort = "last_seen" | "first_seen" | "event_count";
 export type IssueStatus = "all" | "open" | "resolved" | "muted";
 
@@ -191,7 +203,7 @@ export interface AppState {
   projects: ApiProject[];
   currentProject: string;
   currentEnv: string;
-  currentRoute: "issues" | "releases" | "alerts" | "settings" | "logs";
+  currentRoute: "issues" | "releases" | "alerts" | "settings" | "logs" | "analytics";
   issues: ApiIssue[];
   issueQuery: string;
   issueSort: IssueSort;


### PR DESCRIPTION
## Summary

Completes the funnelbarn analytics subsystem on top of the schema that already landed (PR #28).

### What's included

**Collection** (`POST /api/v1/analytics/collect`)
- Public, wildcard CORS, no auth — works with `navigator.sendBeacon` from any origin
- Accepts `application/json` and `text/plain` content-types
- Project resolved from `X-BugBarn-Project` header or `?project=` query param
- Max 10 props, values truncated to 200 chars; no IP stored

**JS Snippet** (`GET /analytics.js?project=<slug>`)
- Self-hosted; server injects its own origin so users only need one `<script>` tag
- Session ID in `sessionStorage` (resets on browser close for accurate session counts)
- Page duration tracked via `visibilitychange`
- Custom props via `window.__bb_analytics = { props: {...} }`

**Query API** (authenticated, 366-day clamp)
- `GET /api/v1/analytics/overview` — pageviews, sessions, pages, avg duration
- `GET /api/v1/analytics/pages` — per-pathname breakdown
- `GET /api/v1/analytics/timeline?granularity=day|week|month` — zero-filled time series
- `GET /api/v1/analytics/referrers` — top referring hostnames
- `GET /api/v1/analytics/segments?dim=<key>` — breakdown by any props key

**UI Dashboard**
- "Analytics" tab in nav, route `#/analytics`
- Date range presets: 7d, 30d (default), 90d
- Overview stat cards
- SVG timeline chart (pageviews + sessions lines)
- Top pages, referrers, and segment tables
- Empty state with snippet install instructions

Closes #23 #24 #25 #26 #27