### PR TITLE
fix: explicit status labels for resolved/muted/regressed issues

### DIFF
--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -65,7 +65,8 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
         const severityClass = severity === "error" || severity === "fatal" ? "bad" : severity === "warning" ? "warn" : "";
         const projectSlug = issue.project_slug ? String(issue.project_slug) : "";
         const status = issueStatus(issue);
-        const statusClass = status === "resolved" ? "resolved" : status === "muted" ? "muted" : "";
+        const statusClass = status === "resolved" ? "resolved" : status === "muted" ? "muted" : status === "regressed" ? "regressed" : "";
+        const statusLabel = status === "resolved" ? "Resolved" : status === "muted" ? "Muted" : status === "regressed" ? "Regressed" : "";
         return `
           <button class="item issue-row ${active} ${statusClass}" type="button" data-issue-id="${escapeAttr(id)}">
             <div class="item-title"><span class="status-dot ${statusClass}"></span>${escapeHtml(title)}</div>
@@ -77,6 +78,7 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
             <span class="issue-cell">${renderSparkline(issue.hourly_counts)}</span>
             <div class="item-meta">
               <span>${escapeHtml(issueExceptionType(issue) || "Error")}</span>
+              ${statusLabel ? `<span class="chip issue-status-chip ${statusClass}" style="font-size:0.65rem">${escapeHtml(statusLabel)}</span>` : ""}
               ${projectSlug ? `<span class="chip" style="font-size:0.65rem;opacity:0.7">${escapeHtml(projectSlug)}</span>` : ""}
               <span>${escapeHtml(id)}</span>
             </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -540,9 +540,28 @@ button:disabled {
   background: var(--muted);
 }
 
+.status-dot.regressed {
+  background: var(--accent-warm);
+}
+
 .issue-row.resolved,
 .issue-row.muted {
-  opacity: 0.55;
+  opacity: 0.5;
+}
+
+.issue-status-chip.resolved {
+  background: #1a3d1a;
+  color: var(--accent);
+}
+
+.issue-status-chip.muted {
+  background: #2a2a2a;
+  color: var(--muted);
+}
+
+.issue-status-chip.regressed {
+  background: #442d13;
+  color: var(--accent-warm);
 }
 
 .item-meta,


### PR DESCRIPTION
## Summary
- Add colored status chips (Resolved/Muted/Regressed) in issue metadata row so issue state is immediately visible
- Increase opacity dimming for resolved/muted rows (0.55 → 0.5)
- Handle regressed status with warm accent color
- Distinct chip background colors per status

Follow-up to #44 — the status dot color change alone was too subtle.

## Test plan
- [ ] View issue list with muted/resolved issues — status chip should be visible in metadata row
- [ ] Verify resolved issues show green "Resolved" chip, muted show grey "Muted" chip
- [ ] Open issues should have no status chip