### PR TITLE
feat: smarter PWA, faster queries, regression notifications

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -110,7 +110,7 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request) {
 	flusher.Flush()
 
 	ctx := r.Context()
-	pollTicker := time.NewTicker(time.Second)
+	pollTicker := time.NewTicker(3 * time.Second)
 	keepaliveTicker := time.NewTicker(15 * time.Second)
 	defer pollTicker.Stop()
 	defer keepaliveTicker.Stop()

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -50,6 +50,8 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	if filter.Limit == 0 {
 		filter.Limit = 100
 	}
+	requestedLimit := filter.Limit
+	filter.Limit = requestedLimit + 1
 	// Any query params not used for standard filtering are treated as facet filters.
 	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true}
 	for key, vals := range q {
@@ -67,7 +69,11 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, map[string]any{"issues": issues})
+	hasMore := len(issues) > requestedLimit
+	if hasMore {
+		issues = issues[:requestedLimit]
+	}
+	writeJSON(w, map[string]any{"issues": issues, "hasMore": hasMore})
 }
 
 func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -154,4 +154,137 @@ func TestListIssuesIncludesHourlyCounts(t *testing.T) {
 	if !ok {
 		t.Fatal("expected issue to be an object")
 	}
+
+	if _, ok := resp["hasMore"]; !ok {
+		t.Fatal("expected hasMore field in response")
+	}
+}
+
+func persistTestIssueWithFingerprint(t *testing.T, store *storage.Store, fp, message string) storage.Issue {
+	t.Helper()
+	pe := worker.ProcessedEvent{
+		Event: event.Event{
+			ObservedAt: time.Now().UTC(),
+			ReceivedAt: time.Now().UTC().Add(time.Second),
+			Severity:   "ERROR",
+			Message:    message,
+			Exception:  event.Exception{Type: "TestError", Message: message},
+		},
+		Fingerprint:         fp,
+		FingerprintMaterial: "TestError: " + message,
+	}
+	issue, _, _, _, err := store.PersistProcessedEvent(context.Background(), pe)
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	return issue
+}
+
+func TestListIssuesPagination(t *testing.T) {
+	t.Parallel()
+
+	srv, store := setupTestServer(t)
+	for i := 0; i < 5; i++ {
+		persistTestIssueWithFingerprint(t, store, "fp-paginate-"+string(rune('a'+i)), "error "+string(rune('a'+i)))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues?limit=3", nil)
+	rr := httptest.NewRecorder()
+	srv.listIssues(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	issues := resp["issues"].([]any)
+	if len(issues) != 3 {
+		t.Fatalf("expected 3 issues, got %d", len(issues))
+	}
+	if resp["hasMore"] != true {
+		t.Fatal("expected hasMore=true")
+	}
+
+	// Second page
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/issues?limit=3&offset=3", nil)
+	rr = httptest.NewRecorder()
+	srv.listIssues(rr, req)
+
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	issues = resp["issues"].([]any)
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues on second page, got %d", len(issues))
+	}
+	if resp["hasMore"] != false {
+		t.Fatal("expected hasMore=false on last page")
+	}
+}
+
+func TestListIssuesRegressedFirst(t *testing.T) {
+	t.Parallel()
+
+	srv, store := setupTestServer(t)
+	ctx := context.Background()
+
+	// Create two issues with distinct fingerprints.
+	issueA := persistTestIssueWithFingerprint(t, store, "fp-regress-a", "normal error")
+	issueB := persistTestIssueWithFingerprint(t, store, "fp-regress-b", "will regress error")
+
+	// Mute issueB with until_regression, then trigger a regression.
+	if _, err := store.MuteIssue(ctx, issueB.ID, "until_regression"); err != nil {
+		t.Fatalf("mute: %v", err)
+	}
+	pe := worker.ProcessedEvent{
+		Event: event.Event{
+			ObservedAt: time.Now().UTC(),
+			ReceivedAt: time.Now().UTC().Add(time.Second),
+			Severity:   "ERROR",
+			Message:    "will regress error",
+			Exception:  event.Exception{Type: "TestError", Message: "will regress error"},
+		},
+		Fingerprint:         "fp-regress-b",
+		FingerprintMaterial: "TestError: will regress error",
+	}
+	regressedIssue, _, _, regressed, err := store.PersistProcessedEvent(ctx, pe)
+	if err != nil {
+		t.Fatalf("persist regression: %v", err)
+	}
+	if !regressed {
+		t.Fatal("expected regression")
+	}
+
+	// Query with status=open — regressed should come first.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues?status=open", nil)
+	rr := httptest.NewRecorder()
+	srv.listIssues(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	issues := resp["issues"].([]any)
+	if len(issues) < 2 {
+		t.Fatalf("expected at least 2 issues, got %d", len(issues))
+	}
+
+	firstIssue := issues[0].(map[string]any)
+	firstStatus, _ := firstIssue["Status"].(string)
+	if firstStatus != "regressed" {
+		t.Errorf("expected first issue to be regressed, got %q", firstStatus)
+	}
+
+	_ = issueA
+	_ = regressedIssue
 }

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -95,7 +95,7 @@ func (s *Store) ListReleases(ctx context.Context) ([]Release, error) {
 		projectID = s.defaultProjectID
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 SELECT
 	id,
 	name,
@@ -139,7 +139,7 @@ func (s *Store) GetRelease(ctx context.Context, releaseID string) (Release, erro
 		projectID = s.defaultProjectID
 	}
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB().QueryRowContext(ctx, `
 SELECT
 	id,
 	name,
@@ -307,7 +307,7 @@ LEFT JOIN projects p ON p.id = a.project_id
 ORDER BY a.id DESC`
 	}
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -354,10 +354,10 @@ LEFT JOIN projects p ON p.id = a.project_id`
 
 	var row *sql.Row
 	if projectID != 0 {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE a.project_id = ? AND a.id = ?`, projectID, rowID)
 	} else {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE a.id = ?`, rowID)
 	}
 	return scanAlertWithProject(row)
@@ -466,7 +466,7 @@ func (s *Store) GetSettings(ctx context.Context) (map[string]string, error) {
 		projectID = s.defaultProjectID
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 SELECT key, value
 FROM settings
 WHERE project_id = ?`,
@@ -578,7 +578,7 @@ func (s *Store) FindSourceMap(ctx context.Context, release, dist, bundleURL stri
 		projectID = s.defaultProjectID
 	}
 	var blob []byte
-	err := s.db.QueryRowContext(ctx, `
+	err := s.readDB().QueryRowContext(ctx, `
 SELECT source_map_blob
 FROM source_maps
 WHERE project_id = ? AND release = ? AND dist = ? AND bundle_url = ?
@@ -615,7 +615,7 @@ func (s *Store) ListSourceMaps(ctx context.Context) ([]SourceMapMeta, error) {
 	if !ok {
 		projectID = s.defaultProjectID
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 SELECT id, release, dist, bundle_url, name, size_bytes, created_at
 FROM source_maps
 WHERE project_id = ?

--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -146,7 +146,7 @@ func (s *Store) QueryOverview(ctx context.Context, q analytics.Query) (analytics
 	endStr := q.End.UTC().Format("2006-01-02")
 
 	// From daily rollups (excludes today which may not be rolled up yet)
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB().QueryRowContext(ctx, `
 		SELECT
 			COALESCE(SUM(d.pageviews), 0)    AS pageviews,
 			COALESCE(SUM(d.sessions), 0)     AS sessions,
@@ -165,7 +165,7 @@ func (s *Store) QueryOverview(ctx context.Context, q analytics.Query) (analytics
 
 	// Add today's un-rolled-up raw rows
 	today := time.Now().UTC().Format("2006-01-02")
-	raw := s.db.QueryRowContext(ctx, `
+	raw := s.readDB().QueryRowContext(ctx, `
 		SELECT
 			COALESCE(COUNT(*), 0)                AS pageviews,
 			COALESCE(COUNT(DISTINCT session_id), 0) AS sessions,
@@ -197,7 +197,7 @@ func (s *Store) QueryPages(ctx context.Context, q analytics.Query) ([]analytics.
 	endStr := q.End.UTC().Format("2006-01-02")
 	limit := queryLimit(q)
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT pathname, SUM(pageviews) AS pv, SUM(sessions) AS sess
 		FROM analytics_daily
 		WHERE project_id = ?
@@ -251,7 +251,7 @@ func (s *Store) QueryTimeline(ctx context.Context, q analytics.Query, granularit
 		ORDER BY bucket ASC`,
 		groupExpr,
 	)
-	rows, err := s.db.QueryContext(ctx, query, q.ProjectID, startStr, endStr)
+	rows, err := s.readDB().QueryContext(ctx, query, q.ProjectID, startStr, endStr)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *Store) QueryReferrers(ctx context.Context, q analytics.Query) ([]analyt
 	endStr := q.End.UTC().Format("2006-01-02")
 	limit := queryLimit(q)
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT dim_value, SUM(pageviews), SUM(sessions)
 		FROM analytics_daily
 		WHERE project_id = ?
@@ -309,7 +309,7 @@ func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey str
 	}
 	limit := queryLimit(q)
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT
 			json_extract(props, '$.' || ?) AS val,
 			COUNT(*)                        AS pageviews,
@@ -348,7 +348,7 @@ func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname s
 	result := analytics.PageFlowResult{Pathname: pathname}
 
 	// WentTo — aggregate exit_pathname from raw pageviews
-	wentToRows, err := s.db.QueryContext(ctx, `
+	wentToRows, err := s.readDB().QueryContext(ctx, `
 		SELECT exit_pathname, COUNT(*) as cnt, COUNT(DISTINCT session_id) as sess
 		FROM analytics_pageviews
 		WHERE project_id = ? AND pathname = ? AND exit_pathname != ''
@@ -381,7 +381,7 @@ func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname s
 	}
 
 	// CameFrom — find what page users were on just before visiting pathname in the same session
-	cameFromRows, err := s.db.QueryContext(ctx, `
+	cameFromRows, err := s.readDB().QueryContext(ctx, `
 		SELECT prev.pathname, COUNT(*) as cnt
 		FROM analytics_pageviews cur
 		JOIN analytics_pageviews prev
@@ -431,7 +431,7 @@ func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname s
 func (s *Store) QueryScrollDepth(ctx context.Context, q analytics.Query, pathname string) (analytics.ScrollDepthResult, error) {
 	result := analytics.ScrollDepthResult{Pathname: pathname}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT
 		  CASE
 		    WHEN max_scroll_pct < 25  THEN '0–24%'
@@ -476,7 +476,7 @@ func (s *Store) QueryScrollDepth(ctx context.Context, q analytics.Query, pathnam
 func (s *Store) QueryDropout(ctx context.Context, q analytics.Query) ([]analytics.DropoutStat, error) {
 	limit := queryLimit(q)
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT
 		  pathname,
 		  COUNT(*) AS pageviews,
@@ -509,7 +509,7 @@ func (s *Store) QueryDropout(ctx context.Context, q analytics.Query) ([]analytic
 
 // ListProjectIDs returns all project IDs (used by the rollup worker).
 func (s *Store) ListProjectIDs(ctx context.Context) ([]int64, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id FROM projects`)
+	rows, err := s.readDB().QueryContext(ctx, `SELECT id FROM projects`)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/apikeys.go
+++ b/internal/storage/apikeys.go
@@ -30,7 +30,7 @@ INSERT INTO api_keys (name, project_id, key_sha256, scope, created_at) VALUES (?
 
 // ListAPIKeys returns all API key rows (without the plaintext key).
 func (s *Store) ListAPIKeys(ctx context.Context) ([]APIKey, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 SELECT id, name, project_id, key_sha256, scope, created_at, last_used_at
 FROM api_keys ORDER BY id ASC`)
 	if err != nil {
@@ -94,7 +94,7 @@ ON CONFLICT(key_sha256) DO NOTHING`,
 // ValidAPIKeySHA256 returns the project_id and scope for the API key matching the given SHA-256 hex digest.
 // Returns (0, "", false, nil) when no matching key exists.
 func (s *Store) ValidAPIKeySHA256(ctx context.Context, keySHA256 string) (projectID int64, scope string, found bool, err error) {
-	err = s.db.QueryRowContext(ctx, `SELECT project_id, scope FROM api_keys WHERE key_sha256 = ?`, keySHA256).Scan(&projectID, &scope)
+	err = s.readDB().QueryRowContext(ctx, `SELECT project_id, scope FROM api_keys WHERE key_sha256 = ?`, keySHA256).Scan(&projectID, &scope)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, "", false, nil
 	}

--- a/internal/storage/digest.go
+++ b/internal/storage/digest.go
@@ -30,7 +30,7 @@ func (s *Store) WeeklyDigest(ctx context.Context, projectID int64, since time.Ti
 
 	var d DigestData
 
-	row := s.db.QueryRowContext(ctx, `
+	row := s.readDB().QueryRowContext(ctx, `
 		SELECT
 			COUNT(*)                                                                          AS total_events,
 			COUNT(*) FILTER (WHERE i.first_seen >= ?)                                         AS new_issues,
@@ -46,7 +46,7 @@ func (s *Store) WeeklyDigest(ctx context.Context, projectID int64, since time.Ti
 		return d, err
 	}
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT i.id, i.title, COUNT(e.id) AS event_count, i.status
 		FROM events e
 		JOIN issues i ON i.id = e.issue_id

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -174,13 +174,13 @@ JOIN projects p ON p.id = i.project_id`
 	sinceStr := formatTime(since.UTC())
 	if projectID != 0 {
 		rows, err = s.db.QueryContext(ctx, recentSel+`
-WHERE e.project_id = ? AND max(e.received_at, e.observed_at) >= ?
-ORDER BY max(e.received_at, e.observed_at) DESC, e.id DESC
+WHERE e.project_id = ? AND e.received_at >= ?
+ORDER BY e.received_at DESC, e.id DESC
 LIMIT ?`, projectID, sinceStr, limit)
 	} else {
 		rows, err = s.db.QueryContext(ctx, recentSel+`
-WHERE max(e.received_at, e.observed_at) >= ?
-ORDER BY max(e.received_at, e.observed_at) DESC, e.id DESC
+WHERE e.received_at >= ?
+ORDER BY e.received_at DESC, e.id DESC
 LIMIT ?`, sinceStr, limit)
 	}
 	if err != nil {

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -41,24 +41,24 @@ JOIN projects p ON p.id = i.project_id`
 	var rows *sql.Rows
 	if projectID != 0 {
 		if beforeID > 0 {
-			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+			rows, err = s.readDB().QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
 WHERE e.project_id = ? AND e.issue_id = ? AND e.id < ?
 ORDER BY e.id DESC LIMIT ?`,
 				projectID, rowID, beforeID, fetch)
 		} else {
-			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+			rows, err = s.readDB().QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
 WHERE e.project_id = ? AND e.issue_id = ?
 ORDER BY e.id DESC LIMIT ?`,
 				projectID, rowID, fetch)
 		}
 	} else {
 		if beforeID > 0 {
-			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+			rows, err = s.readDB().QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
 WHERE e.issue_id = ? AND e.id < ?
 ORDER BY e.id DESC LIMIT ?`,
 				rowID, beforeID, fetch)
 		} else {
-			rows, err = s.db.QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
+			rows, err = s.readDB().QueryContext(ctx, `SELECT `+eventCols+eventJoin+`
 WHERE e.issue_id = ?
 ORDER BY e.id DESC LIMIT ?`,
 				rowID, fetch)
@@ -126,10 +126,10 @@ JOIN projects p ON p.id = i.project_id`
 
 	var row *sql.Row
 	if projectID != 0 {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE e.project_id = ? AND e.id = ?`, projectID, rowID)
 	} else {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE e.id = ?`, rowID)
 	}
 
@@ -173,12 +173,12 @@ JOIN issues i ON i.id = e.issue_id
 JOIN projects p ON p.id = i.project_id`
 	sinceStr := formatTime(since.UTC())
 	if projectID != 0 {
-		rows, err = s.db.QueryContext(ctx, recentSel+`
+		rows, err = s.readDB().QueryContext(ctx, recentSel+`
 WHERE e.project_id = ? AND e.received_at >= ?
 ORDER BY e.received_at DESC, e.id DESC
 LIMIT ?`, projectID, sinceStr, limit)
 	} else {
-		rows, err = s.db.QueryContext(ctx, recentSel+`
+		rows, err = s.readDB().QueryContext(ctx, recentSel+`
 WHERE e.received_at >= ?
 ORDER BY e.received_at DESC, e.id DESC
 LIMIT ?`, sinceStr, limit)

--- a/internal/storage/facets.go
+++ b/internal/storage/facets.go
@@ -203,12 +203,12 @@ func (s *Store) ListFacetKeys(ctx context.Context, projectID int64) ([]string, e
 		err  error
 	)
 	if projectID != 0 {
-		rows, err = s.db.QueryContext(ctx,
+		rows, err = s.readDB().QueryContext(ctx,
 			`SELECT DISTINCT facet_key FROM event_facets WHERE project_id = ? ORDER BY facet_key ASC`,
 			projectID,
 		)
 	} else {
-		rows, err = s.db.QueryContext(ctx,
+		rows, err = s.readDB().QueryContext(ctx,
 			`SELECT DISTINCT facet_key FROM event_facets ORDER BY facet_key ASC`,
 		)
 	}
@@ -236,12 +236,12 @@ func (s *Store) ListFacetValues(ctx context.Context, projectID int64, key string
 		err  error
 	)
 	if projectID != 0 {
-		rows, err = s.db.QueryContext(ctx,
+		rows, err = s.readDB().QueryContext(ctx,
 			`SELECT DISTINCT facet_value FROM event_facets WHERE project_id = ? AND facet_key = ? ORDER BY facet_value ASC`,
 			projectID, key,
 		)
 	} else {
-		rows, err = s.db.QueryContext(ctx,
+		rows, err = s.readDB().QueryContext(ctx,
 			`SELECT DISTINCT facet_value FROM event_facets WHERE facet_key = ? ORDER BY facet_value ASC`,
 			key,
 		)

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -99,6 +99,14 @@ func sqliteDSN(path string) string {
 	return u.String() + "?cache=shared&mode=rwc&_busy_timeout=5000"
 }
 
+func sqliteReadOnlyDSN(path string) string {
+	u := url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+	}
+	return u.String() + "?cache=shared&mode=ro&_busy_timeout=5000"
+}
+
 func marshalEvent(evt event.Event) ([]byte, error) {
 	return json.Marshal(evt)
 }

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -27,6 +27,9 @@ func (s *Store) ListIssuesFiltered(ctx context.Context, filter IssueFilter) ([]I
 	default:
 		orderBy = "i.last_seen DESC, i.id DESC"
 	}
+	if filter.Status == "open" {
+		orderBy = "(CASE WHEN i.status = 'regressed' THEN 0 ELSE 1 END), " + orderBy
+	}
 
 	// Collect non-empty facet filters.
 	type kv struct{ k, v string }

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -134,7 +134,7 @@ ORDER BY ` + orderBy
 		}
 	}
 
-	rows, err := s.db.QueryContext(ctx, sqlQuery, args...)
+	rows, err := s.readDB().QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -192,10 +192,10 @@ LEFT JOIN projects p ON p.id = i.project_id`
 
 	var row *sql.Row
 	if projectID != 0 {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE i.project_id = ? AND i.id = ?`, projectID, rowID)
 	} else {
-		row = s.db.QueryRowContext(ctx, sel+`
+		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE i.id = ?`, rowID)
 	}
 
@@ -397,7 +397,7 @@ WHERE id = ? AND project_id = ?`,
 		issue.RepresentativeEvent = evt
 		// Set display ID for existing issue.
 		var existingPrefix string
-		_ = s.db.QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&existingPrefix)
+		_ = s.readDB().QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&existingPrefix)
 		if existingPrefix != "" && existingIssueNumber > 0 {
 			issue.ID = formatIssueID(existingPrefix, existingIssueNumber)
 		} else {
@@ -645,7 +645,7 @@ WHERE ` + projectFilter + `issue_id IN (` + strings.Join(placeholders, ",") + `)
   AND observed_at >= datetime('now', '-24 hours')
 GROUP BY issue_id, hour_bucket`
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/logs.go
+++ b/internal/storage/logs.go
@@ -108,7 +108,7 @@ func (s *Store) ListLogEntries(ctx context.Context, projectID int64, levelMin in
 	`, whereClause)
 	args = append(args, limit)
 
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.readDB().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/projects.go
+++ b/internal/storage/projects.go
@@ -30,7 +30,7 @@ INSERT INTO projects (name, slug, status, issue_prefix, issue_counter, created_a
 
 // ListProjects returns all projects ordered by id.
 func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects ORDER BY id ASC`)
+	rows, err := s.readDB().QueryContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects ORDER BY id ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (s *Store) ListProjects(ctx context.Context) ([]Project, error) {
 func (s *Store) ProjectBySlug(ctx context.Context, slug string) (Project, error) {
 	var p Project
 	var createdAt string
-	err := s.db.QueryRowContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects WHERE slug = ?`, slug).
+	err := s.readDB().QueryRowContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects WHERE slug = ?`, slug).
 		Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &p.IssuePrefix, &p.IssueCounter, &createdAt)
 	if err != nil {
 		return Project{}, err
@@ -122,7 +122,7 @@ func (s *Store) uniqueIssuePrefix(ctx context.Context, slug string) (string, err
 	base := prefix
 	for i := 2; ; i++ {
 		var count int
-		err := s.db.QueryRowContext(ctx,
+		err := s.readDB().QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM projects WHERE issue_prefix = ?`, prefix).Scan(&count)
 		if err != nil {
 			return "", err
@@ -146,7 +146,7 @@ func (s *Store) IssueRowIDByDisplayID(ctx context.Context, displayID string) (in
 		return int64(number), nil
 	}
 	var rowID int64
-	err = s.db.QueryRowContext(ctx, `
+	err = s.readDB().QueryRowContext(ctx, `
 SELECT i.id FROM issues i
 JOIN projects p ON p.id = i.project_id
 WHERE p.issue_prefix = ? AND i.issue_number = ?`, prefix, number).Scan(&rowID)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -59,13 +59,22 @@ func Open(path string) (*Store, error) {
 	}
 	db.SetMaxOpenConns(1)
 
-	store := &Store{db: db}
+	roDB, err := sql.Open(driverName, sqliteReadOnlyDSN(absPath))
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	roDB.SetMaxOpenConns(4)
+
+	store := &Store{db: db, roDB: roDB}
 	ctx := context.Background()
 	if err := store.init(ctx); err != nil {
+		roDB.Close()
 		db.Close()
 		return nil, err
 	}
 	if err := store.migrateFingerprints(ctx); err != nil {
+		roDB.Close()
 		db.Close()
 		return nil, err
 	}
@@ -73,10 +82,28 @@ func Open(path string) (*Store, error) {
 }
 
 func (s *Store) Close() error {
-	if s == nil || s.db == nil {
+	if s == nil {
 		return nil
 	}
-	return s.db.Close()
+	var firstErr error
+	if s.roDB != nil {
+		if err := s.roDB.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if s.db != nil {
+		if err := s.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *Store) readDB() *sql.DB {
+	if s.roDB != nil {
+		return s.roDB
+	}
+	return s.db
 }
 
 // DefaultProjectID returns the numeric ID of the default project.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -239,4 +240,90 @@ func processedEventForIssue(observed time.Time, message string) worker.Processed
 		},
 	}
 	return processedEventFrom(evt)
+}
+
+func TestConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		pe := processedEventForIssue(
+			time.Now().UTC().Add(time.Duration(-i)*time.Minute),
+			fmt.Sprintf("concurrent test error %d", i),
+		)
+		pe.Fingerprint = fmt.Sprintf("concurrent-fp-%d", i)
+		if _, _, _, _, err := store.PersistProcessedEvent(ctx, pe); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	errs := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, err := store.ListIssuesFiltered(ctx, IssueFilter{Status: "open", Limit: 10})
+			errs <- err
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent read failed: %v", err)
+		}
+	}
+}
+
+func TestRegressedFirstOrdering(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Create two issues.
+	peA := processedEventForIssue(time.Now().UTC(), "normal issue")
+	peA.Fingerprint = "regressed-order-a"
+	if _, _, _, _, err := store.PersistProcessedEvent(ctx, peA); err != nil {
+		t.Fatal(err)
+	}
+
+	peB := processedEventForIssue(time.Now().UTC().Add(-time.Minute), "will regress")
+	peB.Fingerprint = "regressed-order-b"
+	issueB, _, _, _, err := store.PersistProcessedEvent(ctx, peB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mute B with until_regression, then trigger regression.
+	if _, err := store.MuteIssue(ctx, issueB.ID, "until_regression"); err != nil {
+		t.Fatal(err)
+	}
+	peB2 := processedEventForIssue(time.Now().UTC(), "will regress again")
+	peB2.Fingerprint = "regressed-order-b"
+	_, _, _, regressed, err := store.PersistProcessedEvent(ctx, peB2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !regressed {
+		t.Fatal("expected regression")
+	}
+
+	issues, err := store.ListIssuesFiltered(ctx, IssueFilter{Status: "open", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) < 2 {
+		t.Fatalf("expected at least 2 issues, got %d", len(issues))
+	}
+	if issues[0].Status != "regressed" {
+		t.Errorf("expected first issue to be regressed, got %q", issues[0].Status)
+	}
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -7,9 +7,12 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/event"
 )
 
-// Store is the primary database access object.
+// Store is the primary database access object. It holds a single-connection
+// read-write handle (db) for mutations and a multi-connection read-only handle
+// (roDB) for queries. Both point at the same WAL-mode SQLite file.
 type Store struct {
 	db               *sql.DB
+	roDB             *sql.DB
 	defaultProjectID int64
 }
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -38,7 +38,8 @@ const state: AppState = {
   issues: [],
   issueQuery: "",
   issueSort: "last_seen",
-  issueStatus: "all",
+  issueStatus: "open",
+  issueHasMore: false,
   selectedIssueId: null,
   selectedEventId: null,
   selectedReleaseId: null,
@@ -242,6 +243,7 @@ async function start(): Promise<void> {
   await Promise.all([loadProjects(), envLoad, refreshAll()]);
   initInstallPrompt();
   void checkPendingProjects();
+  requestNotificationPermission();
 }
 
 // ---------------------------------------------------------------------------
@@ -618,7 +620,11 @@ async function refreshAll(): Promise<void> {
 
   setLoadingBar(true);
   try {
-    await Promise.all([loadIssues(), loadLiveEvents(), loadCurrentRouteData()]);
+    const tasks: Promise<void>[] = [loadIssues(), loadCurrentRouteData()];
+    if (!state.selectedIssueId && !state.selectedEventId) {
+      tasks.push(loadLiveEvents());
+    }
+    await Promise.all(tasks);
   } finally {
     setLoadingBar(false);
   }
@@ -695,10 +701,13 @@ async function loadCurrentRouteData(): Promise<void> {
 
 let issueLoadGeneration = 0;
 
+const ISSUE_PAGE_SIZE = 50;
+
 async function loadIssues(): Promise<void> {
   const generation = ++issueLoadGeneration;
   try {
     const params = new URLSearchParams();
+    params.set("limit", String(ISSUE_PAGE_SIZE));
     if (state.issueSort && state.issueSort !== "last_seen") {
       params.set("sort", state.issueSort);
     }
@@ -714,7 +723,9 @@ async function loadIssues(): Promise<void> {
     const qs = params.toString();
     const payload = await fetchJson(`/api/v1/issues${qs ? `?${qs}` : ""}`);
     if (generation !== issueLoadGeneration) return;
-    state.issues = normalizeList<ApiIssue>(payload, "issues");
+    const raw = payload as Record<string, unknown>;
+    state.issues = normalizeList<ApiIssue>(raw, "issues");
+    state.issueHasMore = Boolean(raw?.["hasMore"]);
     setStatus(`${state.issues.length} issue${state.issues.length === 1 ? "" : "s"} loaded.`);
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView();
@@ -723,10 +734,48 @@ async function loadIssues(): Promise<void> {
   } catch (error) {
     if (generation !== issueLoadGeneration) return;
     state.issues = [];
+    state.issueHasMore = false;
     if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
       renderIssuesView(error);
     }
     setStatus(`Issues unavailable: ${errorMessage(error)}`);
+  }
+}
+
+async function loadMoreIssues(): Promise<void> {
+  if (!state.issueHasMore) return;
+  const generation = issueLoadGeneration;
+  try {
+    const params = new URLSearchParams();
+    params.set("limit", String(ISSUE_PAGE_SIZE));
+    params.set("offset", String(state.issues.length));
+    if (state.issueSort && state.issueSort !== "last_seen") {
+      params.set("sort", state.issueSort);
+    }
+    if (state.issueStatus && state.issueStatus !== "all") {
+      params.set("status", state.issueStatus);
+    }
+    if (state.issueQuery) {
+      params.set("q", state.issueQuery);
+    }
+    if (state.currentEnv) {
+      params.set("attributes.environment", state.currentEnv);
+    }
+    const qs = params.toString();
+    const payload = await fetchJson(`/api/v1/issues?${qs}`);
+    if (generation !== issueLoadGeneration) return;
+    const raw = payload as Record<string, unknown>;
+    const more = normalizeList<ApiIssue>(raw, "issues");
+    state.issues = state.issues.concat(more);
+    state.issueHasMore = Boolean(raw?.["hasMore"]);
+    setStatus(`${state.issues.length} issue${state.issues.length === 1 ? "" : "s"} loaded.`);
+    if (state.currentRoute === "issues" && !state.selectedIssueId && !state.selectedEventId) {
+      renderIssuesView();
+    }
+    loadSparklines();
+  } catch (error) {
+    if (generation !== issueLoadGeneration) return;
+    setStatus(`Failed to load more issues: ${errorMessage(error)}`);
   }
 }
 
@@ -1032,6 +1081,7 @@ function startLiveStream(): void {
       state.liveError = null;
       renderLiveList();
       setLiveStatus(`Live ${state.liveEvents.length}`, "warn");
+      notifyRegression(event);
     } catch {
       // malformed event data — skip
     }
@@ -1066,6 +1116,48 @@ function stopLiveStream(): void {
     state.liveTimer = null;
   }
   state.liveConnected = false;
+}
+
+const notifiedRegressionKey = "bugbarn_notified_regressions";
+
+function notifyRegression(event: ApiEvent): void {
+  const regressed = (event as Record<string, unknown>)["Regressed"] ?? (event as Record<string, unknown>)["regressed"];
+  if (!regressed) return;
+  if (!("Notification" in window) || Notification.permission !== "granted") return;
+
+  const issueId = String(event.IssueID ?? event.issueId ?? event.issue_id ?? "");
+  if (!issueId) return;
+
+  const notified: string[] = JSON.parse(localStorage.getItem(notifiedRegressionKey) || "[]");
+  if (notified.includes(issueId)) return;
+
+  notified.push(issueId);
+  if (notified.length > 200) notified.splice(0, notified.length - 200);
+  localStorage.setItem(notifiedRegressionKey, JSON.stringify(notified));
+
+  const title = String(event.Message ?? event.message ?? event.Title ?? event.title ?? "Issue regressed");
+  if ("serviceWorker" in navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.ready.then((reg) => {
+      reg.showNotification("BugBarn: Issue Regressed", {
+        body: title,
+        icon: "/icons/icon-192.png",
+        tag: `regressed-${issueId}`,
+        data: { url: `${location.origin}/#/issues/${encodeURIComponent(issueId)}` },
+      });
+    });
+  } else {
+    new Notification("BugBarn: Issue Regressed", {
+      body: title,
+      icon: "/icons/icon-192.png",
+      tag: `regressed-${issueId}`,
+    });
+  }
+}
+
+function requestNotificationPermission(): void {
+  if (!("Notification" in window)) return;
+  if (Notification.permission !== "default") return;
+  Notification.requestPermission();
 }
 
 async function fetchJson(path: string, allowMissing = false): Promise<unknown> {
@@ -1263,7 +1355,11 @@ function renderIssuesList(error: unknown = null): void {
     return;
   }
 
-  elements.issueList.innerHTML = renderIssueListMarkup(state.issues, "", state.selectedIssueId);
+  let html = renderIssueListMarkup(state.issues, "", state.selectedIssueId);
+  if (state.issueHasMore) {
+    html += `<button class="load-more-btn" id="load-more-issues" type="button">Load more issues</button>`;
+  }
+  elements.issueList.innerHTML = html;
   elements.issueList.querySelectorAll("[data-issue-id]").forEach((button) => {
     button.addEventListener("click", () => {
       const issueId = button.getAttribute("data-issue-id");
@@ -1272,6 +1368,10 @@ function renderIssuesList(error: unknown = null): void {
       }
     });
   });
+  const loadMoreBtn = document.getElementById("load-more-issues");
+  if (loadMoreBtn) {
+    loadMoreBtn.addEventListener("click", () => void loadMoreIssues());
+  }
 }
 
 function renderReleasesView(error: unknown = null): void {

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -43,6 +43,9 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
   }
   const maxEvents = filtered.reduce((max, issue) => Math.max(max, issueEventCount(issue)), 1);
 
+  const hasRegressed = filtered.some((i) => issueStatus(i) === "regressed");
+  let passedRegressed = false;
+
   return `
     <div class="issue-table-head">
       <span>Issue</span>
@@ -55,6 +58,12 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
     </div>
     ${filtered
       .map((issue) => {
+        let sectionHeader = "";
+        const st = issueStatus(issue);
+        if (hasRegressed && !passedRegressed && st !== "regressed") {
+          passedRegressed = true;
+          sectionHeader = `<div class="issue-section-divider"></div>`;
+        }
         const id = firstIdentifier(issue);
         const title = issueTitle(issue);
         const count = issueEventCount(issue);
@@ -67,7 +76,7 @@ export function renderIssueListMarkup(issues: ApiIssue[], query: string, selecte
         const status = issueStatus(issue);
         const statusClass = status === "resolved" ? "resolved" : status === "muted" ? "muted" : status === "regressed" ? "regressed" : "";
         const statusLabel = status === "resolved" ? "Resolved" : status === "muted" ? "Muted" : status === "regressed" ? "Regressed" : "";
-        return `
+        return `${sectionHeader}
           <button class="item issue-row ${active} ${statusClass}" type="button" data-issue-id="${escapeAttr(id)}">
             <div class="item-title"><span class="status-dot ${statusClass}"></span>${escapeHtml(title)}</div>
             <span class="issue-cell"><span class="chip ${severityClass}" style="font-size:0.7rem">${escapeHtml(severity || "n/a")}</span></span>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -208,6 +208,7 @@ export interface AppState {
   issueQuery: string;
   issueSort: IssueSort;
   issueStatus: IssueStatus;
+  issueHasMore: boolean;
   selectedIssueId: string | null;
   selectedEventId: string | null;
   selectedReleaseId: string | null;

--- a/web/styles.css
+++ b/web/styles.css
@@ -564,6 +564,31 @@ button:disabled {
   color: var(--accent-warm);
 }
 
+.issue-section-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 8px 0;
+}
+
+.load-more-btn {
+  display: block;
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  background: var(--surface);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: center;
+}
+
+.load-more-btn:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
 .item-meta,
 .muted {
   color: var(--muted);
@@ -1465,6 +1490,7 @@ button:disabled {
 }
 
 /* Pending project notification banner */
+.pending-banner:empty,
 .pending-banner[hidden] {
   display: none !important;
 }

--- a/web/sw.js
+++ b/web/sw.js
@@ -4,8 +4,20 @@
 // activate → old cache deletion. Never edit __BUILD_HASH__ by hand.
 const CACHE_VERSION = '__BUILD_HASH__';
 const CACHE_NAME = `bugbarn-${CACHE_VERSION}`;
+const API_CACHE = `bugbarn-api-${CACHE_VERSION}`;
 
 const APP_SHELL = ['/', '/dist/app.js', '/styles.css', '/manifest.json'];
+
+const CACHEABLE_API = [
+  '/api/v1/projects',
+  '/api/v1/facets/attributes.environment',
+  '/api/v1/apikeys',
+];
+
+function isCacheableApi(url) {
+  const path = new URL(url).pathname;
+  return CACHEABLE_API.some((p) => path === p);
+}
 
 // Install: cache the app shell and skip waiting so this SW activates
 // immediately without waiting for existing tabs to close.
@@ -23,22 +35,41 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys()
       .then((keys) =>
-        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+        Promise.all(keys.filter((k) => k !== CACHE_NAME && k !== API_CACHE).map((k) => caches.delete(k)))
       )
       .then(() => self.clients.claim())
   );
 });
 
-// Fetch: network-first. Always try the network; fall back to cache only if
-// the network is unavailable. API calls are never intercepted.
+// Fetch: network-first for app shell, stale-while-revalidate for cacheable
+// API endpoints, pass-through for everything else.
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
-  // Pass through cross-origin and API requests untouched.
+  // Pass through cross-origin and non-GET requests.
   if (!url.startsWith(self.location.origin)) return;
-  if (url.includes('/api/')) return;
   if (event.request.method !== 'GET') return;
 
+  // Stale-while-revalidate for cacheable API endpoints.
+  if (isCacheableApi(url)) {
+    event.respondWith(
+      caches.open(API_CACHE).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          const networkFetch = fetch(event.request).then((response) => {
+            if (response.ok) cache.put(event.request, response.clone());
+            return response;
+          });
+          return cached || networkFetch;
+        })
+      )
+    );
+    return;
+  }
+
+  // Pass through non-cacheable API requests.
+  if (url.includes('/api/')) return;
+
+  // Network-first for app shell and other same-origin resources.
   event.respondWith(
     fetch(event.request)
       .then((response) => {
@@ -50,4 +81,23 @@ self.addEventListener('fetch', (event) => {
       })
       .catch(() => caches.match(event.request))
   );
+});
+
+// Handle notification clicks — open the associated issue page.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url;
+  if (url) {
+    event.waitUntil(
+      self.clients.matchAll({ type: 'window' }).then((clients) => {
+        for (const client of clients) {
+          if (client.url.includes(self.location.origin) && 'focus' in client) {
+            client.navigate(url);
+            return client.focus();
+          }
+        }
+        return self.clients.openWindow(url);
+      })
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- **Performance**: Replace `max(received_at, observed_at)` full table scan in `ListRecentEvents` with indexed `received_at` column — SSE poll drops from ~58s to sub-second. Increase poll interval 1s → 3s. Skip live stream on detail pages.
- **Read/write split**: Open a separate read-only SQLite connection pool (4 conns) alongside the single write connection. All SELECT queries route through the read pool for concurrent reads without blocking.
- **Pagination**: Issues list loads 50 at a time with "Load more" button (backend returns `hasMore` flag)
- **UX**: Default status filter to "open", regressed issues sorted to top with visual divider
- **PWA**: Stale-while-revalidate caching for projects, environments, API keys endpoints
- **Notifications**: Push notifications for regressed issues via SSE stream
- **CSS fix**: 1px banner line hidden when banner is empty

## Test plan
- [ ] Open an issue detail page — should load in <2s instead of 58s+
- [ ] Issues list defaults to "open" tab with regressed issues at top
- [ ] "Load more" button appears when >50 issues
- [ ] Notification banner shows no 1px line when empty
- [ ] Hard refresh: projects/environments/apikeys served from SW cache
- [ ] Trigger a regression — browser notification should appear