### PR TITLE
fix: tab switch race condition, release badge cutoff, and issue status indicators

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -755,10 +755,10 @@ async function loadReleases(): Promise<void> {
   try {
     const payload = await fetchJson("/api/v1/releases", true);
     state.releases = payload ? normalizeList<ApiRelease>(payload, "releases") : [];
-    renderReleasesView();
+    if (state.currentRoute === "releases") renderReleasesView();
   } catch (error) {
     state.releases = [];
-    renderReleasesView(error);
+    if (state.currentRoute === "releases") renderReleasesView(error);
   }
 }
 
@@ -817,10 +817,10 @@ async function loadAlerts(): Promise<void> {
   try {
     const payload = await fetchJson("/api/v1/alerts", true);
     state.alerts = payload ? normalizeList<ApiAlert>(payload, "alerts") : [];
-    renderAlertsView();
+    if (state.currentRoute === "alerts") renderAlertsView();
   } catch (error) {
     state.alerts = [];
-    renderAlertsView(error);
+    if (state.currentRoute === "alerts") renderAlertsView(error);
   }
 }
 
@@ -832,10 +832,10 @@ async function loadSettings(): Promise<void> {
     ]);
     state.settings = settingsPayload ? normalizeObject<ApiSettings>(settingsPayload, "settings") : null;
     state.apiKeys = keysPayload ? normalizeList<ApiApiKey>(keysPayload as Record<string, unknown>, "apiKeys") : [];
-    renderSettingsView();
+    if (state.currentRoute === "settings") renderSettingsView();
   } catch (error) {
     state.settings = null;
-    renderSettingsView(error);
+    if (state.currentRoute === "settings") renderSettingsView(error);
   }
 }
 
@@ -1794,10 +1794,10 @@ async function loadLogs(): Promise<void> {
     const payload = await fetchJson(`/api/v1/logs${qs ? `?${qs}` : ""}`, true);
     const raw = payload as Record<string, unknown> | null;
     state.logs = Array.isArray(raw?.["logs"]) ? (raw["logs"] as ApiLogEntry[]) : [];
-    renderLogsView();
+    if (state.currentRoute === "logs") renderLogsView();
   } catch {
     state.logs = [];
-    renderLogsView();
+    if (state.currentRoute === "logs") renderLogsView();
   }
 }
 

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -64,9 +64,11 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
         const severity = issueSeverity(issue);
         const severityClass = severity === "error" || severity === "fatal" ? "bad" : severity === "warning" ? "warn" : "";
         const projectSlug = issue.project_slug ? String(issue.project_slug) : "";
+        const status = issueStatus(issue);
+        const statusClass = status === "resolved" ? "resolved" : status === "muted" ? "muted" : "";
         return `
-          <button class="item issue-row ${active}" type="button" data-issue-id="${escapeAttr(id)}">
-            <div class="item-title"><span class="status-dot"></span>${escapeHtml(title)}</div>
+          <button class="item issue-row ${active} ${statusClass}" type="button" data-issue-id="${escapeAttr(id)}">
+            <div class="item-title"><span class="status-dot ${statusClass}"></span>${escapeHtml(title)}</div>
             <span class="issue-cell"><span class="chip ${severityClass}" style="font-size:0.7rem">${escapeHtml(severity || "n/a")}</span></span>
             <span class="issue-cell">${escapeHtml(lastSeen || "No timestamp")}</span>
             <span class="issue-cell">${escapeHtml(firstSeen || "n/a")}</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -532,6 +532,19 @@ button:disabled {
   background: #ae81ff;
 }
 
+.status-dot.resolved {
+  background: var(--accent);
+}
+
+.status-dot.muted {
+  background: var(--muted);
+}
+
+.issue-row.resolved,
+.issue-row.muted {
+  opacity: 0.55;
+}
+
 .item-meta,
 .muted {
   color: var(--muted);
@@ -911,6 +924,14 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  min-width: 0;
+}
+
+.route-item-head strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .route-item-meta {


### PR DESCRIPTION
## Summary
- **Tab switch race condition**: `loadReleases()`, `loadAlerts()`, `loadSettings()`, and `loadLogs()` now check `state.currentRoute` before rendering, preventing stale in-flight fetches from overwriting the active view when switching tabs quickly
- **Release badge cutoff**: Long release titles truncate with ellipsis so environment chips (prod/staging/testing) stay visible on mobile
- **Issue status indicators**: Resolved and muted issues are visually dimmed (55% opacity) with color-coded status dots — green for resolved, grey for muted — so they're distinguishable from open issues at a glance

## Test plan
- [ ] Switch rapidly between tabs (especially Releases → Issues) and verify the correct content renders
- [ ] Check release cards with long names on mobile — environment badge should be visible
- [ ] View issue list with a mix of open/resolved/muted issues and confirm visual differentiation