### PR TITLE
feat: Jira-style issue IDs with per-project prefixes

### DIFF
--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -84,10 +83,15 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 
 	parts := strings.Split(ids, ",")
 	issueIDs := make([]int64, 0, len(parts))
+	displayByRowID := make(map[int64]string, len(parts))
 	for _, p := range parts {
-		if id, err := parseIssueRowID(strings.TrimSpace(p)); err == nil {
-			issueIDs = append(issueIDs, id)
+		displayID := strings.TrimSpace(p)
+		rowID, err := s.store.IssueRowIDByDisplayID(r.Context(), displayID)
+		if err != nil {
+			continue
 		}
+		issueIDs = append(issueIDs, rowID)
+		displayByRowID[rowID] = displayID
 	}
 
 	hourlyCounts, err := s.service.HourlyEventCounts(r.Context(), issueIDs)
@@ -97,7 +101,9 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 
 	result := make(map[string][24]int, len(hourlyCounts))
 	for id, counts := range hourlyCounts {
-		result[fmt.Sprintf("issue-%06d", id)] = counts
+		if displayID, ok := displayByRowID[id]; ok {
+			result[displayID] = counts
+		}
 	}
 	writeJSON(w, map[string]any{"sparklines": result})
 }
@@ -180,10 +186,4 @@ func (s *Server) unmuteIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"issue": item})
-}
-
-// parseIssueRowID extracts the numeric row ID from an issue ID like "issue-000001".
-func parseIssueRowID(id string) (int64, error) {
-	trimmed := strings.TrimPrefix(id, "issue-")
-	return strconv.ParseInt(strings.TrimLeft(trimmed, "0"), 10, 64)
 }

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -44,7 +44,7 @@ func (s *Store) ReopenIssue(ctx context.Context, issueID string) (Issue, error) 
 }
 
 func (s *Store) setIssueStatus(ctx context.Context, issueID, status string) (Issue, error) {
-	rowID, err := parseID(issueIDPrefix, issueID)
+	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {
 		return Issue{}, err
 	}

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Store) ListIssueEvents(ctx context.Context, issueID string, limit int, beforeID int64) ([]Event, bool, error) {
-	rowID, err := parseID(issueIDPrefix, issueID)
+	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -31,41 +31,36 @@ func (s *Store) ListIssueEvents(ctx context.Context, issueID string, limit int, 
 	// Fetch one extra row to know whether there are more pages.
 	fetch := limit + 1
 
+	const eventCols = `e.id, e.issue_id, e.fingerprint, e.fingerprint_material, e.fingerprint_explanation_json,
+       e.received_at, e.observed_at, e.severity, e.message, e.regressed, e.event_json,
+       i.issue_number, COALESCE(p.issue_prefix, '')`
+	const eventJoin = ` FROM events e
+JOIN issues i ON i.id = e.issue_id
+JOIN projects p ON p.id = i.project_id`
+
 	var rows *sql.Rows
 	if projectID != 0 {
 		if beforeID > 0 {
-			rows, err = s.db.QueryContext(ctx, `
-SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
-       received_at, observed_at, severity, message, regressed, event_json
-FROM events
-WHERE project_id = ? AND issue_id = ? AND id < ?
-ORDER BY id DESC LIMIT ?`,
+			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+WHERE e.project_id = ? AND e.issue_id = ? AND e.id < ?
+ORDER BY e.id DESC LIMIT ?`,
 				projectID, rowID, beforeID, fetch)
 		} else {
-			rows, err = s.db.QueryContext(ctx, `
-SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
-       received_at, observed_at, severity, message, regressed, event_json
-FROM events
-WHERE project_id = ? AND issue_id = ?
-ORDER BY id DESC LIMIT ?`,
+			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+WHERE e.project_id = ? AND e.issue_id = ?
+ORDER BY e.id DESC LIMIT ?`,
 				projectID, rowID, fetch)
 		}
 	} else {
 		if beforeID > 0 {
-			rows, err = s.db.QueryContext(ctx, `
-SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
-       received_at, observed_at, severity, message, regressed, event_json
-FROM events
-WHERE issue_id = ? AND id < ?
-ORDER BY id DESC LIMIT ?`,
+			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+WHERE e.issue_id = ? AND e.id < ?
+ORDER BY e.id DESC LIMIT ?`,
 				rowID, beforeID, fetch)
 		} else {
-			rows, err = s.db.QueryContext(ctx, `
-SELECT id, issue_id, fingerprint, fingerprint_material, fingerprint_explanation_json,
-       received_at, observed_at, severity, message, regressed, event_json
-FROM events
-WHERE issue_id = ?
-ORDER BY id DESC LIMIT ?`,
+			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+WHERE e.issue_id = ?
+ORDER BY e.id DESC LIMIT ?`,
 				rowID, fetch)
 		}
 	}
@@ -112,26 +107,30 @@ func (s *Store) GetEvent(ctx context.Context, eventID string) (Event, error) {
 
 	const sel = `
 SELECT
-	id,
-	issue_id,
-	fingerprint,
-	fingerprint_material,
-	fingerprint_explanation_json,
-	received_at,
-	observed_at,
-	severity,
-	message,
-	regressed,
-	event_json
-FROM events`
+	e.id,
+	e.issue_id,
+	e.fingerprint,
+	e.fingerprint_material,
+	e.fingerprint_explanation_json,
+	e.received_at,
+	e.observed_at,
+	e.severity,
+	e.message,
+	e.regressed,
+	e.event_json,
+	i.issue_number,
+	COALESCE(p.issue_prefix, '')
+FROM events e
+JOIN issues i ON i.id = e.issue_id
+JOIN projects p ON p.id = i.project_id`
 
 	var row *sql.Row
 	if projectID != 0 {
 		row = s.db.QueryRowContext(ctx, sel+`
-WHERE project_id = ? AND id = ?`, projectID, rowID)
+WHERE e.project_id = ? AND e.id = ?`, projectID, rowID)
 	} else {
 		row = s.db.QueryRowContext(ctx, sel+`
-WHERE id = ?`, rowID)
+WHERE e.id = ?`, rowID)
 	}
 
 	return scanEvent(row)
@@ -156,28 +155,32 @@ func (s *Store) ListRecentEvents(ctx context.Context, limit int, since time.Time
 	)
 	const recentSel = `
 SELECT
-	id,
-	issue_id,
-	fingerprint,
-	fingerprint_material,
-	fingerprint_explanation_json,
-	received_at,
-	observed_at,
-	severity,
-	message,
-	regressed,
-	event_json
-FROM events`
+	e.id,
+	e.issue_id,
+	e.fingerprint,
+	e.fingerprint_material,
+	e.fingerprint_explanation_json,
+	e.received_at,
+	e.observed_at,
+	e.severity,
+	e.message,
+	e.regressed,
+	e.event_json,
+	i.issue_number,
+	COALESCE(p.issue_prefix, '')
+FROM events e
+JOIN issues i ON i.id = e.issue_id
+JOIN projects p ON p.id = i.project_id`
 	sinceStr := formatTime(since.UTC())
 	if projectID != 0 {
 		rows, err = s.db.QueryContext(ctx, recentSel+`
-WHERE project_id = ? AND max(received_at, observed_at) >= ?
-ORDER BY max(received_at, observed_at) DESC, id DESC
+WHERE e.project_id = ? AND max(e.received_at, e.observed_at) >= ?
+ORDER BY max(e.received_at, e.observed_at) DESC, e.id DESC
 LIMIT ?`, projectID, sinceStr, limit)
 	} else {
 		rows, err = s.db.QueryContext(ctx, recentSel+`
-WHERE max(received_at, observed_at) >= ?
-ORDER BY max(received_at, observed_at) DESC, id DESC
+WHERE max(e.received_at, e.observed_at) >= ?
+ORDER BY max(e.received_at, e.observed_at) DESC, e.id DESC
 LIMIT ?`, sinceStr, limit)
 	}
 	if err != nil {
@@ -199,7 +202,7 @@ LIMIT ?`, sinceStr, limit)
 	return events, nil
 }
 
-func (s *Store) insertEvent(ctx context.Context, projectID int64, issueID int64, regressed bool, processed worker.ProcessedEvent) (Event, int64, error) {
+func (s *Store) insertEvent(ctx context.Context, projectID int64, issueID int64, issueDisplayID string, regressed bool, processed worker.ProcessedEvent) (Event, int64, error) {
 	payload, err := marshalEvent(processed.Event)
 	if err != nil {
 		return Event{}, 0, err
@@ -254,7 +257,7 @@ INSERT INTO events (
 
 	return Event{
 		ID:                     formatID(eventIDPrefix, eventRowID),
-		IssueID:                formatID(issueIDPrefix, issueID),
+		IssueID:                issueDisplayID,
 		Fingerprint:            processed.Fingerprint,
 		FingerprintMaterial:    processed.FingerprintMaterial,
 		FingerprintExplanation: processed.FingerprintExplanation,
@@ -388,6 +391,8 @@ func scanEvent(scanner interface {
 		receivedAt     string
 		observedAt     string
 		regressed      int
+		issueNumber    int
+		issuePrefix    string
 	)
 	if err := scanner.Scan(
 		&id,
@@ -401,6 +406,8 @@ func scanEvent(scanner interface {
 		&entry.Message,
 		&regressed,
 		&payload,
+		&issueNumber,
+		&issuePrefix,
 	); err != nil {
 		return Event{}, err
 	}
@@ -422,7 +429,11 @@ func scanEvent(scanner interface {
 	entry.ObservedAt = parsedObservedAt
 	entry.Regressed = regressed != 0
 	entry.ID = formatID(eventIDPrefix, id)
-	entry.IssueID = formatID(issueIDPrefix, issueID)
+	if issuePrefix != "" && issueNumber > 0 {
+		entry.IssueID = formatIssueID(issuePrefix, issueNumber)
+	} else {
+		entry.IssueID = formatID(issueIDPrefix, issueID)
+	}
 	return entry, nil
 }
 

--- a/internal/storage/facets_test.go
+++ b/internal/storage/facets_test.go
@@ -212,7 +212,7 @@ func TestPersistFacetsCardinalityGuards(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	issueRowID, err := parseID(issueIDPrefix, ev.IssueID)
+	issueRowID, err := store.IssueRowIDByDisplayID(ctx, ev.IssueID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -35,6 +35,62 @@ func parseID(prefix, value string) (int64, error) {
 	return strconv.ParseInt(strings.TrimPrefix(value, prefix), 10, 64)
 }
 
+func formatIssueID(prefix string, number int) string {
+	return fmt.Sprintf("%s-%d", prefix, number)
+}
+
+// parseIssueID splits a Jira-style issue ID like "BW-42" into prefix and number.
+// Also handles legacy "issue-000042" format for backward compatibility.
+func parseIssueID(value string) (prefix string, number int, err error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", 0, fmt.Errorf("empty issue id")
+	}
+	// Legacy format: issue-NNNNNN
+	if strings.HasPrefix(value, issueIDPrefix) {
+		n, err := strconv.ParseInt(strings.TrimPrefix(value, issueIDPrefix), 10, 64)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid legacy issue id %q: %w", value, err)
+		}
+		return "", int(n), nil
+	}
+	idx := strings.LastIndex(value, "-")
+	if idx <= 0 {
+		return "", 0, fmt.Errorf("invalid issue id %q", value)
+	}
+	n, err := strconv.Atoi(value[idx+1:])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid issue id %q: %w", value, err)
+	}
+	return value[:idx], n, nil
+}
+
+// deriveIssuePrefix generates a short uppercase prefix from a project slug.
+// e.g. "bugbarn-web" → "BW", "my-service" → "MS", "frontend" → "FRO"
+func deriveIssuePrefix(slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return "DEF"
+	}
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' ' || r == '.'
+	})
+	if len(parts) == 1 {
+		upper := strings.ToUpper(parts[0])
+		if len(upper) <= 3 {
+			return upper
+		}
+		return upper[:3]
+	}
+	var b strings.Builder
+	for _, p := range parts {
+		if len(p) > 0 {
+			b.WriteByte(p[0])
+		}
+	}
+	return strings.ToUpper(b.String())
+}
+
 func sqliteDSN(path string) string {
 	u := url.URL{
 		Scheme: "file",

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -113,7 +113,9 @@ SELECT
 	i.last_seen,
 	i.event_count,
 	i.representative_event_json,
-	COALESCE(p.slug, '') AS project_slug
+	COALESCE(p.slug, '') AS project_slug,
+	i.issue_number,
+	COALESCE(p.issue_prefix, '') AS issue_prefix
 FROM ` + fromClause
 	if len(conditions) > 0 {
 		sqlQuery += `
@@ -150,7 +152,7 @@ ORDER BY ` + orderBy
 }
 
 func (s *Store) GetIssue(ctx context.Context, issueID string) (Issue, error) {
-	rowID, err := parseID(issueIDPrefix, issueID)
+	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {
 		return Issue{}, err
 	}
@@ -179,7 +181,9 @@ SELECT
 	i.last_seen,
 	i.event_count,
 	i.representative_event_json,
-	COALESCE(p.slug, '') AS project_slug
+	COALESCE(p.slug, '') AS project_slug,
+	i.issue_number,
+	COALESCE(p.issue_prefix, '') AS issue_prefix
 FROM issues i
 LEFT JOIN projects p ON p.id = i.project_id`
 
@@ -241,6 +245,7 @@ func (s *Store) upsertIssue(ctx context.Context, projectID int64, processed work
 		storedRepresentative []byte
 	)
 
+	var existingIssueNumber int
 	err = tx.QueryRowContext(ctx, `
 SELECT
 	id,
@@ -259,7 +264,8 @@ SELECT
 	first_seen,
 	last_seen,
 	event_count,
-	representative_event_json
+	representative_event_json,
+	issue_number
 FROM issues
 WHERE project_id = ? AND fingerprint = ?`,
 		projectID,
@@ -282,6 +288,7 @@ WHERE project_id = ? AND fingerprint = ?`,
 		&lastSeen,
 		&eventCount,
 		&storedRepresentative,
+		&existingIssueNumber,
 	)
 	switch {
 	case err == nil:
@@ -301,7 +308,7 @@ WHERE project_id = ? AND fingerprint = ?`,
 		if err != nil {
 			return Issue{}, 0, false, err
 		}
-		issue.ID = formatID(issueIDPrefix, id)
+		issue.IssueNumber = existingIssueNumber
 		issue.FirstSeen = parsedFirstSeen
 		issue.LastSeen = parsedLastSeen
 		issue.EventCount = eventCount + 1
@@ -385,7 +392,27 @@ WHERE id = ? AND project_id = ?`,
 		}
 		issue.Fingerprint = fingerprintValue
 		issue.RepresentativeEvent = evt
+		// Set display ID for existing issue.
+		var existingPrefix string
+		_ = s.db.QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&existingPrefix)
+		if existingPrefix != "" && existingIssueNumber > 0 {
+			issue.ID = formatIssueID(existingPrefix, existingIssueNumber)
+		} else {
+			issue.ID = formatID(issueIDPrefix, id)
+		}
 		return issue, id, regressed, nil
+	}
+
+	// Atomically increment the project's issue counter.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE projects SET issue_counter = issue_counter + 1 WHERE id = ?`, projectID); err != nil {
+		return Issue{}, 0, false, err
+	}
+	var issueNumber int
+	var issuePrefix string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT issue_counter, issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&issueNumber, &issuePrefix); err != nil {
+		return Issue{}, 0, false, err
 	}
 
 	issue = Issue{
@@ -400,6 +427,7 @@ WHERE id = ? AND project_id = ?`,
 		LastSeen:               seenAt,
 		EventCount:             1,
 		RepresentativeEvent:    evt,
+		IssueNumber:            issueNumber,
 	}
 
 	res, err := tx.ExecContext(ctx, `
@@ -415,8 +443,9 @@ INSERT INTO issues (
 	first_seen,
 	last_seen,
 	event_count,
-	representative_event_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	representative_event_json,
+	issue_number
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		projectID,
 		fingerprintValue,
 		material,
@@ -429,6 +458,7 @@ INSERT INTO issues (
 		formatTime(seenAt),
 		1,
 		representative,
+		issueNumber,
 	)
 	if err != nil {
 		return Issue{}, 0, false, err
@@ -438,7 +468,11 @@ INSERT INTO issues (
 	if err != nil {
 		return Issue{}, 0, false, err
 	}
-	issue.ID = formatID(issueIDPrefix, id)
+	if issuePrefix != "" {
+		issue.ID = formatIssueID(issuePrefix, issueNumber)
+	} else {
+		issue.ID = formatID(issueIDPrefix, id)
+	}
 
 	if err := tx.Commit(); err != nil {
 		return Issue{}, 0, false, err
@@ -460,6 +494,8 @@ func scanIssue(scanner interface {
 		resolvedAt        string
 		reopenedAt        string
 		lastRegressedAt   string
+		issueNumber       int
+		issuePrefix       string
 	)
 	if err := scanner.Scan(
 		&id,
@@ -480,6 +516,8 @@ func scanIssue(scanner interface {
 		&issue.EventCount,
 		&representativeRaw,
 		&issue.ProjectSlug,
+		&issueNumber,
+		&issuePrefix,
 	); err != nil {
 		return Issue{}, err
 	}
@@ -502,7 +540,12 @@ func scanIssue(scanner interface {
 	issue.ResolvedAt, _ = parseTime(resolvedAt)
 	issue.ReopenedAt, _ = parseTime(reopenedAt)
 	issue.LastRegressedAt, _ = parseTime(lastRegressedAt)
-	issue.ID = formatID(issueIDPrefix, id)
+	issue.IssueNumber = issueNumber
+	if issuePrefix != "" && issueNumber > 0 {
+		issue.ID = formatIssueID(issuePrefix, issueNumber)
+	} else {
+		issue.ID = formatID(issueIDPrefix, id)
+	}
 	return issue, nil
 }
 
@@ -512,7 +555,7 @@ func (s *Store) MuteIssue(ctx context.Context, issueID string, muteMode string) 
 	if muteMode != "until_regression" && muteMode != "forever" {
 		return Issue{}, fmt.Errorf("invalid mute_mode %q: must be 'until_regression' or 'forever'", muteMode)
 	}
-	rowID, err := parseID(issueIDPrefix, issueID)
+	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {
 		return Issue{}, err
 	}
@@ -537,7 +580,7 @@ UPDATE issues SET status = 'muted', mute_mode = ?, updated_at = CURRENT_TIMESTAM
 
 // UnmuteIssue clears mute status and sets the issue back to unresolved.
 func (s *Store) UnmuteIssue(ctx context.Context, issueID string) (Issue, error) {
-	rowID, err := parseID(issueIDPrefix, issueID)
+	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {
 		return Issue{}, err
 	}

--- a/internal/storage/issues_test.go
+++ b/internal/storage/issues_test.go
@@ -246,9 +246,9 @@ func TestHourlyEventCounts(t *testing.T) {
 		t.Fatalf("persist pe2: %v", err)
 	}
 
-	rowID, err := parseID(issueIDPrefix, issue.ID)
+	rowID, err := store.IssueRowIDByDisplayID(ctx, issue.ID)
 	if err != nil {
-		t.Fatalf("parseID: %v", err)
+		t.Fatalf("IssueRowIDByDisplayID: %v", err)
 	}
 
 	counts, err := store.HourlyEventCounts(ctx, []int64{rowID})

--- a/internal/storage/projects.go
+++ b/internal/storage/projects.go
@@ -3,15 +3,20 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 )
 
 // CreateProject inserts a new project row; returns an error if the slug already exists.
 func (s *Store) CreateProject(ctx context.Context, name, slug string) (Project, error) {
+	prefix, err := s.uniqueIssuePrefix(ctx, slug)
+	if err != nil {
+		return Project{}, err
+	}
 	now := formatTime(time.Now().UTC())
 	res, err := s.db.ExecContext(ctx, `
-INSERT INTO projects (name, slug, status, created_at) VALUES (?, ?, 'active', ?)`,
-		name, slug, now,
+INSERT INTO projects (name, slug, status, issue_prefix, issue_counter, created_at) VALUES (?, ?, 'active', ?, 0, ?)`,
+		name, slug, prefix, now,
 	)
 	if err != nil {
 		return Project{}, err
@@ -20,12 +25,12 @@ INSERT INTO projects (name, slug, status, created_at) VALUES (?, ?, 'active', ?)
 	if err != nil {
 		return Project{}, err
 	}
-	return Project{ID: id, Name: name, Slug: slug, Status: "active", CreatedAt: time.Now().UTC()}, nil
+	return Project{ID: id, Name: name, Slug: slug, Status: "active", IssuePrefix: prefix, CreatedAt: time.Now().UTC()}, nil
 }
 
 // ListProjects returns all projects ordered by id.
 func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, slug, status, created_at FROM projects ORDER BY id ASC`)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects ORDER BY id ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +40,7 @@ func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
 	for rows.Next() {
 		var p Project
 		var createdAt string
-		if err := rows.Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &createdAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &p.IssuePrefix, &p.IssueCounter, &createdAt); err != nil {
 			return nil, err
 		}
 		p.CreatedAt, _ = parseTime(createdAt)
@@ -48,8 +53,8 @@ func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
 func (s *Store) ProjectBySlug(ctx context.Context, slug string) (Project, error) {
 	var p Project
 	var createdAt string
-	err := s.db.QueryRowContext(ctx, `SELECT id, name, slug, status, created_at FROM projects WHERE slug = ?`, slug).
-		Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &createdAt)
+	err := s.db.QueryRowContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects WHERE slug = ?`, slug).
+		Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &p.IssuePrefix, &p.IssueCounter, &createdAt)
 	if err != nil {
 		return Project{}, err
 	}
@@ -78,10 +83,14 @@ func (s *Store) EnsureProjectPending(ctx context.Context, slug string) (Project,
 
 // CreateProjectPending inserts a new project with status=pending.
 func (s *Store) CreateProjectPending(ctx context.Context, slug string) (Project, error) {
+	prefix, err := s.uniqueIssuePrefix(ctx, slug)
+	if err != nil {
+		return Project{}, err
+	}
 	now := formatTime(time.Now().UTC())
 	res, err := s.db.ExecContext(ctx, `
-INSERT INTO projects (name, slug, status, created_at) VALUES (?, ?, 'pending', ?)`,
-		slug, slug, now,
+INSERT INTO projects (name, slug, status, issue_prefix, issue_counter, created_at) VALUES (?, ?, 'pending', ?, 0, ?)`,
+		slug, slug, prefix, now,
 	)
 	if err != nil {
 		return Project{}, err
@@ -90,7 +99,7 @@ INSERT INTO projects (name, slug, status, created_at) VALUES (?, ?, 'pending', ?
 	if err != nil {
 		return Project{}, err
 	}
-	return Project{ID: id, Name: slug, Slug: slug, Status: "pending", CreatedAt: time.Now().UTC()}, nil
+	return Project{ID: id, Name: slug, Slug: slug, Status: "pending", IssuePrefix: prefix, CreatedAt: time.Now().UTC()}, nil
 }
 
 // ApproveProject sets status='active' for the project with the given slug.
@@ -104,4 +113,45 @@ func (s *Store) ApproveProject(ctx context.Context, slug string) error {
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+// uniqueIssuePrefix derives a unique issue prefix from the slug, appending a
+// numeric suffix if the derived prefix is already taken.
+func (s *Store) uniqueIssuePrefix(ctx context.Context, slug string) (string, error) {
+	prefix := deriveIssuePrefix(slug)
+	base := prefix
+	for i := 2; ; i++ {
+		var count int
+		err := s.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM projects WHERE issue_prefix = ?`, prefix).Scan(&count)
+		if err != nil {
+			return "", err
+		}
+		if count == 0 {
+			return prefix, nil
+		}
+		prefix = fmt.Sprintf("%s%d", base, i)
+	}
+}
+
+// IssueRowIDByDisplayID resolves a Jira-style issue ID (e.g. "BW-42") to the
+// database row ID. Falls back to legacy "issue-NNNNNN" format.
+func (s *Store) IssueRowIDByDisplayID(ctx context.Context, displayID string) (int64, error) {
+	prefix, number, err := parseIssueID(displayID)
+	if err != nil {
+		return 0, err
+	}
+	if prefix == "" {
+		// Legacy format: number is the row ID.
+		return int64(number), nil
+	}
+	var rowID int64
+	err = s.db.QueryRowContext(ctx, `
+SELECT i.id FROM issues i
+JOIN projects p ON p.id = i.project_id
+WHERE p.issue_prefix = ? AND i.issue_number = ?`, prefix, number).Scan(&rowID)
+	if err != nil {
+		return 0, err
+	}
+	return rowID, nil
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -246,6 +246,15 @@ func (s *Store) init(ctx context.Context) error {
 	if err := ensureColumn(ctx, tx, "projects", "status", "TEXT NOT NULL DEFAULT 'active'"); err != nil {
 		return err
 	}
+	if err := ensureColumn(ctx, tx, "projects", "issue_prefix", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := ensureColumn(ctx, tx, "projects", "issue_counter", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := ensureColumn(ctx, tx, "issues", "issue_number", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
 
 	// Analytics tables
 	analyticsSchema := []string{
@@ -303,11 +312,101 @@ ON CONFLICT(slug) DO NOTHING`,
 		return err
 	}
 
+	if err := migrateIssuePrefixes(ctx, tx); err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}
 
 	s.defaultProjectID = projectID
+	return nil
+}
+
+// migrateIssuePrefixes assigns issue_prefix to projects that don't have one yet,
+// and assigns sequential issue_number to issues that have issue_number=0.
+func migrateIssuePrefixes(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `SELECT id, slug FROM projects WHERE issue_prefix = ''`)
+	if err != nil {
+		return err
+	}
+	var projects []struct {
+		id   int64
+		slug string
+	}
+	for rows.Next() {
+		var p struct {
+			id   int64
+			slug string
+		}
+		if err := rows.Scan(&p.id, &p.slug); err != nil {
+			rows.Close()
+			return err
+		}
+		projects = append(projects, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	usedPrefixes := make(map[string]bool)
+	// Collect already-assigned prefixes.
+	existingRows, err := tx.QueryContext(ctx, `SELECT issue_prefix FROM projects WHERE issue_prefix != ''`)
+	if err != nil {
+		return err
+	}
+	for existingRows.Next() {
+		var p string
+		if err := existingRows.Scan(&p); err != nil {
+			existingRows.Close()
+			return err
+		}
+		usedPrefixes[p] = true
+	}
+	existingRows.Close()
+
+	for _, p := range projects {
+		prefix := deriveIssuePrefix(p.slug)
+		// Ensure uniqueness by appending digits if needed.
+		base := prefix
+		for i := 2; usedPrefixes[prefix]; i++ {
+			prefix = fmt.Sprintf("%s%d", base, i)
+		}
+		usedPrefixes[prefix] = true
+
+		// Assign sequential numbers to existing issues for this project.
+		issueRows, err := tx.QueryContext(ctx,
+			`SELECT id FROM issues WHERE project_id = ? AND issue_number = 0 ORDER BY id ASC`, p.id)
+		if err != nil {
+			return err
+		}
+		var issueIDs []int64
+		for issueRows.Next() {
+			var id int64
+			if err := issueRows.Scan(&id); err != nil {
+				issueRows.Close()
+				return err
+			}
+			issueIDs = append(issueIDs, id)
+		}
+		issueRows.Close()
+
+		for i, id := range issueIDs {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE issues SET issue_number = ? WHERE id = ?`, i+1, id); err != nil {
+				return err
+			}
+		}
+
+		counter := len(issueIDs)
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE projects SET issue_prefix = ?, issue_counter = ? WHERE id = ?`,
+			prefix, counter, p.id); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -105,7 +105,7 @@ func (s *Store) PersistProcessedEvent(ctx context.Context, processed worker.Proc
 	// isNew is true when the issue was just created (EventCount == 1 and no regression).
 	isNew := issue.EventCount == 1 && !regressed
 
-	eventRow, eventRowID, err := s.insertEvent(ctx, projectID, issueID, regressed, processed)
+	eventRow, eventRowID, err := s.insertEvent(ctx, projectID, issueID, issue.ID, regressed, processed)
 	if err != nil {
 		return Issue{}, Event{}, false, false, err
 	}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -16,6 +16,7 @@ type Store struct {
 // Issue represents a grouped error occurrence.
 type Issue struct {
 	ID                     string
+	IssueNumber            int
 	Fingerprint            string
 	FingerprintMaterial    string
 	FingerprintExplanation []string
@@ -88,11 +89,13 @@ type User struct {
 
 // Project represents a project row.
 type Project struct {
-	ID        int64
-	Name      string
-	Slug      string
-	Status    string
-	CreatedAt time.Time
+	ID           int64
+	Name         string
+	Slug         string
+	Status       string
+	IssuePrefix  string
+	IssueCounter int
+	CreatedAt    time.Time
 }
 
 // Scope constants for API keys.


### PR DESCRIPTION
## Summary
- Issues now use `PREFIX-N` format (e.g. `BW-1`, `MS-42`) derived from project slugs instead of generic `issue-000001`
- Auto-derives prefix from project slug (e.g. `bugbarn-web` → `BW`), enforces uniqueness
- Per-project counter atomically incremented on issue creation
- Migration backfills existing projects/issues with derived prefixes and sequential numbers
- Legacy `issue-NNNNNN` format still works for backward-compatible lookups

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Verify existing issues get correct prefixes after deploy
- [ ] Verify new events create issues with new format
- [ ] Verify resolve/mute/unmute work with new IDs
- [ ] Verify sparklines load correctly