### PR TITLE
feat: wire BugBarn web frontend to FunnelBarn analytics (opt-in)

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -135,6 +135,7 @@ func run() error {
 	if len(cfg.trustedProxies) > 0 {
 		apiServer.SetTrustedProxies(cfg.trustedProxies)
 	}
+	apiServer.SetFunnelBarnConfig(cfg.funnelBarnEndpoint, cfg.funnelBarnAPIKey)
 	if cfg.maxSourceMapBytes > 0 {
 		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
 	}
@@ -188,8 +189,10 @@ type config struct {
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
-	digest                    digest.Config
-	analyticsRetentionDays   int
+	digest                  digest.Config
+	analyticsRetentionDays  int
+	funnelBarnEndpoint      string // BUGBARN_FUNNELBARN_ENDPOINT — e.g. https://funnelbarn.example.com
+	funnelBarnAPIKey        string // BUGBARN_FUNNELBARN_API_KEY
 }
 
 func loadConfig() config {
@@ -210,6 +213,8 @@ func loadConfig() config {
 		publicURL:           os.Getenv("BUGBARN_PUBLIC_URL"),
 		selfEndpoint:        os.Getenv("BUGBARN_SELF_ENDPOINT"),
 		selfAPIKey:          os.Getenv("BUGBARN_SELF_API_KEY"),
+		funnelBarnEndpoint:  os.Getenv("BUGBARN_FUNNELBARN_ENDPOINT"),
+		funnelBarnAPIKey:    os.Getenv("BUGBARN_FUNNELBARN_API_KEY"),
 	}
 
 	if raw := os.Getenv("BUGBARN_ALLOWED_ORIGINS"); raw != "" {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,0 +1,32 @@
+package api
+
+import "net/http"
+
+// serveRuntimeConfig returns public (non-secret) configuration that the web
+// frontend needs at startup. This endpoint requires no authentication so the
+// frontend can fetch it before the user logs in.
+//
+// FunnelBarn analytics tracking is opt-in: the funnelbarn block is only
+// enabled when BUGBARN_FUNNELBARN_ENDPOINT is set in the server's environment.
+func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+	type funnelBarnConfig struct {
+		Enabled  bool   `json:"enabled"`
+		Endpoint string `json:"endpoint,omitempty"`
+		APIKey   string `json:"apiKey,omitempty"`
+	}
+
+	type runtimeConfig struct {
+		FunnelBarn funnelBarnConfig `json:"funnelbarn"`
+	}
+
+	cfg := runtimeConfig{}
+	if s.funnelBarnEndpoint != "" {
+		cfg.FunnelBarn = funnelBarnConfig{
+			Enabled:  true,
+			Endpoint: s.funnelBarnEndpoint,
+			APIKey:   s.funnelBarnAPIKey,
+		}
+	}
+
+	writeJSON(w, cfg)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,17 +16,19 @@ import (
 const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
 
 type Server struct {
-	ingestHandler     *ingest.Handler
-	store             *storage.Store
-	service           *service.Service
-	users             *auth.UserAuthenticator
-	sessions          *auth.SessionManager
-	allowedOrigins    []string // parsed from BUGBARN_ALLOWED_ORIGINS
-	trustedProxies    []*net.IPNet
-	logHub            *logstream.Hub
-	sessionSecret     string
-	publicURL         string
-	maxSourceMapBytes int64
+	ingestHandler      *ingest.Handler
+	store              *storage.Store
+	service            *service.Service
+	users              *auth.UserAuthenticator
+	sessions           *auth.SessionManager
+	allowedOrigins     []string // parsed from BUGBARN_ALLOWED_ORIGINS
+	trustedProxies     []*net.IPNet
+	logHub             *logstream.Hub
+	sessionSecret      string
+	publicURL          string
+	maxSourceMapBytes  int64
+	funnelBarnEndpoint string
+	funnelBarnAPIKey   string
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -52,6 +54,13 @@ func (s *Server) SetLogHub(h *logstream.Hub) {
 func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 	s.sessionSecret = sessionSecret
 	s.publicURL = publicURL
+}
+
+// SetFunnelBarnConfig wires optional FunnelBarn analytics tracking config.
+// If endpoint is empty, the runtime-config endpoint returns enabled=false.
+func (s *Server) SetFunnelBarnConfig(endpoint, apiKey string) {
+	s.funnelBarnEndpoint = endpoint
+	s.funnelBarnAPIKey = apiKey
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
@@ -163,6 +172,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/api/v1/health" && r.Method == http.MethodGet:
 		writeJSON(w, map[string]any{"status": "ok"})
+		return
+	case r.URL.Path == "/api/v1/runtime-config" && r.Method == http.MethodGet:
+		s.serveRuntimeConfig(w, r)
 		return
 	case r.URL.Path == "/api/v1/login" && r.Method == http.MethodPost:
 		s.login(w, r)

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -228,6 +228,10 @@ window.addEventListener("beforeunload", stopLiveStream);
 void start();
 
 async function start(): Promise<void> {
+  // Kick off FunnelBarn analytics initialisation in parallel — it must not
+  // block the rest of the app startup.
+  void initFunnelBarn();
+
   await loadSession();
   updateBBMenuUser();
   route();
@@ -238,6 +242,76 @@ async function start(): Promise<void> {
   const envLoad = state.currentProject !== "__all" ? loadEnvironments() : (renderEnvSwitcher([]), Promise.resolve());
   await Promise.all([loadProjects(), envLoad, refreshAll()]);
   initInstallPrompt();
+}
+
+// ---------------------------------------------------------------------------
+// FunnelBarn analytics (opt-in)
+//
+// The Go server exposes GET /api/v1/runtime-config. When
+// BUGBARN_FUNNELBARN_ENDPOINT is set, it returns:
+//   { "funnelbarn": { "enabled": true, "endpoint": "...", "apiKey": "..." } }
+//
+// We dynamically inject the FunnelBarn JS SDK from:
+//   {endpoint}/sdk/funnelbarn.js
+// (FunnelBarn serves its pre-built IIFE bundle at that path via the web
+// container's nginx static file server — see web/public/ in the FunnelBarn
+// repo, or build sdks/js and place the output there.)
+//
+// After the script loads, window.funnelbarn is available and we call:
+//   window.funnelbarn.init({ apiKey, endpoint })
+//   window.funnelbarn.page()
+// ---------------------------------------------------------------------------
+
+// TypeScript type declaration for the globally-injected FunnelBarn SDK.
+declare global {
+  interface Window {
+    funnelbarn?: {
+      init(options: { apiKey: string; endpoint: string }): void;
+      page(): void;
+      track(name: string, properties?: Record<string, unknown>): void;
+    };
+  }
+}
+
+async function initFunnelBarn(): Promise<void> {
+  let cfg: { funnelbarn?: { enabled: boolean; endpoint?: string; apiKey?: string } };
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return;
+    cfg = await res.json() as typeof cfg;
+  } catch {
+    // Non-critical — silently abort if the endpoint is unreachable.
+    return;
+  }
+
+  const fb = cfg?.funnelbarn;
+  if (!fb?.enabled || !fb.endpoint || !fb.apiKey) return;
+
+  const { endpoint, apiKey } = fb;
+
+  // Inject the SDK script tag. FunnelBarn serves the pre-built IIFE bundle at
+  // {endpoint}/sdk/funnelbarn.js from the web container's nginx static server.
+  await new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = `${endpoint}/sdk/funnelbarn.js`;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`funnelbarn: failed to load SDK from ${script.src}`));
+    document.head.appendChild(script);
+  }).catch(() => {
+    // SDK load failed — abort silently. This is non-critical.
+    return;
+  });
+
+  if (typeof window.funnelbarn?.init !== "function") return;
+
+  window.funnelbarn.init({ apiKey, endpoint });
+  window.funnelbarn.page();
+
+  // Track subsequent hash-based route changes as additional page views.
+  window.addEventListener("hashchange", () => {
+    window.funnelbarn?.page();
+  });
 }
 
 // PWA install prompt — shown once until dismissed, never shown again after


### PR DESCRIPTION
Supersedes #20 — rebased on current main, conflicts resolved.

Adds opt-in FunnelBarn analytics to BugBarn's web frontend:
- `BUGBARN_FUNNELBARN_ENDPOINT` + `BUGBARN_FUNNELBARN_API_KEY` env vars
- `GET /api/v1/runtime-config` public endpoint returns tracking config
- Frontend dynamically injects SDK and tracks page views on startup + route changes
- Entirely opt-in: no network calls unless operator configures the endpoint