### PR TITLE
feat(analytics): add FunnelBarn conversion tracking

### DIFF
--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -1,6 +1,14 @@
 ---
-// Analytics placeholder — add your analytics script here.
-// This component is rendered in <head> on every page.
-// Example: drop in a Plausible or Fathom snippet when ready.
+// FunnelBarn analytics — pageviews tracked automatically, CTA clicks tracked via data-track
 ---
-<!-- analytics -->
+<script
+  src="https://funnelbarn.wiebe.xyz/sdk.js"
+  data-api-key="64e5dfefab5b21cd111c9bad3ba8a4d5face2384b45c2722a5aa7391bb0de3d5"
+  defer
+></script>
+<script>
+  document.addEventListener('click', (e) => {
+    const el = (e.target as Element).closest('[data-track]') as HTMLElement | null;
+    if (el) window.funnelbarn?.track(el.dataset.track!);
+  });
+</script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -4,7 +4,7 @@
 <section class="max-w-5xl mx-auto px-6 pt-24 pb-20">
   <div class="max-w-2xl">
     <div class="inline-flex items-center gap-2 text-xs font-mono px-3 py-1 rounded-full mb-8" style="background-color: #1e1608; color: #b5843a; border: 1px solid #2d1f06;">
-      v0.1 — open source · MIT license
+      Open source · Single binary · SQLite
     </div>
     <h1 class="text-4xl sm:text-5xl font-bold tracking-tight leading-tight mb-5" style="color: #e6edf3;">
       Error tracking that lives on<br class="hidden sm:block" /> your infrastructure
@@ -14,11 +14,13 @@
     </p>
     <div class="flex flex-wrap gap-3 mb-8">
       <a href="#install"
+         data-track="install_click"
          class="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium transition-colors"
          style="background-color: #b5843a; color: #0f1117;">
         Install in 30 seconds
       </a>
       <a href="https://github.com/webwiebe/bugbarn"
+         data-track="github_click"
          target="_blank" rel="noopener"
          class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium transition-colors"
          style="background-color: #161b22; color: #e6edf3; border: 1px solid #21262d;">
@@ -29,7 +31,7 @@
       </a>
     </div>
     <p class="text-xs font-mono" style="color: #484f58;">
-      Open source &nbsp;·&nbsp; MIT license &nbsp;·&nbsp; SQLite &nbsp;·&nbsp; Single binary
+      Open source &nbsp;·&nbsp; SQLite &nbsp;·&nbsp; Single binary
     </p>
   </div>
 </section>


### PR DESCRIPTION
Supersedes #21 (rebased cleanly on current main).

- Loads FunnelBarn SDK via `Analytics.astro` (already in `<head>` on every page)
- Tracks `install_click` and `github_click` on hero CTAs via `data-track` delegation
- Pageviews tracked automatically by the SDK

Project: **BugBarn** on funnelbarn.wiebe.xyz

## Test plan
- [ ] Visit bugbarn.webwiebe.nl — check funnelbarn.wiebe.xyz live event feed shows `pageview`
- [ ] Click "Install in 30 seconds" — check `install_click` fires
- [ ] Click "View on GitHub" — check `github_click` fires