### PR TITLE
perf: split issue list from sparklines and add DB indexes

### DIFF
--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -37,8 +38,21 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		Status: q.Get("status"),
 		Query:  q.Get("q"),
 	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 500 {
+			filter.Limit = n
+		}
+	}
+	if v := q.Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			filter.Offset = n
+		}
+	}
+	if filter.Limit == 0 {
+		filter.Limit = 100
+	}
 	// Any query params not used for standard filtering are treated as facet filters.
-	knownParams := map[string]bool{"sort": true, "status": true, "q": true}
+	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true}
 	for key, vals := range q {
 		if knownParams[key] || len(vals) == 0 || strings.TrimSpace(vals[0]) == "" {
 			continue
@@ -54,35 +68,38 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Collect numeric issue IDs for hourly count lookup.
-	issueIDs := make([]int64, 0, len(issues))
-	for _, iss := range issues {
-		if id, err := parseIssueRowID(iss.ID); err == nil {
+	writeJSON(w, map[string]any{"issues": issues})
+}
+
+func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil || s.service == nil {
+		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	ids := r.URL.Query().Get("ids")
+	if ids == "" {
+		writeJSON(w, map[string]any{"sparklines": map[string][24]int{}})
+		return
+	}
+
+	parts := strings.Split(ids, ",")
+	issueIDs := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		if id, err := parseIssueRowID(strings.TrimSpace(p)); err == nil {
 			issueIDs = append(issueIDs, id)
 		}
 	}
 
 	hourlyCounts, err := s.service.HourlyEventCounts(r.Context(), issueIDs)
 	if err != nil {
-		// Non-fatal: log and continue without sparkline data.
 		hourlyCounts = map[int64][24]int{}
 	}
 
-	// Build enriched response items.
-	type issueWithCounts struct {
-		storage.Issue
-		HourlyCounts [24]int `json:"hourly_counts"`
+	result := make(map[string][24]int, len(hourlyCounts))
+	for id, counts := range hourlyCounts {
+		result[fmt.Sprintf("issue-%06d", id)] = counts
 	}
-	items := make([]issueWithCounts, len(issues))
-	for i, iss := range issues {
-		counts := [24]int{}
-		if id, err := parseIssueRowID(iss.ID); err == nil {
-			counts = hourlyCounts[id]
-		}
-		items[i] = issueWithCounts{Issue: iss, HourlyCounts: counts}
-	}
-
-	writeJSON(w, map[string]any{"issues": items})
+	writeJSON(w, map[string]any{"sparklines": result})
 }
 
 func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -150,11 +150,8 @@ func TestListIssuesIncludesHourlyCounts(t *testing.T) {
 		t.Fatal("expected at least one issue")
 	}
 
-	first, ok := issues[0].(map[string]any)
+	_, ok = issues[0].(map[string]any)
 	if !ok {
 		t.Fatal("expected issue to be an object")
-	}
-	if _, ok := first["hourly_counts"]; !ok {
-		t.Error("expected hourly_counts in issue list response")
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -294,6 +294,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveAlertRoute(w, r)
 	case r.URL.Path == "/api/v1/issues" && r.Method == http.MethodGet:
 		s.listIssues(w, r)
+	case r.URL.Path == "/api/v1/issues/sparklines" && r.Method == http.MethodGet:
+		s.issueSparklines(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/issues/"):
 		s.serveIssueRoute(w, r)
 	case r.URL.Path == "/api/v1/logs" && r.Method == http.MethodGet:

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -122,6 +122,13 @@ WHERE ` + strings.Join(conditions, " AND ")
 	sqlQuery += `
 ORDER BY ` + orderBy
 
+	if filter.Limit > 0 {
+		sqlQuery += fmt.Sprintf(" LIMIT %d", filter.Limit)
+		if filter.Offset > 0 {
+			sqlQuery += fmt.Sprintf(" OFFSET %d", filter.Offset)
+		}
+	}
+
 	rows, err := s.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, err

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -140,10 +140,13 @@ func (s *Store) init(ctx context.Context) error {
 			last_used_at TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_issues_project_last_seen ON issues(project_id, last_seen DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_issues_project_status_last_seen ON issues(project_id, status, last_seen DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_events_issue_id ON events(project_id, issue_id, id ASC)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_issue_observed ON events(project_id, issue_id, observed_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_events_project_received_at ON events(project_id, received_at DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_releases_project_observed_at ON releases(project_id, observed_at DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_event_facets_lookup ON event_facets(project_id, section, facet_key, facet_value)`,
+		`CREATE INDEX IF NOT EXISTS idx_event_facets_issue ON event_facets(project_id, issue_id, facet_key, facet_value)`,
 		`CREATE TABLE IF NOT EXISTS alert_firings (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			alert_id INTEGER NOT NULL,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -71,6 +71,10 @@ type IssueFilter struct {
 	// Facets is an optional map of facet key→value pairs to filter by.
 	// Issues must match ALL provided facet filters (AND semantics).
 	Facets map[string]string
+	// Limit caps the number of returned issues. 0 means no limit.
+	Limit int
+	// Offset skips the first N results (for pagination).
+	Offset int
 }
 
 // User represents an admin user stored in the database.

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -696,12 +696,39 @@ async function loadIssues(): Promise<void> {
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView();
     }
+    loadSparklines();
   } catch (error) {
     state.issues = [];
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView(error);
     }
     setStatus(`Issues unavailable: ${errorMessage(error)}`);
+  }
+}
+
+async function loadSparklines(): Promise<void> {
+  if (state.issues.length === 0) return;
+  const ids = state.issues
+    .map((i) => String(i.ID ?? i.id ?? ""))
+    .filter(Boolean)
+    .join(",");
+  if (!ids) return;
+  try {
+    const payload = await fetchJson(`/api/v1/issues/sparklines?ids=${encodeURIComponent(ids)}`);
+    const sparklines = (payload as Record<string, unknown>)?.["sparklines"] as Record<string, number[]> | undefined;
+    if (sparklines) {
+      for (const issue of state.issues) {
+        const key = String(issue.ID ?? issue.id ?? "");
+        if (key && sparklines[key]) {
+          issue.hourly_counts = sparklines[key];
+        }
+      }
+      if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
+        renderIssuesView();
+      }
+    }
+  } catch {
+    // Sparklines are non-critical; silently ignore failures.
   }
 }
 


### PR DESCRIPTION
## Summary
- Split the `/api/v1/issues` endpoint: issue metadata loads instantly, sparkline (hourly event counts) data loads via a new lazy `/api/v1/issues/sparklines` endpoint
- Added pagination support (`limit`/`offset` query params, default limit 100)
- Added three new SQLite indexes: status-filtered issue queries, hourly event aggregation (`observed_at`), and facet→issue lookups

## Test plan
- [x] All Go tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify issue list renders immediately without waiting for sparklines
- [ ] Confirm sparkline bars appear shortly after the list loads
- [ ] Test pagination with `?limit=10&offset=0`