### PR TITLE
fix: log stream empty state & project badge

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1638,6 +1638,8 @@ function connectLogSSE(): void {
       state.logs = [entry, ...state.logs].slice(0, 500);
       const list = document.getElementById("log-list");
       if (list) {
+        const empty = list.querySelector(".empty");
+        if (empty) empty.remove();
         const row = document.createElement("div");
         row.innerHTML = renderLogRow(entry);
         const newRow = row.firstElementChild as HTMLElement | null;

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -1258,7 +1258,7 @@ export function renderLogRow(entry: ApiLogEntry): string {
   const dataExpanded = hasData
     ? `<div class="log-data-expanded"><pre>${escapeHtml(JSON.stringify(entry.data, null, 2))}</pre></div>`
     : "";
-  const projectBadge = entry.project_slug ? `<span class="chip" style="font-size:0.65rem;opacity:0.7;margin-left:0.25rem">${escapeHtml(entry.project_slug)}</span>` : "";
+  const projectBadge = entry.project_slug ? `<span class="log-project-badge">${escapeHtml(entry.project_slug)}</span>` : "";
   return `
     <div class="log-row log-row-${escapeAttr(entry.level)}" data-log-id="${escapeAttr(String(entry.id))}">
       <span class="log-time">${escapeHtml(formatTime(entry.received_at))}</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1379,6 +1379,16 @@ button:disabled {
   white-space: nowrap;
 }
 
+.log-project-badge {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: #1a2e3a;
+  color: #7eb8db;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .log-data {
   color: var(--muted);
   font-size: 11px;


### PR DESCRIPTION
## Summary
- **Fix stale empty state**: the "No log entries yet" placeholder now gets removed when the first SSE log entry arrives, instead of staying visible below the live log lines.
- **Project badge**: each log line shows a teal badge with the project name so you can tell at a glance which project it belongs to.

## Test plan
- [ ] Open Logs view with no logs → empty state shows
- [ ] Wait for SSE logs to stream in → empty state disappears
- [ ] Verify each log row shows the project badge
- [ ] Clear logs → empty state reappears