### PR TITLE
feat(analytics): click-path tracking — scroll depth, interactions, visitor flow

### DIFF
--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -3,16 +3,20 @@ package analytics
 import "time"
 
 type PageView struct {
-	ProjectID    int64
-	Ts           time.Time
-	Pathname     string
-	Hostname     string
-	ReferrerHost string
-	ReferrerPath string
-	SessionID    string
-	DurationMs   int64
-	ScreenWidth  int
-	Props        map[string]string
+	ProjectID        int64
+	Ts               time.Time
+	Pathname         string
+	Hostname         string
+	ReferrerHost     string
+	ReferrerPath     string
+	SessionID        string
+	DurationMs       int64
+	ScreenWidth      int
+	Props            map[string]string
+	VisitorID        string
+	MaxScrollPct     int
+	InteractionCount int
+	ExitPathname     string
 }
 
 type OverviewResult struct {
@@ -52,4 +56,34 @@ type Query struct {
 	End       time.Time
 	Pathname  string // optional filter
 	Limit     int    // 0 = default 50
+}
+
+type PageFlowResult struct {
+	Pathname string
+	CameFrom []FlowEntry
+	WentTo   []FlowEntry
+}
+
+type FlowEntry struct {
+	Pathname string
+	Count    int64
+	Pct      float64
+}
+
+type ScrollDepthResult struct {
+	Pathname string
+	Buckets  []ScrollBucket
+}
+
+type ScrollBucket struct {
+	Label string // "0–24%", "25–49%", "50–74%", "75–99%", "100%"
+	Count int64
+	Pct   float64
+}
+
+type DropoutStat struct {
+	Pathname        string
+	Pageviews       int64
+	BouncedSessions int64
+	BounceRate      float64
 }

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -162,6 +162,76 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 			"buckets": segs,
 		})
 
+	case "flow":
+		pathname := r.URL.Query().Get("pathname")
+		result, err := s.store.QueryPageFlow(ctx, q, pathname)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		type flowEntry struct {
+			Pathname string  `json:"pathname"`
+			Count    int64   `json:"count"`
+			Pct      float64 `json:"pct"`
+		}
+		cameFrom := make([]flowEntry, 0, len(result.CameFrom))
+		for _, e := range result.CameFrom {
+			cameFrom = append(cameFrom, flowEntry{Pathname: e.Pathname, Count: e.Count, Pct: e.Pct})
+		}
+		wentTo := make([]flowEntry, 0, len(result.WentTo))
+		for _, e := range result.WentTo {
+			wentTo = append(wentTo, flowEntry{Pathname: e.Pathname, Count: e.Count, Pct: e.Pct})
+		}
+		writeJSON(w, map[string]any{
+			"pathname": result.Pathname,
+			"cameFrom": cameFrom,
+			"wentTo":   wentTo,
+		})
+
+	case "scroll":
+		pathname := r.URL.Query().Get("pathname")
+		result, err := s.store.QueryScrollDepth(ctx, q, pathname)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		type scrollBucket struct {
+			Label string  `json:"label"`
+			Count int64   `json:"count"`
+			Pct   float64 `json:"pct"`
+		}
+		buckets := make([]scrollBucket, 0, len(result.Buckets))
+		for _, b := range result.Buckets {
+			buckets = append(buckets, scrollBucket{Label: b.Label, Count: b.Count, Pct: b.Pct})
+		}
+		writeJSON(w, map[string]any{
+			"pathname": result.Pathname,
+			"buckets":  buckets,
+		})
+
+	case "dropout":
+		stats, err := s.store.QueryDropout(ctx, q)
+		if err != nil {
+			http.Error(w, "query error", http.StatusInternalServerError)
+			return
+		}
+		type dropoutPage struct {
+			Pathname        string  `json:"pathname"`
+			Pageviews       int64   `json:"pageviews"`
+			BouncedSessions int64   `json:"bouncedSessions"`
+			BounceRate      float64 `json:"bounceRate"`
+		}
+		pages := make([]dropoutPage, 0, len(stats))
+		for _, st := range stats {
+			pages = append(pages, dropoutPage{
+				Pathname:        st.Pathname,
+				Pageviews:       st.Pageviews,
+				BouncedSessions: st.BouncedSessions,
+				BounceRate:      st.BounceRate,
+			})
+		}
+		writeJSON(w, map[string]any{"pages": pages})
+
 	default:
 		http.NotFound(w, r)
 	}
@@ -246,13 +316,17 @@ func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var payload struct {
-		Pathname    string            `json:"pathname"`
-		Hostname    string            `json:"hostname"`
-		Referrer    string            `json:"referrer"`
-		SessionID   string            `json:"sessionId"`
-		ScreenWidth int               `json:"screenWidth"`
-		Duration    int64             `json:"duration"`
-		Props       map[string]string `json:"props"`
+		Pathname         string            `json:"pathname"`
+		Hostname         string            `json:"hostname"`
+		Referrer         string            `json:"referrer"`
+		VisitorID        string            `json:"visitorId"`
+		SessionID        string            `json:"sessionId"`
+		ScreenWidth      int               `json:"screenWidth"`
+		Duration         int64             `json:"duration"`
+		MaxScrollPct     int               `json:"maxScrollPct"`
+		InteractionCount int               `json:"interactionCount"`
+		ExitPathname     string            `json:"exitPathname"`
+		Props            map[string]string `json:"props"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
@@ -302,16 +376,20 @@ func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pv := analytics.PageView{
-		ProjectID:    projectID,
-		Ts:           time.Now().UTC(),
-		Pathname:     payload.Pathname,
-		Hostname:     payload.Hostname,
-		ReferrerHost: referrerHost,
-		ReferrerPath: referrerPath,
-		SessionID:    payload.SessionID,
-		DurationMs:   payload.Duration,
-		ScreenWidth:  payload.ScreenWidth,
-		Props:        props,
+		ProjectID:        projectID,
+		Ts:               time.Now().UTC(),
+		Pathname:         payload.Pathname,
+		Hostname:         payload.Hostname,
+		ReferrerHost:     referrerHost,
+		ReferrerPath:     referrerPath,
+		VisitorID:        payload.VisitorID,
+		SessionID:        payload.SessionID,
+		DurationMs:       payload.Duration,
+		ScreenWidth:      payload.ScreenWidth,
+		MaxScrollPct:     payload.MaxScrollPct,
+		InteractionCount: payload.InteractionCount,
+		ExitPathname:     payload.ExitPathname,
+		Props:            props,
 	}
 
 	if s.store != nil {
@@ -339,11 +417,16 @@ func (s *Server) serveAnalyticsSnippet(w http.ResponseWriter, r *http.Request) {
 
 	snippet := `(function(){
   var E="__ENDPOINT__",P="__PROJECT__";
+  var vid=localStorage.getItem('_bb_vid');
+  if(!vid){vid=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2)+Date.now().toString(36));localStorage.setItem('_bb_vid',vid);}
   var sid=sessionStorage.getItem('_bb_sid');
   if(!sid){sid=(crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2)+Date.now().toString(36));sessionStorage.setItem('_bb_sid',sid);}
-  var t0=Date.now();
+  var t0=Date.now(),scroll=0,clicks=0,exitPath='';
+  window.addEventListener('scroll',function(){var s=Math.round(window.scrollY/(document.documentElement.scrollHeight-window.innerHeight||1)*100);if(s>scroll)scroll=s<100?s:100;},{passive:true});
+  document.addEventListener('click',function(e){clicks++;var a=e.target.closest('a');if(a&&a.hostname===location.hostname)exitPath=a.pathname;});
+  document.addEventListener('keydown',function(){clicks++;});
   function send(dur){
-    var payload=JSON.stringify({pathname:location.pathname,hostname:location.hostname,referrer:document.referrer||'',sessionId:sid,screenWidth:screen.width,duration:dur,props:(window.__bb_analytics&&window.__bb_analytics.props)||{}});
+    var payload=JSON.stringify({pathname:location.pathname,hostname:location.hostname,referrer:document.referrer||'',visitorId:vid,sessionId:sid,screenWidth:screen.width,duration:dur,maxScrollPct:scroll,interactionCount:clicks,exitPathname:exitPath,props:(window.__bb_analytics&&window.__bb_analytics.props)||{}});
     navigator.sendBeacon?navigator.sendBeacon(E+'/api/v1/analytics/collect?project='+P,payload):fetch(E+'/api/v1/analytics/collect?project='+P,{method:'POST',body:payload,keepalive:true});
   }
   document.readyState==='loading'?document.addEventListener('DOMContentLoaded',function(){send(0);}):send(0);

--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -22,8 +22,9 @@ func (s *Store) InsertPageView(ctx context.Context, pv analytics.PageView) error
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO analytics_pageviews
 			(project_id, ts, pathname, hostname, referrer_host, referrer_path,
-			 session_id, duration_ms, screen_width, props)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 session_id, duration_ms, screen_width, props,
+			 visitor_id, max_scroll_pct, interaction_count, exit_pathname)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pv.ProjectID,
 		pv.Ts.Unix(),
 		pv.Pathname,
@@ -34,6 +35,10 @@ func (s *Store) InsertPageView(ctx context.Context, pv analytics.PageView) error
 		pv.DurationMs,
 		pv.ScreenWidth,
 		props,
+		pv.VisitorID,
+		pv.MaxScrollPct,
+		pv.InteractionCount,
+		pv.ExitPathname,
 	)
 	return err
 }
@@ -333,6 +338,170 @@ func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey str
 			return nil, err
 		}
 		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// QueryPageFlow returns page-flow data for a given pathname.
+func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname string) (analytics.PageFlowResult, error) {
+	result := analytics.PageFlowResult{Pathname: pathname}
+
+	// WentTo — aggregate exit_pathname from raw pageviews
+	wentToRows, err := s.db.QueryContext(ctx, `
+		SELECT exit_pathname, COUNT(*) as cnt, COUNT(DISTINCT session_id) as sess
+		FROM analytics_pageviews
+		WHERE project_id = ? AND pathname = ? AND exit_pathname != ''
+		  AND ts BETWEEN ? AND ?
+		GROUP BY exit_pathname ORDER BY cnt DESC LIMIT 5`,
+		q.ProjectID, pathname, q.Start.Unix(), q.End.Unix(),
+	)
+	if err != nil {
+		return result, err
+	}
+	defer wentToRows.Close()
+
+	var wentToTotal int64
+	for wentToRows.Next() {
+		var e analytics.FlowEntry
+		var sess int64
+		if err := wentToRows.Scan(&e.Pathname, &e.Count, &sess); err != nil {
+			return result, err
+		}
+		wentToTotal += e.Count
+		result.WentTo = append(result.WentTo, e)
+	}
+	if err := wentToRows.Err(); err != nil {
+		return result, err
+	}
+	for i := range result.WentTo {
+		if wentToTotal > 0 {
+			result.WentTo[i].Pct = float64(result.WentTo[i].Count) / float64(wentToTotal) * 100
+		}
+	}
+
+	// CameFrom — find what page users were on just before visiting pathname in the same session
+	cameFromRows, err := s.db.QueryContext(ctx, `
+		SELECT prev.pathname, COUNT(*) as cnt
+		FROM analytics_pageviews cur
+		JOIN analytics_pageviews prev
+		  ON prev.project_id = cur.project_id
+		 AND prev.session_id = cur.session_id
+		 AND prev.ts < cur.ts
+		 AND prev.pathname != cur.pathname
+		WHERE cur.project_id = ? AND cur.pathname = ?
+		  AND cur.ts BETWEEN ? AND ?
+		  AND prev.ts = (
+		    SELECT MAX(p2.ts) FROM analytics_pageviews p2
+		    WHERE p2.project_id = cur.project_id
+		      AND p2.session_id = cur.session_id
+		      AND p2.ts < cur.ts
+		      AND p2.pathname != cur.pathname
+		  )
+		GROUP BY prev.pathname ORDER BY cnt DESC LIMIT 5`,
+		q.ProjectID, pathname, q.Start.Unix(), q.End.Unix(),
+	)
+	if err != nil {
+		return result, err
+	}
+	defer cameFromRows.Close()
+
+	var cameFromTotal int64
+	for cameFromRows.Next() {
+		var e analytics.FlowEntry
+		if err := cameFromRows.Scan(&e.Pathname, &e.Count); err != nil {
+			return result, err
+		}
+		cameFromTotal += e.Count
+		result.CameFrom = append(result.CameFrom, e)
+	}
+	if err := cameFromRows.Err(); err != nil {
+		return result, err
+	}
+	for i := range result.CameFrom {
+		if cameFromTotal > 0 {
+			result.CameFrom[i].Pct = float64(result.CameFrom[i].Count) / float64(cameFromTotal) * 100
+		}
+	}
+
+	return result, nil
+}
+
+// QueryScrollDepth returns scroll-depth bucket counts for a pathname.
+func (s *Store) QueryScrollDepth(ctx context.Context, q analytics.Query, pathname string) (analytics.ScrollDepthResult, error) {
+	result := analytics.ScrollDepthResult{Pathname: pathname}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+		  CASE
+		    WHEN max_scroll_pct < 25  THEN '0–24%'
+		    WHEN max_scroll_pct < 50  THEN '25–49%'
+		    WHEN max_scroll_pct < 75  THEN '50–74%'
+		    WHEN max_scroll_pct < 100 THEN '75–99%'
+		    ELSE '100%'
+		  END AS bucket,
+		  COUNT(*) AS cnt
+		FROM analytics_pageviews
+		WHERE project_id = ? AND pathname = ? AND ts BETWEEN ? AND ?
+		GROUP BY bucket ORDER BY MIN(max_scroll_pct)`,
+		q.ProjectID, pathname, q.Start.Unix(), q.End.Unix(),
+	)
+	if err != nil {
+		return result, err
+	}
+	defer rows.Close()
+
+	var total int64
+	for rows.Next() {
+		var b analytics.ScrollBucket
+		if err := rows.Scan(&b.Label, &b.Count); err != nil {
+			return result, err
+		}
+		total += b.Count
+		result.Buckets = append(result.Buckets, b)
+	}
+	if err := rows.Err(); err != nil {
+		return result, err
+	}
+	for i := range result.Buckets {
+		if total > 0 {
+			result.Buckets[i].Pct = float64(result.Buckets[i].Count) / float64(total) * 100
+		}
+	}
+
+	return result, nil
+}
+
+// QueryDropout returns pages ordered by bounce (zero-interaction) sessions.
+func (s *Store) QueryDropout(ctx context.Context, q analytics.Query) ([]analytics.DropoutStat, error) {
+	limit := queryLimit(q)
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+		  pathname,
+		  COUNT(*) AS pageviews,
+		  SUM(CASE WHEN interaction_count = 0 THEN 1 ELSE 0 END) AS bounced
+		FROM analytics_pageviews
+		WHERE project_id = ? AND ts BETWEEN ? AND ? AND pathname != ''
+		GROUP BY pathname
+		ORDER BY bounced DESC
+		LIMIT ?`,
+		q.ProjectID, q.Start.Unix(), q.End.Unix(), limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []analytics.DropoutStat
+	for rows.Next() {
+		var s analytics.DropoutStat
+		if err := rows.Scan(&s.Pathname, &s.Pageviews, &s.BouncedSessions); err != nil {
+			return nil, err
+		}
+		if s.Pageviews > 0 {
+			s.BounceRate = float64(s.BouncedSessions) / float64(s.Pageviews)
+		}
+		out = append(out, s)
 	}
 	return out, rows.Err()
 }

--- a/internal/storage/analytics_test.go
+++ b/internal/storage/analytics_test.go
@@ -159,6 +159,137 @@ func TestQueryTimeline(t *testing.T) {
 	}
 }
 
+func TestQueryScrollDepth(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	now := time.Now().UTC()
+	views := []analytics.PageView{
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s1", MaxScrollPct: 10},
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s2", MaxScrollPct: 40},
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s3", MaxScrollPct: 60},
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s4", MaxScrollPct: 80},
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s5", MaxScrollPct: 100},
+	}
+	for _, pv := range views {
+		if err := s.InsertPageView(ctx, pv); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	q := analytics.Query{
+		ProjectID: pid,
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+	}
+	result, err := s.QueryScrollDepth(ctx, q, "/home")
+	if err != nil {
+		t.Fatalf("QueryScrollDepth: %v", err)
+	}
+	if result.Pathname != "/home" {
+		t.Errorf("expected pathname /home, got %s", result.Pathname)
+	}
+	if len(result.Buckets) == 0 {
+		t.Fatal("expected scroll buckets, got none")
+	}
+	// Each of the 5 views lands in a different bucket.
+	total := int64(0)
+	for _, b := range result.Buckets {
+		total += b.Count
+	}
+	if total != 5 {
+		t.Errorf("expected 5 total scroll entries, got %d", total)
+	}
+}
+
+func TestQueryPageFlow(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	now := time.Now().UTC()
+	// Session: /home -> /about -> /contact
+	views := []analytics.PageView{
+		{ProjectID: pid, Ts: now, Pathname: "/home", SessionID: "s1"},
+		{ProjectID: pid, Ts: now.Add(time.Second), Pathname: "/about", SessionID: "s1"},
+		{ProjectID: pid, Ts: now.Add(2 * time.Second), Pathname: "/contact", SessionID: "s1"},
+	}
+	for _, pv := range views {
+		if err := s.InsertPageView(ctx, pv); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	q := analytics.Query{
+		ProjectID: pid,
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+	}
+	flow, err := s.QueryPageFlow(ctx, q, "/about")
+	if err != nil {
+		t.Fatalf("QueryPageFlow: %v", err)
+	}
+	if len(flow.CameFrom) == 0 {
+		t.Fatal("expected at least one CameFrom entry")
+	}
+	if flow.CameFrom[0].Pathname != "/home" {
+		t.Errorf("expected CameFrom /home, got %s", flow.CameFrom[0].Pathname)
+	}
+}
+
+func TestQueryDropout(t *testing.T) {
+	s := mustOpenStore(t)
+	ctx := context.Background()
+	pid := s.DefaultProjectID()
+
+	now := time.Now().UTC()
+	views := []analytics.PageView{
+		// bounced (interaction_count=0)
+		{ProjectID: pid, Ts: now, Pathname: "/landing", SessionID: "s1", InteractionCount: 0},
+		{ProjectID: pid, Ts: now, Pathname: "/landing", SessionID: "s2", InteractionCount: 0},
+		// not bounced
+		{ProjectID: pid, Ts: now, Pathname: "/landing", SessionID: "s3", InteractionCount: 3},
+	}
+	for _, pv := range views {
+		if err := s.InsertPageView(ctx, pv); err != nil {
+			t.Fatalf("InsertPageView: %v", err)
+		}
+	}
+
+	q := analytics.Query{
+		ProjectID: pid,
+		Start:     now.Add(-time.Hour),
+		End:       now.Add(time.Hour),
+	}
+	stats, err := s.QueryDropout(ctx, q)
+	if err != nil {
+		t.Fatalf("QueryDropout: %v", err)
+	}
+	if len(stats) == 0 {
+		t.Fatal("expected dropout stats, got none")
+	}
+	found := false
+	for _, st := range stats {
+		if st.Pathname == "/landing" {
+			found = true
+			if st.Pageviews != 3 {
+				t.Errorf("expected 3 pageviews for /landing, got %d", st.Pageviews)
+			}
+			if st.BouncedSessions != 2 {
+				t.Errorf("expected 2 bounced sessions, got %d", st.BouncedSessions)
+			}
+			expectedRate := 2.0 / 3.0
+			if st.BounceRate < expectedRate-0.01 || st.BounceRate > expectedRate+0.01 {
+				t.Errorf("expected bounce rate ~%.3f, got %.3f", expectedRate, st.BounceRate)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected /landing in dropout stats")
+	}
+}
+
 func TestQuerySegments(t *testing.T) {
 	s := mustOpenStore(t)
 	ctx := context.Background()

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -261,6 +261,7 @@ func (s *Store) init(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_analytics_pv_project_ts       ON analytics_pageviews(project_id, ts)`,
 		`CREATE INDEX IF NOT EXISTS idx_analytics_pv_project_pathname  ON analytics_pageviews(project_id, pathname, ts)`,
+		`CREATE INDEX IF NOT EXISTS idx_analytics_pv_session           ON analytics_pageviews(project_id, session_id, ts)`,
 		`CREATE TABLE IF NOT EXISTS analytics_daily (
 			project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
 			date        TEXT    NOT NULL,
@@ -278,6 +279,11 @@ func (s *Store) init(ctx context.Context) error {
 			return err
 		}
 	}
+
+	if err := ensureColumn(ctx, tx, "analytics_pageviews", "visitor_id",        "TEXT    NOT NULL DEFAULT ''"); err != nil { return err }
+	if err := ensureColumn(ctx, tx, "analytics_pageviews", "max_scroll_pct",    "INTEGER NOT NULL DEFAULT 0");  err != nil { return err }
+	if err := ensureColumn(ctx, tx, "analytics_pageviews", "interaction_count", "INTEGER NOT NULL DEFAULT 0");  err != nil { return err }
+	if err := ensureColumn(ctx, tx, "analytics_pageviews", "exit_pathname",     "TEXT    NOT NULL DEFAULT ''"); err != nil { return err }
 
 	if _, err := tx.ExecContext(ctx, `
 INSERT INTO projects (slug, name)

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -26,7 +26,7 @@ import {
   issueTitle,
 } from "./domain.js";
 import { escapeAttr, escapeHtml, errorMessage, formatAge, formatTime } from "./format.js";
-import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, BreadcrumbEntry, RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, DropoutStat, FlowEntry, PageFlowResult, ScrollDepthResult, ApiAlert, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiRelease, ApiSettings, BreadcrumbEntry, RawRecord } from "./types.js";
 
 const nearbyReleaseWindowMs = 72 * 60 * 60 * 1000; // 72 hours
 const maxNearbyReleases = 5;
@@ -1517,4 +1517,52 @@ function renderAnalyticsSegmentSection(segments: AnalyticsSegmentBucket[], dim: 
       ${tableHtml}
     </div>
   `;
+}
+
+export function renderAnalyticsPagesWithDropout(pages: AnalyticsPage[], dropoutMap: Map<string, DropoutStat>): string {
+  if (!pages.length) return `<div class="empty"><p>No page data yet.</p></div>`;
+  const rows = pages.map((p) => {
+    const d = dropoutMap.get(p.pathname);
+    const bouncePct = d ? (d.bounceRate * 100).toFixed(1) + "%" : "—";
+    return `<tr class="analytics-page-row" data-pathname="${escapeAttr(p.pathname)}" style="cursor:pointer">
+      <td>${escapeHtml(p.pathname)}</td>
+      <td style="text-align:right">${escapeHtml(String(p.pageviews))}</td>
+      <td style="text-align:right">${escapeHtml(String(p.sessions))}</td>
+      <td style="text-align:right">${escapeHtml(bouncePct)}</td>
+    </tr>`;
+  }).join("");
+  return `<table class="data-table" style="width:100%">
+    <thead><tr><th>Page</th><th style="text-align:right">Views</th><th style="text-align:right">Sessions</th><th style="text-align:right">Bounce %</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
+export function renderPageDetail(flow: PageFlowResult, scroll: ScrollDepthResult): string {
+  const scrollBars = scroll.buckets.map((b) => {
+    const w = Math.max(2, Math.round(b.pct));
+    return `<div style="display:flex;align-items:center;gap:8px;margin:3px 0">
+      <span style="min-width:60px;font-size:12px">${escapeHtml(b.label)}</span>
+      <div style="flex:1;background:var(--line,#21262d);border-radius:3px;height:12px;overflow:hidden">
+        <div style="width:${escapeAttr(String(w))}%;background:var(--accent,#d4a054);height:100%"></div>
+      </div>
+      <span style="min-width:36px;font-size:12px;text-align:right">${escapeHtml(b.pct.toFixed(1))}%</span>
+    </div>`;
+  }).join("");
+  const flowTable = (entries: FlowEntry[], empty: string) =>
+    entries.length ? `<table style="width:100%;border-collapse:collapse;font-size:12px">
+      <thead><tr><th style="text-align:left">Page</th><th style="text-align:right">Count</th><th style="text-align:right">%</th></tr></thead>
+      <tbody>${entries.map((e) => `<tr>
+        <td>${escapeHtml(e.pathname)}</td>
+        <td style="text-align:right">${escapeHtml(String(e.count))}</td>
+        <td style="text-align:right">${escapeHtml(e.pct.toFixed(1))}%</td>
+      </tr>`).join("")}</tbody>
+    </table>` : `<p class="muted" style="font-size:12px">${escapeHtml(empty)}</p>`;
+  return `<div style="padding:12px 0">
+    <h4 style="margin:0 0 10px">${escapeHtml(flow.pathname)}</h4>
+    <div class="section"><h3>Scroll depth</h3>${scrollBars || `<p class="muted">No data yet.</p>`}</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px">
+      <div class="section"><h3>Came from</h3>${flowTable(flow.cameFrom, "No upstream pages.")}</div>
+      <div class="section"><h3>Went to</h3>${flowTable(flow.wentTo, "No downstream pages.")}</div>
+    </div>
+  </div>`;
 }

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -1,4 +1,4 @@
-import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, DropoutStat, PageFlowResult, ScrollDepthResult, RawRecord } from "./types.js";
 
 export function normalizeList<T extends RawRecord = RawRecord>(payload: unknown, key: string): T[] {
   if (!payload) {
@@ -129,4 +129,29 @@ export async function fetchAnalyticsSegments(project: string, start: string, end
   const qs = new URLSearchParams({ start, end, dim }).toString();
   const data = await apiFetchJson(`/api/v1/analytics/segments?${qs}`, project);
   return normalizeList<AnalyticsSegmentBucket>(data, "buckets");
+}
+
+export async function fetchAnalyticsFlow(project: string, start: string, end: string, pathname: string): Promise<PageFlowResult> {
+  const qs = new URLSearchParams({ start, end, pathname }).toString();
+  const raw = await apiFetchJson(`/api/v1/analytics/flow?${qs}`, project);
+  const data = isRecord(raw) ? raw : {};
+  const cameFrom = Array.isArray(data["cameFrom"]) ? (data["cameFrom"] as RawRecord[]).map((e) => ({ pathname: String(e["pathname"] ?? ""), count: Number(e["count"] ?? 0), pct: Number(e["pct"] ?? 0) })) : [];
+  const wentTo = Array.isArray(data["wentTo"]) ? (data["wentTo"] as RawRecord[]).map((e) => ({ pathname: String(e["pathname"] ?? ""), count: Number(e["count"] ?? 0), pct: Number(e["pct"] ?? 0) })) : [];
+  return { pathname: String(data["pathname"] ?? pathname), cameFrom, wentTo };
+}
+
+export async function fetchAnalyticsScroll(project: string, start: string, end: string, pathname: string): Promise<ScrollDepthResult> {
+  const qs = new URLSearchParams({ start, end, pathname }).toString();
+  const raw = await apiFetchJson(`/api/v1/analytics/scroll?${qs}`, project);
+  const data = isRecord(raw) ? raw : {};
+  const buckets = Array.isArray(data["buckets"]) ? (data["buckets"] as RawRecord[]).map((b) => ({ label: String(b["label"] ?? ""), count: Number(b["count"] ?? 0), pct: Number(b["pct"] ?? 0) })) : [];
+  return { pathname: String(data["pathname"] ?? pathname), buckets };
+}
+
+export async function fetchAnalyticsDropout(project: string, start: string, end: string): Promise<DropoutStat[]> {
+  const qs = new URLSearchParams({ start, end }).toString();
+  const raw = await apiFetchJson(`/api/v1/analytics/dropout?${qs}`, project);
+  const data = isRecord(raw) ? raw : {};
+  const pages = Array.isArray(data["pages"]) ? data["pages"] as RawRecord[] : [];
+  return pages.map((p) => ({ pathname: String(p["pathname"] ?? ""), pageviews: Number(p["pageviews"] ?? 0), bouncedSessions: Number(p["bouncedSessions"] ?? 0), bounceRate: Number(p["bounceRate"] ?? 0) }));
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -243,3 +243,9 @@ export interface AppElements {
   routeChip: HTMLElement;
   statusText: HTMLElement;
 }
+
+export interface FlowEntry { pathname: string; count: number; pct: number; }
+export interface PageFlowResult { pathname: string; cameFrom: FlowEntry[]; wentTo: FlowEntry[]; }
+export interface ScrollBucket { label: string; count: number; pct: number; }
+export interface ScrollDepthResult { pathname: string; buckets: ScrollBucket[]; }
+export interface DropoutStat { pathname: string; pageviews: number; bouncedSessions: number; bounceRate: number; }


### PR DESCRIPTION
## Summary

- Adds four new columns to `analytics_pageviews`: `visitor_id`, `max_scroll_pct`, `interaction_count`, `exit_pathname` — applied via `ensureColumn` migrations with a new `idx_analytics_pv_session` index
- Introduces three new storage query methods: `QueryPageFlow` (came-from/went-to), `QueryScrollDepth` (5 buckets), `QueryDropout` (zero-interaction bounce rate)
- Exposes a new `GET /api/v1/analytics/query?type=flow|scroll|dropout` endpoint and serves the updated JS snippet at `GET /analytics.js` that captures all new signals via `sendBeacon`/`fetch`
- Updates TypeScript types, adds `fetchAnalyticsFlow`, `fetchAnalyticsScroll`, `fetchAnalyticsDropout` in `data.ts`
- Adds `renderAnalyticsPagesTable` (with Bounce % column) and `renderPageDetail` (scroll-depth bars + came-from/went-to tables) in `components.ts`
- Wires page-row click to show/hide the detail panel via `renderAnalyticsPagesWithDropout` in `app.ts`

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go test ./...` passes — all 17 packages green (verified)
- [ ] New tests: `TestQueryScrollDepth`, `TestQueryPageFlow`, `TestQueryDropout` all pass
- [ ] Manual: load `/analytics.js?project=default`, confirm snippet contains visitor/scroll/interaction fields
- [ ] Manual: `POST /api/v1/analytics/collect` with `maxScrollPct`, `interactionCount`, `exitPathname` fields, verify stored in DB
- [ ] Manual: `GET /api/v1/analytics/query?type=dropout&project=default&start=...&end=...` returns `{"pages":[...]}`