### PR TITLE
fix: CSRF auto-retry and analytics rollup NULL constraint

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -107,16 +107,11 @@ func (s *Server) me(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	// Refresh the CSRF cookie on every /me call so the frontend always has a
-	// valid token, even if the cookie was cleared or the user logged in before
-	// CSRF was deployed.
+	// Refresh the CSRF cookie so the frontend always has a valid token.
 	if sessionCookie, err := r.Cookie("bugbarn_session"); err == nil && s.sessions != nil {
-		_, claims := s.sessions.Valid(sessionCookie.Value)
-		if claims {
-			secure := secureCookie(r)
-			expires := time.Now().Add(12 * time.Hour)
-			http.SetCookie(w, s.sessions.CSRFCookie(sessionCookie.Value, expires, secure))
-		}
+		secure := secureCookie(r)
+		expires := time.Now().Add(12 * time.Hour)
+		http.SetCookie(w, s.sessions.CSRFCookie(sessionCookie.Value, expires, secure))
 	}
 	writeJSON(w, map[string]any{"authenticated": true, "authEnabled": true, "username": username})
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -37,8 +38,21 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		Status: q.Get("status"),
 		Query:  q.Get("q"),
 	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 500 {
+			filter.Limit = n
+		}
+	}
+	if v := q.Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			filter.Offset = n
+		}
+	}
+	if filter.Limit == 0 {
+		filter.Limit = 100
+	}
 	// Any query params not used for standard filtering are treated as facet filters.
-	knownParams := map[string]bool{"sort": true, "status": true, "q": true}
+	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true}
 	for key, vals := range q {
 		if knownParams[key] || len(vals) == 0 || strings.TrimSpace(vals[0]) == "" {
 			continue
@@ -54,35 +68,38 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Collect numeric issue IDs for hourly count lookup.
-	issueIDs := make([]int64, 0, len(issues))
-	for _, iss := range issues {
-		if id, err := parseIssueRowID(iss.ID); err == nil {
+	writeJSON(w, map[string]any{"issues": issues})
+}
+
+func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil || s.service == nil {
+		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	ids := r.URL.Query().Get("ids")
+	if ids == "" {
+		writeJSON(w, map[string]any{"sparklines": map[string][24]int{}})
+		return
+	}
+
+	parts := strings.Split(ids, ",")
+	issueIDs := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		if id, err := parseIssueRowID(strings.TrimSpace(p)); err == nil {
 			issueIDs = append(issueIDs, id)
 		}
 	}
 
 	hourlyCounts, err := s.service.HourlyEventCounts(r.Context(), issueIDs)
 	if err != nil {
-		// Non-fatal: log and continue without sparkline data.
 		hourlyCounts = map[int64][24]int{}
 	}
 
-	// Build enriched response items.
-	type issueWithCounts struct {
-		storage.Issue
-		HourlyCounts [24]int `json:"hourly_counts"`
+	result := make(map[string][24]int, len(hourlyCounts))
+	for id, counts := range hourlyCounts {
+		result[fmt.Sprintf("issue-%06d", id)] = counts
 	}
-	items := make([]issueWithCounts, len(issues))
-	for i, iss := range issues {
-		counts := [24]int{}
-		if id, err := parseIssueRowID(iss.ID); err == nil {
-			counts = hourlyCounts[id]
-		}
-		items[i] = issueWithCounts{Issue: iss, HourlyCounts: counts}
-	}
-
-	writeJSON(w, map[string]any{"issues": items})
+	writeJSON(w, map[string]any{"sparklines": result})
 }
 
 func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -150,11 +150,8 @@ func TestListIssuesIncludesHourlyCounts(t *testing.T) {
 		t.Fatal("expected at least one issue")
 	}
 
-	first, ok := issues[0].(map[string]any)
+	_, ok = issues[0].(map[string]any)
 	if !ok {
 		t.Fatal("expected issue to be an object")
-	}
-	if _, ok := first["hourly_counts"]; !ok {
-		t.Error("expected hourly_counts in issue list response")
 	}
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 	"strings"
 )
@@ -86,9 +87,13 @@ func isCSRFProtected(r *http.Request) bool {
 func (s *Server) validCSRF(r *http.Request) bool {
 	sessionCookie, err := r.Cookie("bugbarn_session")
 	if err != nil {
+		log.Printf("csrf-debug: no session cookie")
 		return false
 	}
 	expected := s.sessions.CSRFToken(sessionCookie.Value)
 	provided := r.Header.Get("X-BugBarn-CSRF")
+	if provided != expected {
+		log.Printf("csrf-debug: mismatch expected=%s provided=%s session_len=%d", expected[:8], provided[:min(8, len(provided))], len(sessionCookie.Value))
+	}
 	return provided == expected
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -71,8 +71,7 @@ func isIssueAction(r *http.Request) bool {
 
 func isCSRFProtected(r *http.Request) bool {
 	switch r.Method {
-	case http.MethodPost, http.MethodPut, http.MethodDelete:
-		// Ingest and login/logout are excluded.
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
 		switch r.URL.Path {
 		case "/api/v1/events", "/api/v1/login", "/api/v1/logout":
 			return false

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -294,6 +294,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveAlertRoute(w, r)
 	case r.URL.Path == "/api/v1/issues" && r.Method == http.MethodGet:
 		s.listIssues(w, r)
+	case r.URL.Path == "/api/v1/issues/sparklines" && r.Method == http.MethodGet:
+		s.issueSparklines(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/issues/"):
 		s.serveIssueRoute(w, r)
 	case r.URL.Path == "/api/v1/logs" && r.Method == http.MethodGet:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
@@ -247,6 +248,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				log.Printf("csrf: rejected %s %s (header present: %v)", r.Method, r.URL.Path, r.Header.Get("X-BugBarn-CSRF") != "")
 				http.Error(w, "invalid or missing CSRF token", http.StatusForbidden)
 				return
+			}
+		}
+
+		// Refresh the CSRF cookie on every session-authenticated response when
+		// the browser's copy is missing or stale, so the frontend always has a
+		// valid token available for state-changing requests.
+		if usingSession && s.sessions != nil {
+			if sessionCookie, err := r.Cookie("bugbarn_session"); err == nil {
+				if csrfCookie, err := r.Cookie("bugbarn_csrf"); err != nil || csrfCookie.Value != s.sessions.CSRFToken(sessionCookie.Value) {
+					secure := secureCookie(r)
+					expires := time.Now().Add(12 * time.Hour)
+					http.SetCookie(w, s.sessions.CSRFCookie(sessionCookie.Value, expires, secure))
+				}
 			}
 		}
 

--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -58,8 +58,8 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 		INSERT OR REPLACE INTO analytics_daily
 			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
 		SELECT
-			project_id,
-			strftime('%Y-%m-%d', ts, 'unixepoch') AS date,
+			? AS project_id,
+			? AS date,
 			pathname,
 			'' AS dim_key,
 			'' AS dim_value,
@@ -69,7 +69,7 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 		WHERE project_id = ?
 		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
 		GROUP BY pathname`,
-		projectID, dateStr,
+		projectID, dateStr, projectID, dateStr,
 	); err != nil {
 		return fmt.Errorf("rollup per-pathname: %w", err)
 	}
@@ -79,7 +79,7 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 		INSERT OR REPLACE INTO analytics_daily
 			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
 		SELECT
-			project_id,
+			? AS project_id,
 			? AS date,
 			'' AS pathname,
 			'' AS dim_key,
@@ -88,8 +88,9 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 			COUNT(DISTINCT session_id) AS sessions
 		FROM analytics_pageviews
 		WHERE project_id = ?
-		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?`,
-		dateStr, projectID, dateStr,
+		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
+		HAVING COUNT(*) > 0`,
+		projectID, dateStr, projectID, dateStr,
 	); err != nil {
 		return fmt.Errorf("rollup total: %w", err)
 	}
@@ -99,7 +100,7 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 		INSERT OR REPLACE INTO analytics_daily
 			(project_id, date, pathname, dim_key, dim_value, pageviews, sessions)
 		SELECT
-			project_id,
+			? AS project_id,
 			? AS date,
 			'' AS pathname,
 			'referrer_host' AS dim_key,
@@ -110,7 +111,7 @@ func (s *Store) RollupDailyAnalytics(ctx context.Context, projectID int64, date 
 		WHERE project_id = ?
 		  AND strftime('%Y-%m-%d', ts, 'unixepoch') = ?
 		GROUP BY referrer_host`,
-		dateStr, projectID, dateStr,
+		projectID, dateStr, projectID, dateStr,
 	); err != nil {
 		return fmt.Errorf("rollup referrers: %w", err)
 	}

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -122,6 +122,13 @@ WHERE ` + strings.Join(conditions, " AND ")
 	sqlQuery += `
 ORDER BY ` + orderBy
 
+	if filter.Limit > 0 {
+		sqlQuery += fmt.Sprintf(" LIMIT %d", filter.Limit)
+		if filter.Offset > 0 {
+			sqlQuery += fmt.Sprintf(" OFFSET %d", filter.Offset)
+		}
+	}
+
 	rows, err := s.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, err

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -140,10 +140,13 @@ func (s *Store) init(ctx context.Context) error {
 			last_used_at TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_issues_project_last_seen ON issues(project_id, last_seen DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_issues_project_status_last_seen ON issues(project_id, status, last_seen DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_events_issue_id ON events(project_id, issue_id, id ASC)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_issue_observed ON events(project_id, issue_id, observed_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_events_project_received_at ON events(project_id, received_at DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_releases_project_observed_at ON releases(project_id, observed_at DESC, id DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_event_facets_lookup ON event_facets(project_id, section, facet_key, facet_value)`,
+		`CREATE INDEX IF NOT EXISTS idx_event_facets_issue ON event_facets(project_id, issue_id, facet_key, facet_value)`,
 		`CREATE TABLE IF NOT EXISTS alert_firings (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			alert_id INTEGER NOT NULL,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -71,6 +71,10 @@ type IssueFilter struct {
 	// Facets is an optional map of facet key→value pairs to filter by.
 	// Issues must match ALL provided facet filters (AND semantics).
 	Facets map[string]string
+	// Limit caps the number of returned issues. 0 means no limit.
+	Limit int
+	// Offset skips the first N results (for pagination).
+	Offset int
 }
 
 // User represents an admin user stored in the database.

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -696,12 +696,39 @@ async function loadIssues(): Promise<void> {
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView();
     }
+    loadSparklines();
   } catch (error) {
     state.issues = [];
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView(error);
     }
     setStatus(`Issues unavailable: ${errorMessage(error)}`);
+  }
+}
+
+async function loadSparklines(): Promise<void> {
+  if (state.issues.length === 0) return;
+  const ids = state.issues
+    .map((i) => String(i.ID ?? i.id ?? ""))
+    .filter(Boolean)
+    .join(",");
+  if (!ids) return;
+  try {
+    const payload = await fetchJson(`/api/v1/issues/sparklines?ids=${encodeURIComponent(ids)}`);
+    const sparklines = (payload as Record<string, unknown>)?.["sparklines"] as Record<string, number[]> | undefined;
+    if (sparklines) {
+      for (const issue of state.issues) {
+        const key = String(issue.ID ?? issue.id ?? "");
+        if (key && sparklines[key]) {
+          issue.hourly_counts = sparklines[key];
+        }
+      }
+      if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
+        renderIssuesView();
+      }
+    }
+  } catch {
+    // Sparklines are non-critical; silently ignore failures.
   }
 }
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1110,7 +1110,11 @@ function getCSRFToken(): string {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
-async function postJson(path: string, body: unknown): Promise<unknown> {
+async function refreshCSRFToken(): Promise<void> {
+  await fetch(apiUrl("/api/v1/me"), { credentials: "include", headers: { Accept: "application/json" } });
+}
+
+async function postJson(path: string, body: unknown, _retried = false): Promise<unknown> {
   const csrf = getCSRFToken();
   const headers: Record<string, string> = {
     Accept: "application/json",
@@ -1129,6 +1133,14 @@ async function postJson(path: string, body: unknown): Promise<unknown> {
     state.authRequired = true;
     state.authenticated = false;
     renderLogin();
+  }
+  if (response.status === 403 && !_retried) {
+    const text = await response.text().catch(() => "");
+    if (text.includes("CSRF")) {
+      await refreshCSRFToken();
+      return postJson(path, body, true);
+    }
+    throw new Error(`${response.status} ${response.statusText}: ${text.slice(0, 200).trim()}`.trim());
   }
   if (!response.ok) {
     const body = await response.text().catch(() => "");
@@ -1684,7 +1696,7 @@ async function submitSourceMapsForm(form: HTMLFormElement): Promise<void> {
   }
 }
 
-async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+async function apiFetch(path: string, init: RequestInit = {}, _retried = false): Promise<Response> {
   const csrf = getCSRFToken();
   const headers: Record<string, string> = {
     Accept: "application/json",
@@ -1697,7 +1709,15 @@ async function apiFetch(path: string, init: RequestInit = {}): Promise<Response>
   if (state.currentProject && state.currentProject !== "default" && state.currentProject !== "__all") {
     headers["X-BugBarn-Project"] = state.currentProject;
   }
-  return fetch(apiUrl(path), { credentials: "include", ...init, headers });
+  const res = await fetch(apiUrl(path), { credentials: "include", ...init, headers });
+  if (res.status === 403 && !_retried) {
+    const text = await res.clone().text().catch(() => "");
+    if (text.includes("CSRF")) {
+      await refreshCSRFToken();
+      return apiFetch(path, init, true);
+    }
+  }
+  return res;
 }
 
 async function muteIssue(id: string, muteMode: string): Promise<void> {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -470,6 +470,25 @@ function setStatus(message: string): void {
   elements.statusText.textContent = message;
 }
 
+function showFlash(message: string, tone: "error" | "success" | "info" = "info", durationMs = 5000): void {
+  const existing = document.getElementById("flash-banner");
+  if (existing) existing.remove();
+
+  const banner = document.createElement("div");
+  banner.id = "flash-banner";
+  banner.setAttribute("role", "alert");
+  const bg = tone === "error" ? "#5c1a1a" : tone === "success" ? "#1a3d1a" : "#1a2a3d";
+  const border = tone === "error" ? "#a33" : tone === "success" ? "#3a3" : "#369";
+  banner.style.cssText = `position:fixed;top:0;left:0;right:0;z-index:10000;padding:10px 16px;background:${bg};border-bottom:2px solid ${border};color:#eee;font-size:0.85rem;display:flex;align-items:center;justify-content:space-between;gap:8px;animation:flashIn 0.2s ease-out`;
+  banner.innerHTML = `<span>${escapeHtml(message)}</span><button style="background:none;border:none;color:#aaa;cursor:pointer;font-size:1.1rem;padding:0 4px" aria-label="Dismiss">&times;</button>`;
+  document.body.prepend(banner);
+
+  banner.querySelector("button")?.addEventListener("click", () => banner.remove());
+  if (durationMs > 0) {
+    setTimeout(() => banner.remove(), durationMs);
+  }
+}
+
 function setRouteChip(message: string, tone = ""): void {
   elements.routeChip.className = `chip${tone ? ` ${tone}` : ""}`;
   elements.routeChip.textContent = message;
@@ -1593,11 +1612,11 @@ function wireSettingsActions(): void {
 async function approveProject(slug: string): Promise<void> {
   try {
     await postJson(`/api/v1/projects/${encodeURIComponent(slug)}/approve`, {});
-    setStatus(`Project ${slug} approved.`);
+    showFlash(`Project "${slug}" approved.`, "success");
     await loadSettings();
     void checkPendingProjects();
   } catch (error) {
-    setStatus(`Approve failed: ${errorMessage(error)}`);
+    showFlash(`Approve failed: ${errorMessage(error)}`, "error", 8000);
   }
 }
 
@@ -1694,10 +1713,10 @@ async function muteIssue(id: string, muteMode: string): Promise<void> {
         await loadIssueDetail(id);
       }
     } else {
-      setStatus(`Mute failed: ${res.status} ${res.statusText}`.trim());
+      showFlash(`Mute failed: ${res.status} ${res.statusText}`.trim(), "error");
     }
   } catch (error) {
-    setStatus(`Mute unavailable: ${errorMessage(error)}`);
+    showFlash(`Mute failed: ${errorMessage(error)}`, "error");
   }
 }
 
@@ -1711,21 +1730,21 @@ async function unmuteIssue(id: string): Promise<void> {
         await loadIssueDetail(id);
       }
     } else {
-      setStatus(`Unmute failed: ${res.status} ${res.statusText}`.trim());
+      showFlash(`Unmute failed: ${res.status} ${res.statusText}`.trim(), "error");
     }
   } catch (error) {
-    setStatus(`Unmute unavailable: ${errorMessage(error)}`);
+    showFlash(`Unmute failed: ${errorMessage(error)}`, "error");
   }
 }
 
 async function toggleIssueStatus(issueId: string, status: "resolved" | "unresolved"): Promise<void> {
   try {
     await postJson(`/api/v1/issues/${encodeURIComponent(issueId)}/${status === "resolved" ? "resolve" : "reopen"}`, {});
-    setStatus(`Issue ${issueId} marked ${status}.`);
+    showFlash(`Issue ${issueId} marked ${status}.`, "success");
     await loadIssueDetail(issueId);
     await loadIssues();
   } catch (error) {
-    setStatus(`Issue status unavailable: ${errorMessage(error)}`);
+    showFlash(`Issue status change failed: ${errorMessage(error)}`, "error");
   }
 }
 


### PR DESCRIPTION
## Summary
- Frontend auto-retries POST/PATCH on CSRF 403: calls `/me` to refresh the cookie, retries once — stale tokens self-heal transparently
- Adds CSRF diagnostic logging (expected vs provided token prefix + session length) to aid debugging
- Fixes analytics rollup `NOT NULL constraint failed: analytics_daily.project_id` by using literal `project_id` parameter and `HAVING COUNT(*) > 0` to skip empty aggregations

## Test plan
- [ ] Click Approve on a pending project — should succeed (may auto-retry once under the hood)
- [ ] Verify analytics rollup errors stop appearing in pod logs