### PR TITLE
feat: frontend self-reporting (dogfooding)

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -105,8 +105,9 @@ func run() error {
 	selfReporting := cfg.selfEndpoint != "" && cfg.selfAPIKey != ""
 	if selfReporting {
 		bb.Init(bb.Options{
-			APIKey:   cfg.selfAPIKey,
-			Endpoint: cfg.selfEndpoint,
+			APIKey:      cfg.selfAPIKey,
+			Endpoint:    cfg.selfEndpoint,
+			ProjectSlug: cfg.selfProject,
 		})
 		log.Printf("self-reporting enabled → %s", cfg.selfEndpoint)
 	}
@@ -136,6 +137,9 @@ func run() error {
 		apiServer.SetTrustedProxies(cfg.trustedProxies)
 	}
 	apiServer.SetFunnelBarnConfig(cfg.funnelBarnEndpoint, cfg.funnelBarnAPIKey)
+	if selfReporting {
+		apiServer.SetSelfReportingConfig(cfg.selfAPIKey, cfg.selfProject)
+	}
 	if cfg.maxSourceMapBytes > 0 {
 		apiServer.SetMaxSourceMapBytes(cfg.maxSourceMapBytes)
 	}
@@ -189,6 +193,7 @@ type config struct {
 	publicURL           string
 	selfEndpoint        string
 	selfAPIKey          string
+	selfProject         string
 	digest                  digest.Config
 	analyticsRetentionDays  int
 	funnelBarnEndpoint      string // BUGBARN_FUNNELBARN_ENDPOINT — e.g. https://funnelbarn.example.com
@@ -213,6 +218,7 @@ func loadConfig() config {
 		publicURL:           os.Getenv("BUGBARN_PUBLIC_URL"),
 		selfEndpoint:        os.Getenv("BUGBARN_SELF_ENDPOINT"),
 		selfAPIKey:          os.Getenv("BUGBARN_SELF_API_KEY"),
+		selfProject:         os.Getenv("BUGBARN_SELF_PROJECT"),
 		funnelBarnEndpoint:  os.Getenv("BUGBARN_FUNNELBARN_ENDPOINT"),
 		funnelBarnAPIKey:    os.Getenv("BUGBARN_FUNNELBARN_API_KEY"),
 	}

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -39,7 +39,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: bugbarn-secrets
-                  key: BUGBARN_API_KEY
+                  key: BUGBARN_SELF_API_KEY
+            - name: BUGBARN_SELF_PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SELF_PROJECT
             - name: BUGBARN_SPOOL_DIR
               value: /var/lib/bugbarn/spool
             - name: BUGBARN_DB_PATH

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -15,8 +15,15 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		APIKey   string `json:"apiKey,omitempty"`
 	}
 
+	type bugbarnSelfConfig struct {
+		Enabled bool   `json:"enabled"`
+		APIKey  string `json:"apiKey,omitempty"`
+		Project string `json:"project,omitempty"`
+	}
+
 	type runtimeConfig struct {
-		FunnelBarn funnelBarnConfig `json:"funnelbarn"`
+		FunnelBarn funnelBarnConfig  `json:"funnelbarn"`
+		BugBarn    bugbarnSelfConfig `json:"bugbarn"`
 	}
 
 	cfg := runtimeConfig{}
@@ -25,6 +32,13 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 			Enabled:  true,
 			Endpoint: s.funnelBarnEndpoint,
 			APIKey:   s.funnelBarnAPIKey,
+		}
+	}
+	if s.selfAPIKey != "" {
+		cfg.BugBarn = bugbarnSelfConfig{
+			Enabled: true,
+			APIKey:  s.selfAPIKey,
+			Project: s.selfProject,
 		}
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,8 @@ type Server struct {
 	maxSourceMapBytes  int64
 	funnelBarnEndpoint string
 	funnelBarnAPIKey   string
+	selfAPIKey         string
+	selfProject        string
 
 	loginLimiter sync.Map // map[string]*loginAttempt
 }
@@ -61,6 +63,13 @@ func (s *Server) SetSetupConfig(sessionSecret, publicURL string) {
 func (s *Server) SetFunnelBarnConfig(endpoint, apiKey string) {
 	s.funnelBarnEndpoint = endpoint
 	s.funnelBarnAPIKey = apiKey
+}
+
+// SetSelfReportingConfig exposes the ingest API key to the web frontend so it
+// can report its own errors back into BugBarn.
+func (s *Server) SetSelfReportingConfig(apiKey, project string) {
+	s.selfAPIKey = apiKey
+	s.selfProject = project
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -228,9 +228,8 @@ window.addEventListener("beforeunload", stopLiveStream);
 void start();
 
 async function start(): Promise<void> {
-  // Kick off FunnelBarn analytics initialisation in parallel — it must not
-  // block the rest of the app startup.
   void initFunnelBarn();
+  void initSelfReporting();
 
   await loadSession();
   updateBBMenuUser();
@@ -311,6 +310,82 @@ async function initFunnelBarn(): Promise<void> {
   // Track subsequent hash-based route changes as additional page views.
   window.addEventListener("hashchange", () => {
     window.funnelbarn?.page();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Self-reporting — dogfood BugBarn by capturing frontend errors into itself.
+// ---------------------------------------------------------------------------
+
+let selfReportApiKey = "";
+let selfReportProject = "";
+
+function sendErrorEnvelope(error: unknown): void {
+  if (!selfReportApiKey) return;
+  const err = error instanceof Error ? error : new Error(String(error));
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-bugbarn-api-key": selfReportApiKey,
+  };
+  if (selfReportProject) {
+    headers["x-bugbarn-project"] = selfReportProject;
+  }
+  const body = JSON.stringify({
+    timestamp: new Date().toISOString(),
+    severityText: "ERROR",
+    body: err.message,
+    exception: {
+      type: err.name || "Error",
+      message: err.message,
+      stacktrace: parseStack(err.stack),
+    },
+    attributes: {
+      url: location.href,
+      userAgent: navigator.userAgent,
+    },
+    sender: { sdk: { name: "bugbarn.web", version: "0.1.0" } },
+  });
+  fetch(apiUrl("/api/v1/events"), { method: "POST", headers, body, keepalive: true }).catch(() => {});
+}
+
+function parseStack(stack?: string): Array<{ file: string; line: number; column: number; function?: string }> | undefined {
+  if (!stack) return undefined;
+  const frames: Array<{ file: string; line: number; column: number; function?: string }> = [];
+  for (const raw of stack.split("\n").map((l) => l.trim()).slice(1)) {
+    const m = /^at (?:(.+?) )?\(?(.+?):(\d+):(\d+)\)?$/.exec(raw);
+    if (!m) continue;
+    const f: { file: string; line: number; column: number; function?: string } = {
+      file: m[2],
+      line: Number(m[3]),
+      column: Number(m[4]),
+    };
+    if (m[1]) f.function = m[1];
+    frames.push(f);
+  }
+  return frames.length > 0 ? frames : undefined;
+}
+
+async function initSelfReporting(): Promise<void> {
+  let cfg: { bugbarn?: { enabled: boolean; apiKey?: string; project?: string } };
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return;
+    cfg = await res.json() as typeof cfg;
+  } catch {
+    return;
+  }
+
+  const bb = cfg?.bugbarn;
+  if (!bb?.enabled || !bb.apiKey) return;
+
+  selfReportApiKey = bb.apiKey;
+  selfReportProject = bb.project ?? "";
+
+  window.addEventListener("error", (ev) => {
+    if (ev.error) sendErrorEnvelope(ev.error);
+  });
+  window.addEventListener("unhandledrejection", (ev) => {
+    sendErrorEnvelope(ev.reason);
   });
 }
 


### PR DESCRIPTION
## Summary
- **Backend**: Expose `bugbarn` block in `/api/v1/runtime-config` with the self-reporting API key and project slug when `BUGBARN_SELF_ENDPOINT` + `BUGBARN_SELF_API_KEY` are set. Also adds `BUGBARN_SELF_PROJECT` env var and passes `ProjectSlug` to the Go SDK init.
- **Frontend**: Lightweight browser error reporter that hooks `window.onerror` and `unhandledrejection`, then POSTs BugBarn envelopes to `/api/v1/events` with stack traces and page URL context. Initialised from runtime-config — zero additional config needed.

## Context
The Go backend was already dogfooding via the Go SDK (panics + dead-letters), but the web frontend had zero error capture — all 16+ try-catch blocks only showed errors to the user. This means any frontend JS errors were silently lost.

Also fixed during investigation: MinIO (S3 backup) was scaled to 0 replicas on layer7, causing Litestream replication failures → database locking → record dead-lettering. MinIO has been restored and credentials re-synced.

## Test plan
- [ ] Set `BUGBARN_SELF_ENDPOINT` and `BUGBARN_SELF_API_KEY` env vars
- [ ] Verify `/api/v1/runtime-config` returns `bugbarn.enabled: true`
- [ ] Trigger a JS error in the console → verify it appears as an issue in BugBarn
- [ ] Verify `window.onerror` and `unhandledrejection` handlers fire