### PR TITLE
feat: bump SDKs to v1.0.0 and add npm/PyPI publish CI

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -363,3 +363,52 @@ jobs:
             git commit -m "Update formula to ${VERSION}"
             git push
           fi
+
+  # ---------------------------------------------------------------------------
+  # TypeScript SDK — publish to npm
+  # ---------------------------------------------------------------------------
+  publish-npm:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/typescript
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Python SDK — publish to PyPI
+  # ---------------------------------------------------------------------------
+  publish-pypi:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Build
+        run: python -m build
+      - name: Test before publish
+        run: pip install -e ".[dev]" && python -m pytest tests/ -v
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/sdks/php/PUBLISHING.md
+++ b/sdks/php/PUBLISHING.md
@@ -1,0 +1,25 @@
+# Publishing to Packagist
+
+Packagist syncs automatically from GitHub tags — no CI job is needed. Follow these steps once to register the package.
+
+## One-time submission
+
+1. Go to [packagist.org/packages/submit](https://packagist.org/packages/submit) and log in.
+2. Enter the GitHub repository URL (e.g. `https://github.com/webwiebe/bugbarn`) and click **Check**.
+3. Confirm the package name (`bugbarn/bugbarn-php`) and click **Submit**.
+
+## GitHub webhook (auto-update on push)
+
+After submission, Packagist shows a webhook URL. Add it to the GitHub repo so Packagist picks up new tags immediately:
+
+1. In the GitHub repo go to **Settings → Webhooks → Add webhook**.
+2. Set **Payload URL** to the URL shown on your Packagist package page (format: `https://packagist.org/api/github?username=<your-packagist-username>`).
+3. Set **Content type** to `application/json`.
+4. Under **Which events**, choose **Just the push event**.
+5. Click **Add webhook**.
+
+From this point on, every `git push --tags` triggers Packagist to pull the latest release automatically.
+
+## Required secrets
+
+None — Packagist needs no CI secrets. Tags pushed by the existing `binary-release.yml` workflow will trigger the webhook.

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "bugbarn/bugbarn-php",
   "description": "BugBarn PHP SDK — lightweight error reporting for self-hosted BugBarn instances",
+  "version": "1.0.0",
   "type": "library",
   "license": "MIT",
   "require": {

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bugbarn-python"
-version = "0.1.0"
+version = "1.0.0"
 description = "BugBarn Python SDK skeleton"
 requires-python = ">=3.9"
 dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugbarn/typescript",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Supersedes #19 — rebased cleanly on current main.

- Bump TypeScript, Python, PHP SDKs to v1.0.0
- Add npm publish CI job for `@bugbarn/typescript`
- Add PyPI publish CI job for `bugbarn-python`