### PR TITLE
refactor: domain services + fix PWA tab bar

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -27,13 +28,14 @@ import (
 	bb "github.com/wiebe-xyz/bugbarn-go"
 	"github.com/wiebe-xyz/bugbarn/internal/alert"
 	"github.com/wiebe-xyz/bugbarn/internal/analytics"
-	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/api"
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
+	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
 	"github.com/wiebe-xyz/bugbarn/internal/issues"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
+	"github.com/wiebe-xyz/bugbarn/internal/selflog"
 	"github.com/wiebe-xyz/bugbarn/internal/service"
 	"github.com/wiebe-xyz/bugbarn/internal/spool"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
@@ -57,6 +59,12 @@ func main() {
 // run owns process wiring: it opens storage, starts the worker, and serves the API.
 func run() error {
 	cfg := loadConfig()
+
+	logHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	logger := slog.New(logHandler)
+	slog.SetDefault(logger)
 
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -109,7 +117,9 @@ func run() error {
 			Endpoint:    cfg.selfEndpoint,
 			ProjectSlug: cfg.selfProject,
 		})
-		log.Printf("self-reporting enabled → %s", cfg.selfEndpoint)
+		logger = slog.New(selflog.NewHandler(logHandler))
+		slog.SetDefault(logger)
+		logger.Info("self-reporting enabled", "endpoint", cfg.selfEndpoint)
 	}
 
 	workerStatus := &worker.Status{}
@@ -131,7 +141,7 @@ func run() error {
 	go handler.Start(ctx)
 
 	logHub := logstream.NewHub()
-	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.allowedOrigins)
+	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.allowedOrigins, logger)
 	apiServer.SetLogHub(logHub)
 	apiServer.SetSetupConfig(cfg.sessionSecret, cfg.publicURL)
 	if len(cfg.trustedProxies) > 0 {

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -100,7 +100,7 @@ func run() error {
 	evaluator := alert.NewEvaluator(alertRepo, deliverer, cfg.publicURL)
 	bus.Subscribe(evaluator.HandleEvent)
 
-	svc := service.NewWithBus(store, bus)
+	eventPub := service.NewEventPublisher(bus)
 
 	selfReporting := cfg.selfEndpoint != "" && cfg.selfAPIKey != ""
 	if selfReporting {
@@ -113,7 +113,7 @@ func run() error {
 	}
 
 	workerStatus := &worker.Status{}
-	go runBackgroundWorker(ctx, eventSpool, cfg.spoolDir, store, svc, selfReporting, workerStatus)
+	go runBackgroundWorker(ctx, eventSpool, cfg.spoolDir, store, eventPub, selfReporting, workerStatus)
 
 	digest.StartScheduler(ctx, cfg.digest, store)
 	analytics.StartWorker(ctx, store, cfg.analyticsRetentionDays)
@@ -515,7 +515,7 @@ const (
 	workerRotateThreshold = 64 << 20 // 64 MiB
 )
 
-func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir string, store *storage.Store, svc *service.Service, selfReporting bool, ws *worker.Status) {
+func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir string, store *storage.Store, svc *service.EventPublisher, selfReporting bool, ws *worker.Status) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 

--- a/internal/alert/deliverer.go
+++ b/internal/alert/deliverer.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 // Deliverer sends alert webhook payloads with retry logic.
@@ -26,7 +26,7 @@ func NewDeliverer() *Deliverer {
 
 // Fire sends an alert webhook for the given rule and issue. It retries up to 3 times
 // with exponential backoff (1s, 2s, 4s). Returns nil on first success, or the last error.
-func (d *Deliverer) Fire(ctx context.Context, rule Rule, issue storage.Issue, publicURL string) error {
+func (d *Deliverer) Fire(ctx context.Context, rule Rule, issue domain.Issue, publicURL string) error {
 	payload, err := d.buildPayload(rule, issue, publicURL)
 	if err != nil {
 		return fmt.Errorf("build payload: %w", err)
@@ -64,7 +64,7 @@ func (d *Deliverer) Fire(ctx context.Context, rule Rule, issue storage.Issue, pu
 	return lastErr
 }
 
-func (d *Deliverer) buildPayload(rule Rule, issue storage.Issue, publicURL string) ([]byte, error) {
+func (d *Deliverer) buildPayload(rule Rule, issue domain.Issue, publicURL string) ([]byte, error) {
 	issueURL := strings.TrimRight(publicURL, "/") + "/issues/" + issue.ID
 
 	switch {
@@ -77,7 +77,7 @@ func (d *Deliverer) buildPayload(rule Rule, issue storage.Issue, publicURL strin
 	}
 }
 
-func (d *Deliverer) genericPayload(rule Rule, issue storage.Issue, issueURL string) ([]byte, error) {
+func (d *Deliverer) genericPayload(rule Rule, issue domain.Issue, issueURL string) ([]byte, error) {
 	payload := map[string]any{
 		"alert":     rule.Name,
 		"condition": rule.Condition,
@@ -94,7 +94,7 @@ func (d *Deliverer) genericPayload(rule Rule, issue storage.Issue, issueURL stri
 	return json.Marshal(payload)
 }
 
-func (d *Deliverer) slackPayload(rule Rule, issue storage.Issue, issueURL string) ([]byte, error) {
+func (d *Deliverer) slackPayload(rule Rule, issue domain.Issue, issueURL string) ([]byte, error) {
 	severity := severityFromIssue(issue)
 	text := fmt.Sprintf("[BugBarn] %s: %s", rule.Name, issue.Title)
 	payload := map[string]any{
@@ -138,7 +138,7 @@ func (d *Deliverer) slackPayload(rule Rule, issue storage.Issue, issueURL string
 	return json.Marshal(payload)
 }
 
-func (d *Deliverer) discordPayload(rule Rule, issue storage.Issue, issueURL string) ([]byte, error) {
+func (d *Deliverer) discordPayload(rule Rule, issue domain.Issue, issueURL string) ([]byte, error) {
 	severity := severityFromIssue(issue)
 	payload := map[string]any{
 		"content": "[BugBarn] New issue",
@@ -161,7 +161,7 @@ func (d *Deliverer) discordPayload(rule Rule, issue storage.Issue, issueURL stri
 	return json.Marshal(payload)
 }
 
-func severityFromIssue(issue storage.Issue) string {
+func severityFromIssue(issue domain.Issue) string {
 	if issue.RepresentativeEvent.Severity != "" {
 		return strings.ToLower(issue.RepresentativeEvent.Severity)
 	}

--- a/internal/alert/evaluator.go
+++ b/internal/alert/evaluator.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
 // Evaluator subscribes to the domain event bus and fires alert webhooks when
@@ -36,7 +36,7 @@ func (e *Evaluator) HandleEvent(evt any) {
 	}
 }
 
-func (e *Evaluator) evaluate(ctx context.Context, projectID int64, issue storage.Issue, conditionType string) {
+func (e *Evaluator) evaluate(ctx context.Context, projectID int64, issue domain.Issue, conditionType string) {
 	rules, err := e.repo.ListForProject(ctx, projectID)
 	if err != nil {
 		log.Printf("alert evaluator: list rules for project %d: %v", projectID, err)

--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -20,70 +20,70 @@ type PageView struct {
 }
 
 type OverviewResult struct {
-	Pageviews     int64
-	Sessions      int64
-	PagesCount    int64
-	AvgDurationMs int64
+	Pageviews     int64 `json:"pageviews"`
+	Sessions      int64 `json:"sessions"`
+	PagesCount    int64 `json:"pages"`
+	AvgDurationMs int64 `json:"avgDurationMs"`
 }
 
 type PageStat struct {
-	Pathname  string
-	Pageviews int64
-	Sessions  int64
+	Pathname  string `json:"pathname"`
+	Pageviews int64  `json:"pageviews"`
+	Sessions  int64  `json:"sessions"`
 }
 
 type TimelineBucket struct {
-	Date      string // YYYY-MM-DD (day), YYYY-WXX (ISO week), YYYY-MM (month)
-	Pageviews int64
-	Sessions  int64
+	Date      string `json:"date"`
+	Pageviews int64  `json:"pageviews"`
+	Sessions  int64  `json:"sessions"`
 }
 
 type ReferrerStat struct {
-	Host      string
-	Pageviews int64
-	Sessions  int64
+	Host      string `json:"host"`
+	Pageviews int64  `json:"pageviews"`
+	Sessions  int64  `json:"sessions"`
 }
 
 type SegmentBucket struct {
-	Value     string
-	Pageviews int64
-	Sessions  int64
+	Value     string `json:"value"`
+	Pageviews int64  `json:"pageviews"`
+	Sessions  int64  `json:"sessions"`
 }
 
 type Query struct {
 	ProjectID int64
 	Start     time.Time
 	End       time.Time
-	Pathname  string // optional filter
-	Limit     int    // 0 = default 50
+	Pathname  string
+	Limit     int
 }
 
 type PageFlowResult struct {
-	Pathname string
-	CameFrom []FlowEntry
-	WentTo   []FlowEntry
+	Pathname string      `json:"pathname"`
+	CameFrom []FlowEntry `json:"cameFrom"`
+	WentTo   []FlowEntry `json:"wentTo"`
 }
 
 type FlowEntry struct {
-	Pathname string
-	Count    int64
-	Pct      float64
+	Pathname string  `json:"pathname"`
+	Count    int64   `json:"count"`
+	Pct      float64 `json:"pct"`
 }
 
 type ScrollDepthResult struct {
-	Pathname string
-	Buckets  []ScrollBucket
+	Pathname string         `json:"pathname"`
+	Buckets  []ScrollBucket `json:"buckets"`
 }
 
 type ScrollBucket struct {
-	Label string // "0–24%", "25–49%", "50–74%", "75–99%", "100%"
-	Count int64
-	Pct   float64
+	Label string  `json:"label"`
+	Count int64   `json:"count"`
+	Pct   float64 `json:"pct"`
 }
 
 type DropoutStat struct {
-	Pathname        string
-	Pageviews       int64
-	BouncedSessions int64
-	BounceRate      float64
+	Pathname        string  `json:"pathname"`
+	Pageviews       int64   `json:"pageviews"`
+	BouncedSessions int64   `json:"bouncedSessions"`
+	BounceRate      float64 `json:"bounceRate"`
 }

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -6,13 +6,13 @@ import (
 )
 
 func (s *Server) serveAlertsRoot(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
+	if s.alerts == nil {
 		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
-		alerts, err := s.service.ListAlerts(r.Context())
+		alerts, err := s.alerts.List(r.Context())
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -24,7 +24,7 @@ func (s *Server) serveAlertsRoot(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid alert payload", http.StatusBadRequest)
 			return
 		}
-		item, err := s.service.CreateAlert(r.Context(), alertFromRequest(request))
+		item, err := s.alerts.Create(r.Context(), alertFromRequest(request))
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -36,14 +36,14 @@ func (s *Server) serveAlertsRoot(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) serveAlertRoute(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
+	if s.alerts == nil {
 		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	alertID := strings.TrimPrefix(r.URL.Path, "/api/v1/alerts/")
 	switch r.Method {
 	case http.MethodGet:
-		item, err := s.service.GetAlert(r.Context(), alertID)
+		item, err := s.alerts.Get(r.Context(), alertID)
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -55,14 +55,14 @@ func (s *Server) serveAlertRoute(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid alert payload", http.StatusBadRequest)
 			return
 		}
-		item, err := s.service.UpdateAlert(r.Context(), alertID, alertFromRequest(request))
+		item, err := s.alerts.Update(r.Context(), alertID, alertFromRequest(request))
 		if err != nil {
 			writeStorageError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"alert": item})
 	case http.MethodDelete:
-		if err := s.service.DeleteAlert(r.Context(), alertID); err != nil {
+		if err := s.alerts.Delete(r.Context(), alertID); err != nil {
 			writeStorageError(w, err)
 			return
 		}

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -14,7 +14,7 @@ func (s *Server) serveAlertsRoot(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		alerts, err := s.alerts.List(r.Context())
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"alerts": alerts})
@@ -26,7 +26,7 @@ func (s *Server) serveAlertsRoot(w http.ResponseWriter, r *http.Request) {
 		}
 		item, err := s.alerts.Create(r.Context(), alertFromRequest(request))
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"alert": item})
@@ -45,7 +45,7 @@ func (s *Server) serveAlertRoute(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		item, err := s.alerts.Get(r.Context(), alertID)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"alert": item})
@@ -57,13 +57,13 @@ func (s *Server) serveAlertRoute(w http.ResponseWriter, r *http.Request) {
 		}
 		item, err := s.alerts.Update(r.Context(), alertID, alertFromRequest(request))
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"alert": item})
 	case http.MethodDelete:
 		if err := s.alerts.Delete(r.Context(), alertID); err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"deleted": true})

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,11 +13,8 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
-
 const analyticsMaxDays = 366
 
-// parseAnalyticsQuery parses common analytics query parameters from the request.
-// Defaults to the last 30 days. Clamps to max 366 days. Returns 400 if start > end.
 func parseAnalyticsQuery(r *http.Request, projectID int64) (analytics.Query, error) {
 	now := time.Now().UTC()
 	end := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
@@ -43,7 +39,6 @@ func parseAnalyticsQuery(r *http.Request, projectID int64) (analytics.Query, err
 		return analytics.Query{}, fmt.Errorf("start must not be after end")
 	}
 
-	// Clamp to max 366 days.
 	if end.Sub(start) > analyticsMaxDays*24*time.Hour {
 		start = end.AddDate(0, 0, -analyticsMaxDays)
 	}
@@ -55,8 +50,6 @@ func parseAnalyticsQuery(r *http.Request, projectID int64) (analytics.Query, err
 	}, nil
 }
 
-// resolveAnalyticsProjectID resolves the project ID for analytics requests using
-// the same logic as other protected routes.
 func (s *Server) resolveAnalyticsProjectID(r *http.Request) int64 {
 	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" {
 		if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
@@ -69,7 +62,17 @@ func (s *Server) resolveAnalyticsProjectID(r *http.Request) int64 {
 	return s.projects.DefaultProjectID()
 }
 
-// serveAnalyticsQuery handles all GET /api/v1/analytics/* endpoints.
+var analyticsRoutes = map[string]func(*Server, http.ResponseWriter, *http.Request, analytics.Query){
+	"overview":  (*Server).analyticsOverview,
+	"pages":     (*Server).analyticsPages,
+	"timeline":  (*Server).analyticsTimeline,
+	"referrers": (*Server).analyticsReferrers,
+	"segments":  (*Server).analyticsSegments,
+	"flow":      (*Server).analyticsFlow,
+	"scroll":    (*Server).analyticsScroll,
+	"dropout":   (*Server).analyticsDropout,
+}
+
 func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 	projectID := s.resolveAnalyticsProjectID(r)
 
@@ -80,172 +83,120 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/analytics/")
-
-	ctx := r.Context()
-
-	switch tail {
-	case "overview":
-		result, err := s.analytics.QueryOverview(ctx, q)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		writeJSON(w, map[string]any{
-			"pageviews":     result.Pageviews,
-			"sessions":      result.Sessions,
-			"pages":         result.PagesCount,
-			"avgDurationMs": result.AvgDurationMs,
-		})
-
-	case "pages":
-		pages, err := s.analytics.QueryPages(ctx, q)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		if pages == nil {
-			pages = []analytics.PageStat{}
-		}
-		writeJSON(w, map[string]any{"pages": pages})
-
-	case "timeline":
-		granularity := r.URL.Query().Get("granularity")
-		if granularity == "" {
-			granularity = "day"
-		}
-		switch granularity {
-		case "day", "week", "month":
-			// valid
-		default:
-			granularity = "day"
-		}
-
-		buckets, err := s.analytics.QueryTimeline(ctx, q, granularity)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-
-		buckets = zeroFillTimeline(buckets, q.Start, q.End, granularity)
-
-		writeJSON(w, map[string]any{
-			"granularity": granularity,
-			"buckets":     buckets,
-		})
-
-	case "referrers":
-		refs, err := s.analytics.QueryReferrers(ctx, q)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		if refs == nil {
-			refs = []analytics.ReferrerStat{}
-		}
-		writeJSON(w, map[string]any{"referrers": refs})
-
-	case "segments":
-		dim := r.URL.Query().Get("dim")
-		segs, err := s.analytics.QuerySegments(ctx, q, dim)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		if segs == nil {
-			segs = []analytics.SegmentBucket{}
-		}
-		writeJSON(w, map[string]any{
-			"dim":     dim,
-			"buckets": segs,
-		})
-
-	case "flow":
-		pathname := r.URL.Query().Get("pathname")
-		result, err := s.analytics.QueryPageFlow(ctx, q, pathname)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		type flowEntry struct {
-			Pathname string  `json:"pathname"`
-			Count    int64   `json:"count"`
-			Pct      float64 `json:"pct"`
-		}
-		cameFrom := make([]flowEntry, 0, len(result.CameFrom))
-		for _, e := range result.CameFrom {
-			cameFrom = append(cameFrom, flowEntry{Pathname: e.Pathname, Count: e.Count, Pct: e.Pct})
-		}
-		wentTo := make([]flowEntry, 0, len(result.WentTo))
-		for _, e := range result.WentTo {
-			wentTo = append(wentTo, flowEntry{Pathname: e.Pathname, Count: e.Count, Pct: e.Pct})
-		}
-		writeJSON(w, map[string]any{
-			"pathname": result.Pathname,
-			"cameFrom": cameFrom,
-			"wentTo":   wentTo,
-		})
-
-	case "scroll":
-		pathname := r.URL.Query().Get("pathname")
-		result, err := s.analytics.QueryScrollDepth(ctx, q, pathname)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		type scrollBucket struct {
-			Label string  `json:"label"`
-			Count int64   `json:"count"`
-			Pct   float64 `json:"pct"`
-		}
-		buckets := make([]scrollBucket, 0, len(result.Buckets))
-		for _, b := range result.Buckets {
-			buckets = append(buckets, scrollBucket{Label: b.Label, Count: b.Count, Pct: b.Pct})
-		}
-		writeJSON(w, map[string]any{
-			"pathname": result.Pathname,
-			"buckets":  buckets,
-		})
-
-	case "dropout":
-		stats, err := s.analytics.QueryDropout(ctx, q)
-		if err != nil {
-			log.Printf("analytics: query error: %v", err)
-			http.Error(w, "query error", http.StatusInternalServerError)
-			return
-		}
-		type dropoutPage struct {
-			Pathname        string  `json:"pathname"`
-			Pageviews       int64   `json:"pageviews"`
-			BouncedSessions int64   `json:"bouncedSessions"`
-			BounceRate      float64 `json:"bounceRate"`
-		}
-		pages := make([]dropoutPage, 0, len(stats))
-		for _, st := range stats {
-			pages = append(pages, dropoutPage{
-				Pathname:        st.Pathname,
-				Pageviews:       st.Pageviews,
-				BouncedSessions: st.BouncedSessions,
-				BounceRate:      st.BounceRate,
-			})
-		}
-		writeJSON(w, map[string]any{"pages": pages})
-
-	default:
+	handler, ok := analyticsRoutes[tail]
+	if !ok {
 		http.NotFound(w, r)
+		return
 	}
+	handler(s, w, r, q)
 }
 
-// zeroFillTimeline inserts zero-value buckets for any dates missing from the
-// DB results so the client always gets a contiguous series.
+func (s *Server) analyticsOverview(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	result, err := s.analytics.QueryOverview(r.Context(), q)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, result)
+}
+
+func (s *Server) analyticsPages(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	pages, err := s.analytics.QueryPages(r.Context(), q)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	if pages == nil {
+		pages = []analytics.PageStat{}
+	}
+	writeJSON(w, map[string]any{"pages": pages})
+}
+
+func (s *Server) analyticsTimeline(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	granularity := r.URL.Query().Get("granularity")
+	switch granularity {
+	case "day", "week", "month":
+	default:
+		granularity = "day"
+	}
+
+	buckets, err := s.analytics.QueryTimeline(r.Context(), q, granularity)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"granularity": granularity,
+		"buckets":     zeroFillTimeline(buckets, q.Start, q.End, granularity),
+	})
+}
+
+func (s *Server) analyticsReferrers(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	refs, err := s.analytics.QueryReferrers(r.Context(), q)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	if refs == nil {
+		refs = []analytics.ReferrerStat{}
+	}
+	writeJSON(w, map[string]any{"referrers": refs})
+}
+
+func (s *Server) analyticsSegments(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	dim := r.URL.Query().Get("dim")
+	segs, err := s.analytics.QuerySegments(r.Context(), q, dim)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	if segs == nil {
+		segs = []analytics.SegmentBucket{}
+	}
+	writeJSON(w, map[string]any{
+		"dim":     dim,
+		"buckets": segs,
+	})
+}
+
+func (s *Server) analyticsFlow(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	pathname := r.URL.Query().Get("pathname")
+	result, err := s.analytics.QueryPageFlow(r.Context(), q, pathname)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"pathname": result.Pathname,
+		"cameFrom": result.CameFrom,
+		"wentTo":   result.WentTo,
+	})
+}
+
+func (s *Server) analyticsScroll(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	pathname := r.URL.Query().Get("pathname")
+	result, err := s.analytics.QueryScrollDepth(r.Context(), q, pathname)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"pathname": result.Pathname,
+		"buckets":  result.Buckets,
+	})
+}
+
+func (s *Server) analyticsDropout(w http.ResponseWriter, r *http.Request, q analytics.Query) {
+	stats, err := s.analytics.QueryDropout(r.Context(), q)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{"pages": stats})
+}
+
 func zeroFillTimeline(buckets []analytics.TimelineBucket, start, end time.Time, granularity string) []analytics.TimelineBucket {
-	// Build a lookup from the DB results.
 	have := make(map[string]analytics.TimelineBucket, len(buckets))
 	for _, b := range buckets {
 		have[b.Date] = b
@@ -254,7 +205,6 @@ func zeroFillTimeline(buckets []analytics.TimelineBucket, start, end time.Time, 
 	var keys []string
 	switch granularity {
 	case "week":
-		// Iterate by week from start to end.
 		cur := weekStart(start)
 		for !cur.After(end) {
 			key := cur.UTC().Format("2006-W") + fmt.Sprintf("%02d", isoWeekNumber(cur))
@@ -268,7 +218,7 @@ func zeroFillTimeline(buckets []analytics.TimelineBucket, start, end time.Time, 
 			keys = append(keys, cur.Format("2006-01"))
 			cur = cur.AddDate(0, 1, 0)
 		}
-	default: // day
+	default:
 		cur := start
 		for !cur.After(end) {
 			keys = append(keys, cur.Format("2006-01-02"))
@@ -287,32 +237,18 @@ func zeroFillTimeline(buckets []analytics.TimelineBucket, start, end time.Time, 
 	return out
 }
 
-// weekStart returns the Monday of the week containing t (matching strftime %W
-// which counts weeks starting on Sunday, but we align on Monday for ISO feel).
-// We use Go's time.Weekday with Sunday=0, Monday=1, …
-// strftime('%Y-W%W', date) in SQLite uses Sunday as the first day of the week.
-// So we align our iteration to match SQLite's Sunday-based week numbers.
 func weekStart(t time.Time) time.Time {
-	// Go's time.Sunday == 0, time.Monday == 1, …
-	offset := int(t.Weekday()) // 0 for Sunday
+	offset := int(t.Weekday())
 	return time.Date(t.Year(), t.Month(), t.Day()-offset, 0, 0, 0, 0, time.UTC)
 }
 
-// isoWeekNumber returns the SQLite strftime('%W', …) week number (0-53),
-// where weeks start on Sunday.
 func isoWeekNumber(t time.Time) int {
-	// Jan 1 of the year
 	jan1 := time.Date(t.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
-	// Day-of-year (0-based)
 	dayOfYear := t.YearDay() - 1
-	// Day of week of Jan 1 (Sunday=0)
 	jan1DOW := int(jan1.Weekday())
-	// SQLite %W: number of Sundays before this date / week of year
 	return (dayOfYear + jan1DOW) / 7
 }
 
-// collectPageView handles POST /api/v1/analytics/collect.
-// It is public and unauthenticated; CORS headers are set by the caller in ServeHTTP.
 func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 	if err != nil {
@@ -405,7 +341,6 @@ func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 	writeJSONStatus(w, http.StatusAccepted, map[string]any{})
 }
 
-// serveAnalyticsSnippet handles GET /analytics.js.
 func (s *Server) serveAnalyticsSnippet(w http.ResponseWriter, r *http.Request) {
 	origin := s.publicURL
 	if origin == "" {

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
+
 const analyticsMaxDays = 366
 
 // parseAnalyticsQuery parses common analytics query parameters from the request.
@@ -57,24 +58,19 @@ func parseAnalyticsQuery(r *http.Request, projectID int64) (analytics.Query, err
 // resolveAnalyticsProjectID resolves the project ID for analytics requests using
 // the same logic as other protected routes.
 func (s *Server) resolveAnalyticsProjectID(r *http.Request) int64 {
-	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.store != nil {
-		if proj, err := s.store.EnsureProject(r.Context(), slug); err == nil {
+	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" {
+		if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
 			return proj.ID
 		}
 	}
 	if id, ok := storage.ProjectIDFromContext(r.Context()); ok && id > 0 {
 		return id
 	}
-	return s.store.DefaultProjectID()
+	return s.projects.DefaultProjectID()
 }
 
 // serveAnalyticsQuery handles all GET /api/v1/analytics/* endpoints.
 func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-
 	projectID := s.resolveAnalyticsProjectID(r)
 
 	q, err := parseAnalyticsQuery(r, projectID)
@@ -89,7 +85,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 
 	switch tail {
 	case "overview":
-		result, err := s.store.QueryOverview(ctx, q)
+		result, err := s.analytics.QueryOverview(ctx, q)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -103,7 +99,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case "pages":
-		pages, err := s.store.QueryPages(ctx, q)
+		pages, err := s.analytics.QueryPages(ctx, q)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -126,7 +122,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 			granularity = "day"
 		}
 
-		buckets, err := s.store.QueryTimeline(ctx, q, granularity)
+		buckets, err := s.analytics.QueryTimeline(ctx, q, granularity)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -141,7 +137,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case "referrers":
-		refs, err := s.store.QueryReferrers(ctx, q)
+		refs, err := s.analytics.QueryReferrers(ctx, q)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -154,7 +150,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 
 	case "segments":
 		dim := r.URL.Query().Get("dim")
-		segs, err := s.store.QuerySegments(ctx, q, dim)
+		segs, err := s.analytics.QuerySegments(ctx, q, dim)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -170,7 +166,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 
 	case "flow":
 		pathname := r.URL.Query().Get("pathname")
-		result, err := s.store.QueryPageFlow(ctx, q, pathname)
+		result, err := s.analytics.QueryPageFlow(ctx, q, pathname)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -197,7 +193,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 
 	case "scroll":
 		pathname := r.URL.Query().Get("pathname")
-		result, err := s.store.QueryScrollDepth(ctx, q, pathname)
+		result, err := s.analytics.QueryScrollDepth(ctx, q, pathname)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -218,7 +214,7 @@ func (s *Server) serveAnalyticsQuery(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case "dropout":
-		stats, err := s.store.QueryDropout(ctx, q)
+		stats, err := s.analytics.QueryDropout(ctx, q)
 		if err != nil {
 			log.Printf("analytics: query error: %v", err)
 			http.Error(w, "query error", http.StatusInternalServerError)
@@ -354,13 +350,13 @@ func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 	if slug == "" {
 		slug = r.URL.Query().Get("project")
 	}
-	if slug != "" && s.store != nil {
-		if proj, err := s.store.EnsureProject(ctx, slug); err == nil {
+	if slug != "" {
+		if proj, err := s.projects.Ensure(ctx, slug); err == nil {
 			projectID = proj.ID
 		}
 	}
-	if projectID == 0 && s.store != nil {
-		projectID = s.store.DefaultProjectID()
+	if projectID == 0 {
+		projectID = s.projects.DefaultProjectID()
 	}
 
 	var referrerHost, referrerPath string
@@ -401,11 +397,9 @@ func (s *Server) collectPageView(w http.ResponseWriter, r *http.Request) {
 		Props:            props,
 	}
 
-	if s.store != nil {
-		if err := s.store.InsertPageView(ctx, pv); err != nil {
-			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
-			return
-		}
+	if err := s.analytics.InsertPageView(ctx, pv); err != nil {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		return
 	}
 
 	writeJSONStatus(w, http.StatusAccepted, map[string]any{})

--- a/internal/api/analytics.go
+++ b/internal/api/analytics.go
@@ -106,9 +106,6 @@ func (s *Server) analyticsPages(w http.ResponseWriter, r *http.Request, q analyt
 		writeServiceError(w, err)
 		return
 	}
-	if pages == nil {
-		pages = []analytics.PageStat{}
-	}
 	writeJSON(w, map[string]any{"pages": pages})
 }
 
@@ -138,9 +135,6 @@ func (s *Server) analyticsReferrers(w http.ResponseWriter, r *http.Request, q an
 		writeServiceError(w, err)
 		return
 	}
-	if refs == nil {
-		refs = []analytics.ReferrerStat{}
-	}
 	writeJSON(w, map[string]any{"referrers": refs})
 }
 
@@ -151,40 +145,25 @@ func (s *Server) analyticsSegments(w http.ResponseWriter, r *http.Request, q ana
 		writeServiceError(w, err)
 		return
 	}
-	if segs == nil {
-		segs = []analytics.SegmentBucket{}
-	}
-	writeJSON(w, map[string]any{
-		"dim":     dim,
-		"buckets": segs,
-	})
+	writeJSON(w, map[string]any{"dim": dim, "buckets": segs})
 }
 
 func (s *Server) analyticsFlow(w http.ResponseWriter, r *http.Request, q analytics.Query) {
-	pathname := r.URL.Query().Get("pathname")
-	result, err := s.analytics.QueryPageFlow(r.Context(), q, pathname)
+	result, err := s.analytics.QueryPageFlow(r.Context(), q, r.URL.Query().Get("pathname"))
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{
-		"pathname": result.Pathname,
-		"cameFrom": result.CameFrom,
-		"wentTo":   result.WentTo,
-	})
+	writeJSON(w, result)
 }
 
 func (s *Server) analyticsScroll(w http.ResponseWriter, r *http.Request, q analytics.Query) {
-	pathname := r.URL.Query().Get("pathname")
-	result, err := s.analytics.QueryScrollDepth(r.Context(), q, pathname)
+	result, err := s.analytics.QueryScrollDepth(r.Context(), q, r.URL.Query().Get("pathname"))
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{
-		"pathname": result.Pathname,
-		"buckets":  result.Buckets,
-	})
+	writeJSON(w, result)
 }
 
 func (s *Server) analyticsDropout(w http.ResponseWriter, r *http.Request, q analytics.Query) {

--- a/internal/api/analytics_query_test.go
+++ b/internal/api/analytics_query_test.go
@@ -15,7 +15,7 @@ func TestAnalyticsOverviewEmptyProject(t *testing.T) {
 	store := mustOpenStore(t)
 	defer store.Close()
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/overview", nil)
@@ -53,7 +53,7 @@ func TestAnalyticsTimelineDayGranularityZeroFills(t *testing.T) {
 	store := mustOpenStore(t)
 	defer store.Close()
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	// Request exactly 3 days: 2026-04-01 to 2026-04-03.
 	rr := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func TestAnalyticsSegmentsUnknownDimReturnsEmpty(t *testing.T) {
 	store := mustOpenStore(t)
 	defer store.Close()
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/segments?dim=nonexistent_dimension", nil)
@@ -137,7 +137,7 @@ func TestAnalyticsUnauthenticatedReturns401(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessions := auth.NewSessionManager("test-secret", time.Hour)
-	server := NewServerWithAuth(nil, store, userAuth, sessions, nil)
+	server := NewServerWithAuth(nil, store, userAuth, sessions, nil, nil)
 
 	endpoints := []string{
 		"/api/v1/analytics/overview",
@@ -164,7 +164,7 @@ func TestAnalyticsStartAfterEndReturns400(t *testing.T) {
 	store := mustOpenStore(t)
 	defer store.Close()
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/analytics/overview?start=2026-04-10&end=2026-04-01", nil)

--- a/internal/api/analytics_test.go
+++ b/internal/api/analytics_test.go
@@ -26,7 +26,7 @@ func TestCollectPageView(t *testing.T) {
 	t.Run("POST valid JSON returns 202 and inserts row", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 
 		body := `{"pathname":"/hello","hostname":"example.com","referrer":"https://google.com/search?q=test","sessionId":"abc123","screenWidth":1440,"duration":5000}`
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
@@ -47,7 +47,7 @@ func TestCollectPageView(t *testing.T) {
 	t.Run("POST with text/plain content-type returns 202", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 
 		body := `{"pathname":"/beacon","hostname":"example.com","sessionId":"sid-plain"}`
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
@@ -64,7 +64,7 @@ func TestCollectPageView(t *testing.T) {
 	t.Run("POST missing pathname returns 400", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 
 		body := `{"hostname":"example.com","sessionId":"abc"}`
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(body))
@@ -81,7 +81,7 @@ func TestCollectPageView(t *testing.T) {
 	t.Run("OPTIONS preflight returns 204 with correct CORS headers", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 
 		req := httptest.NewRequest(http.MethodOptions, "/api/v1/analytics/collect", nil)
 		rr := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func TestCollectPageView(t *testing.T) {
 	t.Run("project resolved from query param when header absent", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 
 		body := `{"pathname":"/page","hostname":"example.com","sessionId":"sess-qp"}`
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect?project=mysite", strings.NewReader(body))
@@ -132,7 +132,7 @@ func TestServeAnalyticsSnippet(t *testing.T) {
 	t.Run("GET /analytics.js?project=mysite returns 200 with JS containing project slug", func(t *testing.T) {
 		store := mustOpenAnalyticsStore(t)
 		defer store.Close()
-		server := NewServer(nil, store)
+		server := NewServer(nil, store, nil)
 		server.SetSetupConfig("secret", "https://bugs.example.com")
 
 		req := httptest.NewRequest(http.MethodGet, "/analytics.js?project=mysite", nil)

--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -12,7 +12,7 @@ import (
 func (s *Server) listAPIKeys(w http.ResponseWriter, r *http.Request) {
 	keys, err := s.projects.ListAPIKeys(r.Context())
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	type safeKey struct {
@@ -49,7 +49,7 @@ func (s *Server) deleteAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.projects.DeleteAPIKey(r.Context(), id); err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"deleted": true})

--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -6,15 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func (s *Server) listAPIKeys(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-	keys, err := s.store.ListAPIKeys(r.Context())
+	keys, err := s.projects.ListAPIKeys(r.Context())
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -31,7 +27,7 @@ func (s *Server) listAPIKeys(w http.ResponseWriter, r *http.Request) {
 	for _, k := range keys {
 		scope := k.Scope
 		if scope == "" {
-			scope = storage.APIKeyScopeFull
+			scope = domain.APIKeyScopeFull
 		}
 		out = append(out, safeKey{
 			ID:         k.ID,
@@ -46,17 +42,13 @@ func (s *Server) listAPIKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteAPIKey(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	idStr := strings.TrimPrefix(r.URL.Path, "/api/v1/apikeys/")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
 		http.Error(w, "invalid api key id", http.StatusBadRequest)
 		return
 	}
-	if err := s.store.DeleteAPIKey(r.Context(), id); err != nil {
+	if err := s.projects.DeleteAPIKey(r.Context(), id); err != nil {
 		writeStorageError(w, err)
 		return
 	}

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -27,7 +27,7 @@ func (s *Server) listIssueEvents(w http.ResponseWriter, r *http.Request) {
 
 	events, hasMore, err := s.issues.ListEvents(r.Context(), issueID, limit, beforeID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"events": events, "hasMore": hasMore})
@@ -37,7 +37,7 @@ func (s *Server) getEvent(w http.ResponseWriter, r *http.Request) {
 	eventID := strings.TrimPrefix(r.URL.Path, "/api/v1/events/")
 	event, err := s.issues.GetEvent(r.Context(), eventID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"event": event})
@@ -63,7 +63,7 @@ func (s *Server) listRecentEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	events, err := s.issues.ListLiveEvents(r.Context(), limit, since)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"events": events})

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -10,10 +10,6 @@ import (
 )
 
 func (s *Server) listIssueEvents(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/events")
 
 	limit := 25
@@ -29,7 +25,7 @@ func (s *Server) listIssueEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	events, hasMore, err := s.service.ListIssueEvents(r.Context(), issueID, limit, beforeID)
+	events, hasMore, err := s.issues.ListEvents(r.Context(), issueID, limit, beforeID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -38,12 +34,8 @@ func (s *Server) listIssueEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getEvent(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	eventID := strings.TrimPrefix(r.URL.Path, "/api/v1/events/")
-	event, err := s.service.GetEvent(r.Context(), eventID)
+	event, err := s.issues.GetEvent(r.Context(), eventID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -52,10 +44,6 @@ func (s *Server) getEvent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listRecentEvents(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	limit := 50
 	if raw := r.URL.Query().Get("limit"); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
@@ -73,7 +61,7 @@ func (s *Server) listRecentEvents(w http.ResponseWriter, r *http.Request) {
 			since = time.Now().UTC().Add(-parsed)
 		}
 	}
-	events, err := s.service.ListLiveEvents(r.Context(), limit, since)
+	events, err := s.issues.ListLiveEvents(r.Context(), limit, since)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -82,12 +70,6 @@ func (s *Server) listRecentEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-
-	// Parse optional ?since= parameter to resume from a specific timestamp.
 	since := time.Now().UTC().Add(-15 * time.Minute)
 	if raw := r.URL.Query().Get("since"); raw != "" {
 		if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
@@ -115,7 +97,6 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request) {
 	defer pollTicker.Stop()
 	defer keepaliveTicker.Stop()
 
-	// Track the latest timestamp seen so we only emit new events.
 	cursor := since
 
 	for {
@@ -128,7 +109,7 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request) {
 			}
 			flusher.Flush()
 		case <-pollTicker.C:
-			events, err := s.service.ListLiveEvents(ctx, 100, cursor)
+			events, err := s.issues.ListLiveEvents(ctx, 100, cursor)
 			if err != nil {
 				return
 			}

--- a/internal/api/facets.go
+++ b/internal/api/facets.go
@@ -18,7 +18,7 @@ func (s *Server) serveFacetsRoute(w http.ResponseWriter, r *http.Request) {
 		}
 		keys, err := s.issues.ListFacetKeys(r.Context(), projectID)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		if keys == nil {
@@ -34,7 +34,7 @@ func (s *Server) serveFacetsRoute(w http.ResponseWriter, r *http.Request) {
 	}
 	values, err := s.issues.ListFacetValues(r.Context(), projectID, suffix)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	if values == nil {

--- a/internal/api/facets.go
+++ b/internal/api/facets.go
@@ -7,23 +7,16 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
-// serveFacetsRoute handles GET /api/v1/facets and GET /api/v1/facets/{key}.
 func (s *Server) serveFacetsRoute(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-	// Trim the base prefix then check whether a key is present.
 	suffix := strings.TrimPrefix(r.URL.Path, "/api/v1/facets")
 	suffix = strings.TrimPrefix(suffix, "/")
 
 	if suffix == "" {
-		// GET /api/v1/facets — list all facet keys.
 		projectID, ok := storage.ProjectIDFromContext(r.Context())
 		if !ok {
-			projectID = s.store.DefaultProjectID()
+			projectID = s.projects.DefaultProjectID()
 		}
-		keys, err := s.service.ListFacetKeys(r.Context(), projectID)
+		keys, err := s.issues.ListFacetKeys(r.Context(), projectID)
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -35,12 +28,11 @@ func (s *Server) serveFacetsRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// GET /api/v1/facets/{key} — list values for a key.
 	projectID, ok := storage.ProjectIDFromContext(r.Context())
 	if !ok {
-		projectID = s.store.DefaultProjectID()
+		projectID = s.projects.DefaultProjectID()
 	}
-	values, err := s.service.ListFacetValues(r.Context(), projectID, suffix)
+	values, err := s.issues.ListFacetValues(r.Context(), projectID, suffix)
 	if err != nil {
 		writeStorageError(w, err)
 		return

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -59,8 +59,8 @@ func (s *Server) serveHealth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if s.store != nil {
-		projects, err := s.store.ListProjects(r.Context())
+	if s.projects != nil {
+		projects, err := s.projects.List(r.Context())
 		if err == nil {
 			for _, p := range projects {
 				if p.Status == "pending" {

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func writeJSON(w http.ResponseWriter, value any) {
@@ -72,8 +72,8 @@ func decodeStringMap(w http.ResponseWriter, r *http.Request) (map[string]string,
 	return out, nil
 }
 
-func alertFromRequest(payload map[string]any) storage.Alert {
-	alert := storage.Alert{
+func alertFromRequest(payload map[string]any) domain.Alert {
+	alert := domain.Alert{
 		Name:       stringValue(payload["name"]),
 		Severity:   stringValue(payload["severity"]),
 		WebhookURL: stringValue(payload["webhook_url"]),

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -1,15 +1,14 @@
 package api
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
@@ -23,13 +22,22 @@ func writeJSONStatus(w http.ResponseWriter, status int, value any) {
 	_ = json.NewEncoder(w).Encode(value)
 }
 
-func writeStorageError(w http.ResponseWriter, err error) {
-	if errors.Is(err, sql.ErrNoRows) {
-		http.Error(w, "not found", http.StatusNotFound)
+func writeServiceError(w http.ResponseWriter, err error) {
+	var appErr *apperr.Error
+	if errors.As(err, &appErr) {
+		switch appErr.Code {
+		case "not_found":
+			http.Error(w, "not found", http.StatusNotFound)
+		case "conflict":
+			http.Error(w, "conflict", http.StatusConflict)
+		case "invalid_input":
+			http.Error(w, appErr.Message, http.StatusBadRequest)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
 		return
 	}
-	log.Printf("storage error: %v", err)
-	http.Error(w, "storage error", http.StatusInternalServerError)
+	http.Error(w, "internal error", http.StatusInternalServerError)
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, dest any) error {

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -60,7 +60,7 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	}
 	issues, err := s.issues.ListFiltered(r.Context(), filter)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimPrefix(r.URL.Path, "/api/v1/issues/")
 	issue, err := s.issues.Get(r.Context(), issueID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"issue": issue})
@@ -119,7 +119,7 @@ func (s *Server) resolveIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/resolve")
 	item, err := s.issues.Resolve(r.Context(), issueID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"issue": item})
@@ -129,7 +129,7 @@ func (s *Server) reopenIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/reopen")
 	item, err := s.issues.Reopen(r.Context(), issueID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"issue": item})
@@ -146,7 +146,7 @@ func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	item, err := s.issues.Mute(r.Context(), issueID, body.MuteMode)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"issue": item})
@@ -156,7 +156,7 @@ func (s *Server) unmuteIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/unmute")
 	item, err := s.issues.Unmute(r.Context(), issueID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"issue": item})

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 // serveIssueRoute handles /api/v1/issues/{id} and sub-paths.
@@ -27,12 +27,8 @@ func (s *Server) serveIssueRoute(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	q := r.URL.Query()
-	filter := storage.IssueFilter{
+	filter := domain.IssueFilter{
 		Sort:   q.Get("sort"),
 		Status: q.Get("status"),
 		Query:  q.Get("q"),
@@ -52,7 +48,6 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	}
 	requestedLimit := filter.Limit
 	filter.Limit = requestedLimit + 1
-	// Any query params not used for standard filtering are treated as facet filters.
 	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true}
 	for key, vals := range q {
 		if knownParams[key] || len(vals) == 0 || strings.TrimSpace(vals[0]) == "" {
@@ -63,7 +58,7 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 		}
 		filter.Facets[key] = vals[0]
 	}
-	issues, err := s.service.ListIssuesFiltered(r.Context(), filter)
+	issues, err := s.issues.ListFiltered(r.Context(), filter)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -77,10 +72,6 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	ids := r.URL.Query().Get("ids")
 	if ids == "" {
 		writeJSON(w, map[string]any{"sparklines": map[string][24]int{}})
@@ -92,7 +83,7 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 	displayByRowID := make(map[int64]string, len(parts))
 	for _, p := range parts {
 		displayID := strings.TrimSpace(p)
-		rowID, err := s.store.IssueRowIDByDisplayID(r.Context(), displayID)
+		rowID, err := s.issues.RowIDByDisplayID(r.Context(), displayID)
 		if err != nil {
 			continue
 		}
@@ -100,7 +91,7 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 		displayByRowID[rowID] = displayID
 	}
 
-	hourlyCounts, err := s.service.HourlyEventCounts(r.Context(), issueIDs)
+	hourlyCounts, err := s.issues.HourlyEventCounts(r.Context(), issueIDs)
 	if err != nil {
 		hourlyCounts = map[int64][24]int{}
 	}
@@ -115,12 +106,8 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimPrefix(r.URL.Path, "/api/v1/issues/")
-	issue, err := s.service.GetIssue(r.Context(), issueID)
+	issue, err := s.issues.Get(r.Context(), issueID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -129,12 +116,8 @@ func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) resolveIssue(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/resolve")
-	item, err := s.service.ResolveIssue(r.Context(), issueID)
+	item, err := s.issues.Resolve(r.Context(), issueID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -143,12 +126,8 @@ func (s *Server) resolveIssue(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) reopenIssue(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/reopen")
-	item, err := s.service.ReopenIssue(r.Context(), issueID)
+	item, err := s.issues.Reopen(r.Context(), issueID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -156,13 +135,7 @@ func (s *Server) reopenIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"issue": item})
 }
 
-// muteIssue handles PATCH /api/v1/issues/:id/mute
-// Body: {"mute_mode":"until_regression"|"forever"}
 func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/mute")
 	var body struct {
 		MuteMode string `json:"mute_mode"`
@@ -171,7 +144,7 @@ func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid mute payload", http.StatusBadRequest)
 		return
 	}
-	item, err := s.service.MuteIssue(r.Context(), issueID, body.MuteMode)
+	item, err := s.issues.Mute(r.Context(), issueID, body.MuteMode)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -179,14 +152,9 @@ func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"issue": item})
 }
 
-// unmuteIssue handles PATCH /api/v1/issues/:id/unmute
 func (s *Server) unmuteIssue(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/unmute")
-	item, err := s.service.UnmuteIssue(r.Context(), issueID)
+	item, err := s.issues.Unmute(r.Context(), issueID)
 	if err != nil {
 		writeStorageError(w, err)
 		return

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -29,12 +29,12 @@ func setupTestServer(t *testing.T) (*Server, *storage.Store) {
 	}
 	t.Cleanup(func() { store.Close() })
 	return &Server{
-		issues:    issuesvc.New(store),
-		projects:  projectsvc.New(store),
-		releases:  releasesvc.New(store),
-		alerts:    alertsvc.New(store),
-		logs:      logsvc.New(store),
-		analytics: analyticssvc.New(store),
+		issues:    issuesvc.New(store, nil),
+		projects:  projectsvc.New(store, nil),
+		releases:  releasesvc.New(store, nil),
+		alerts:    alertsvc.New(store, nil),
+		logs:      logsvc.New(store, nil),
+		analytics: analyticssvc.New(store, nil),
 	}, store
 }
 
@@ -71,7 +71,7 @@ func TestMuteIssueEndpoint(t *testing.T) {
 	}{
 		{"until_regression", "until_regression", http.StatusOK},
 		{"forever", "forever", http.StatusOK},
-		{"invalid_mode", "never", http.StatusInternalServerError},
+		{"invalid_mode", "never", http.StatusBadRequest},
 	}
 
 	for _, tc := range cases {

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -11,7 +11,12 @@ import (
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/event"
-	"github.com/wiebe-xyz/bugbarn/internal/service"
+	alertsvc "github.com/wiebe-xyz/bugbarn/internal/service/alerts"
+	analyticssvc "github.com/wiebe-xyz/bugbarn/internal/service/analytics"
+	issuesvc "github.com/wiebe-xyz/bugbarn/internal/service/issues"
+	logsvc "github.com/wiebe-xyz/bugbarn/internal/service/logs"
+	projectsvc "github.com/wiebe-xyz/bugbarn/internal/service/projects"
+	releasesvc "github.com/wiebe-xyz/bugbarn/internal/service/releases"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 	"github.com/wiebe-xyz/bugbarn/internal/worker"
 )
@@ -23,8 +28,14 @@ func setupTestServer(t *testing.T) (*Server, *storage.Store) {
 		t.Fatalf("open store: %v", err)
 	}
 	t.Cleanup(func() { store.Close() })
-	svc := service.New(store)
-	return &Server{store: store, service: svc}, store
+	return &Server{
+		issues:    issuesvc.New(store),
+		projects:  projectsvc.New(store),
+		releases:  releasesvc.New(store),
+		alerts:    alertsvc.New(store),
+		logs:      logsvc.New(store),
+		analytics: analyticssvc.New(store),
+	}, store
 }
 
 func persistTestIssue(t *testing.T, store *storage.Store) storage.Issue {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -150,7 +150,7 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.logs.Insert(r.Context(), entries); err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 
@@ -192,7 +192,7 @@ func (s *Server) serveLogs(w http.ResponseWriter, r *http.Request) {
 
 	entries, err := s.logs.List(r.Context(), projectID, levelMin, q, limit, beforeID)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
-// pinoLevelNames maps Pino numeric levels to level name strings.
 var pinoLevelNames = map[int]string{
 	10: "trace",
 	20: "debug",
@@ -23,7 +23,6 @@ var pinoLevelNames = map[int]string{
 	60: "fatal",
 }
 
-// pinoLevelNums maps level name strings to Pino numeric levels.
 var pinoLevelNums = map[string]int{
 	"trace": 10,
 	"debug": 20,
@@ -33,7 +32,6 @@ var pinoLevelNums = map[string]int{
 	"fatal": 60,
 }
 
-// skipFields are fields stripped from the Data map during ingest.
 var skipFields = map[string]bool{
 	"v":        true,
 	"pid":      true,
@@ -44,10 +42,8 @@ var skipFields = map[string]bool{
 	"time":     true,
 }
 
-// parsePinoObject converts a raw JSON object from a Pino-style log payload
-// into a LogEntry. projectID must be set by the caller.
-func parsePinoObject(obj map[string]any, projectID int64) storage.LogEntry {
-	entry := storage.LogEntry{
+func parsePinoObject(obj map[string]any, projectID int64) domain.LogEntry {
+	entry := domain.LogEntry{
 		ProjectID:  projectID,
 		ReceivedAt: time.Now().UTC(),
 		LevelNum:   30,
@@ -55,14 +51,12 @@ func parsePinoObject(obj map[string]any, projectID int64) storage.LogEntry {
 		Data:       make(map[string]any),
 	}
 
-	// Extract message from "msg" or "message".
 	if msg, ok := obj["msg"].(string); ok {
 		entry.Message = msg
 	} else if msg, ok := obj["message"].(string); ok {
 		entry.Message = msg
 	}
 
-	// Extract level — may be a number or string.
 	if lvl, ok := obj["level"]; ok {
 		switch v := lvl.(type) {
 		case float64:
@@ -80,13 +74,11 @@ func parsePinoObject(obj map[string]any, projectID int64) storage.LogEntry {
 		}
 	}
 
-	// Extract timestamp from "time" field (epoch ms).
 	if t, ok := obj["time"].(float64); ok {
 		ms := int64(t)
 		entry.ReceivedAt = time.UnixMilli(ms).UTC()
 	}
 
-	// Collect remaining fields into Data, excluding reserved keys.
 	for k, v := range obj {
 		if !skipFields[k] {
 			entry.Data[k] = v
@@ -99,7 +91,6 @@ func parsePinoObject(obj map[string]any, projectID int64) storage.LogEntry {
 	return entry
 }
 
-// levelMinFromName converts a level name to the minimum numeric level for filtering.
 func levelMinFromName(name string) int {
 	name = strings.ToLower(strings.TrimSpace(name))
 	if num, ok := pinoLevelNums[name]; ok {
@@ -108,13 +99,7 @@ func levelMinFromName(name string) int {
 	return 0
 }
 
-// serveLogsIngest handles POST /api/v1/logs
 func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-
 	projectID, ok := storage.ProjectIDFromContext(r.Context())
 	if !ok || projectID == 0 {
 		http.Error(w, "project required: provide X-BugBarn-Project header or use a project-scoped API key", http.StatusBadRequest)
@@ -122,7 +107,6 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ct := r.Header.Get("Content-Type")
-	// Strip params like "; charset=utf-8"
 	if idx := strings.Index(ct, ";"); idx != -1 {
 		ct = strings.TrimSpace(ct[:idx])
 	}
@@ -139,12 +123,11 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 			}
 			var obj map[string]any
 			if err := json.Unmarshal([]byte(line), &obj); err != nil {
-				continue // skip malformed lines
+				continue
 			}
 			rawEntries = append(rawEntries, obj)
 		}
 	default:
-		// Default: application/json with {"logs":[...]}
 		var payload struct {
 			Logs []map[string]any `json:"logs"`
 		}
@@ -161,12 +144,12 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries := make([]storage.LogEntry, 0, len(rawEntries))
+	entries := make([]domain.LogEntry, 0, len(rawEntries))
 	for _, obj := range rawEntries {
 		entries = append(entries, parsePinoObject(obj, projectID))
 	}
 
-	if err := s.store.InsertLogEntries(r.Context(), entries); err != nil {
+	if err := s.logs.Insert(r.Context(), entries); err != nil {
 		writeStorageError(w, err)
 		return
 	}
@@ -180,15 +163,8 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// serveLogs handles GET /api/v1/logs
 func (s *Server) serveLogs(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-
 	projectID, _ := storage.ProjectIDFromContext(r.Context())
-	// projectID == 0 means all projects — handled by ListLogEntries
 
 	limit := 200
 	if v := r.URL.Query().Get("limit"); v != "" {
@@ -214,7 +190,7 @@ func (s *Server) serveLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	entries, err := s.store.ListLogEntries(r.Context(), projectID, levelMin, q, limit, beforeID)
+	entries, err := s.logs.List(r.Context(), projectID, levelMin, q, limit, beforeID)
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -231,7 +207,6 @@ func (s *Server) serveLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// serveLogsStream handles GET /api/v1/logs/stream (SSE)
 func (s *Server) serveLogsStream(w http.ResponseWriter, r *http.Request) {
 	if s.logHub == nil {
 		http.Error(w, "log streaming unavailable", http.StatusServiceUnavailable)
@@ -239,7 +214,6 @@ func (s *Server) serveLogsStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	projectID, _ := storage.ProjectIDFromContext(r.Context())
-	// projectID == 0 means all projects — hub.Subscribe(0) receives from all projects
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -7,7 +7,7 @@ import (
 
 func (s *Server) approveProject(w http.ResponseWriter, r *http.Request) {
 	slug := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/projects/"), "/approve")
-	if err := s.store.ApproveProject(r.Context(), slug); err != nil {
+	if err := s.projects.Approve(r.Context(), slug); err != nil {
 		writeStorageError(w, err)
 		return
 	}
@@ -15,11 +15,7 @@ func (s *Server) approveProject(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) servePendingProjectCount(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-	projects, err := s.store.ListProjects(r.Context())
+	projects, err := s.projects.List(r.Context())
 	if err != nil {
 		writeStorageError(w, err)
 		return
@@ -34,13 +30,9 @@ func (s *Server) servePendingProjectCount(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) serveProjectsRoot(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	switch r.Method {
 	case http.MethodGet:
-		projects, err := s.store.ListProjects(r.Context())
+		projects, err := s.projects.List(r.Context())
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -63,7 +55,7 @@ func (s *Server) serveProjectsRoot(w http.ResponseWriter, r *http.Request) {
 		if req.Slug == "" {
 			req.Slug = slugify(req.Name)
 		}
-		p, err := s.store.CreateProject(r.Context(), req.Name, req.Slug)
+		p, err := s.projects.Create(r.Context(), req.Name, req.Slug)
 		if err != nil {
 			writeStorageError(w, err)
 			return

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -8,7 +8,7 @@ import (
 func (s *Server) approveProject(w http.ResponseWriter, r *http.Request) {
 	slug := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/projects/"), "/approve")
 	if err := s.projects.Approve(r.Context(), slug); err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSON(w, map[string]any{"ok": true})
@@ -17,7 +17,7 @@ func (s *Server) approveProject(w http.ResponseWriter, r *http.Request) {
 func (s *Server) servePendingProjectCount(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.projects.List(r.Context())
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	var pending []string
@@ -34,7 +34,7 @@ func (s *Server) serveProjectsRoot(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		projects, err := s.projects.List(r.Context())
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"projects": projects})
@@ -57,7 +57,7 @@ func (s *Server) serveProjectsRoot(w http.ResponseWriter, r *http.Request) {
 		}
 		p, err := s.projects.Create(r.Context(), req.Name, req.Slug)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSONStatus(w, http.StatusCreated, map[string]any{"project": p})

--- a/internal/api/releases.go
+++ b/internal/api/releases.go
@@ -13,7 +13,7 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		releases, err := s.releases.List(r.Context())
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"releases": releases})
@@ -46,7 +46,7 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 		}
 		item, err := s.releases.Create(r.Context(), release)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"release": item})
@@ -61,7 +61,7 @@ func (s *Server) serveReleaseRoute(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		item, err := s.releases.Get(r.Context(), releaseID)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"release": item})
@@ -94,13 +94,13 @@ func (s *Server) serveReleaseRoute(w http.ResponseWriter, r *http.Request) {
 		}
 		item, err := s.releases.Update(r.Context(), releaseID, release)
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"release": item})
 	case http.MethodDelete:
 		if err := s.releases.Delete(r.Context(), releaseID); err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"deleted": true})

--- a/internal/api/releases.go
+++ b/internal/api/releases.go
@@ -5,17 +5,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	switch r.Method {
 	case http.MethodGet:
-		releases, err := s.service.ListReleases(r.Context())
+		releases, err := s.releases.List(r.Context())
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -36,7 +32,7 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid release payload", http.StatusBadRequest)
 			return
 		}
-		release := storage.Release{
+		release := domain.Release{
 			Name:        request.Name,
 			Environment: request.Environment,
 			Version:     request.Version,
@@ -48,7 +44,7 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 		if parsed, err := time.Parse(time.RFC3339Nano, request.ObservedAt); err == nil {
 			release.ObservedAt = parsed
 		}
-		item, err := s.service.CreateRelease(r.Context(), release)
+		item, err := s.releases.Create(r.Context(), release)
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -60,14 +56,10 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) serveReleaseRoute(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	releaseID := strings.TrimPrefix(r.URL.Path, "/api/v1/releases/")
 	switch r.Method {
 	case http.MethodGet:
-		item, err := s.service.GetRelease(r.Context(), releaseID)
+		item, err := s.releases.Get(r.Context(), releaseID)
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -88,7 +80,7 @@ func (s *Server) serveReleaseRoute(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid release payload", http.StatusBadRequest)
 			return
 		}
-		release := storage.Release{
+		release := domain.Release{
 			Name:        request.Name,
 			Environment: request.Environment,
 			Version:     request.Version,
@@ -100,14 +92,14 @@ func (s *Server) serveReleaseRoute(w http.ResponseWriter, r *http.Request) {
 		if parsed, err := time.Parse(time.RFC3339Nano, request.ObservedAt); err == nil {
 			release.ObservedAt = parsed
 		}
-		item, err := s.service.UpdateRelease(r.Context(), releaseID, release)
+		item, err := s.releases.Update(r.Context(), releaseID, release)
 		if err != nil {
 			writeStorageError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"release": item})
 	case http.MethodDelete:
-		if err := s.service.DeleteRelease(r.Context(), releaseID); err != nil {
+		if err := s.releases.Delete(r.Context(), releaseID); err != nil {
 			writeStorageError(w, err)
 			return
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,9 +9,15 @@ import (
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
-	"github.com/wiebe-xyz/bugbarn/internal/service"
+	alertsvc "github.com/wiebe-xyz/bugbarn/internal/service/alerts"
+	analyticssvc "github.com/wiebe-xyz/bugbarn/internal/service/analytics"
+	issuesvc "github.com/wiebe-xyz/bugbarn/internal/service/issues"
+	logsvc "github.com/wiebe-xyz/bugbarn/internal/service/logs"
+	projectsvc "github.com/wiebe-xyz/bugbarn/internal/service/projects"
+	releasesvc "github.com/wiebe-xyz/bugbarn/internal/service/releases"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 	"github.com/wiebe-xyz/bugbarn/internal/worker"
 )
@@ -19,9 +25,14 @@ import (
 const defaultMaxSourceMapBytes = 32 << 20 // 32 MiB
 
 type Server struct {
-	ingestHandler      *ingest.Handler
-	store              *storage.Store
-	service            *service.Service
+	ingestHandler *ingest.Handler
+	issues        *issuesvc.Service
+	projects      *projectsvc.Service
+	releases      *releasesvc.Service
+	alerts        *alertsvc.Service
+	logs          *logsvc.Service
+	analytics     *analyticssvc.Service
+
 	users              *auth.UserAuthenticator
 	sessions           *auth.SessionManager
 	allowedOrigins     []string // parsed from BUGBARN_ALLOWED_ORIGINS
@@ -32,9 +43,9 @@ type Server struct {
 	maxSourceMapBytes  int64
 	funnelBarnEndpoint string
 	funnelBarnAPIKey   string
-	selfAPIKey          string
-	selfProject         string
-	workerStatus        *worker.Status
+	selfAPIKey         string
+	selfProject        string
+	workerStatus       *worker.Status
 	autoApproveProjects bool
 
 	loginLimiter sync.Map // map[string]*loginAttempt
@@ -90,14 +101,27 @@ func (s *Server) SetAutoApproveProjects(auto bool) {
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
-	return &Server{ingestHandler: ingestHandler, store: store, service: service.New(store), maxSourceMapBytes: defaultMaxSourceMapBytes}
+	return &Server{
+		ingestHandler:     ingestHandler,
+		issues:            issuesvc.New(store),
+		projects:          projectsvc.New(store),
+		releases:          releasesvc.New(store),
+		alerts:            alertsvc.New(store),
+		logs:              logsvc.New(store),
+		analytics:         analyticssvc.New(store),
+		maxSourceMapBytes: defaultMaxSourceMapBytes,
+	}
 }
 
 func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string) *Server {
 	s := &Server{
 		ingestHandler:     ingestHandler,
-		store:             store,
-		service:           service.New(store),
+		issues:            issuesvc.New(store),
+		projects:          projectsvc.New(store),
+		releases:          releasesvc.New(store),
+		alerts:            alertsvc.New(store),
+		logs:              logsvc.New(store),
+		analytics:         analyticssvc.New(store),
 		users:             users,
 		sessions:          sessions,
 		allowedOrigins:    allowedOrigins,
@@ -139,8 +163,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				logProjectID = pid
 			}
 		}
-		if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.store != nil {
-			if proj, err := s.store.EnsureProject(r.Context(), slug); err == nil {
+		if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.projects != nil {
+			if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
 				logProjectID = proj.ID
 			}
 		}
@@ -225,7 +249,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if s.ingestHandler != nil {
 			pid, scope, ok := s.ingestHandler.APIKeyProjectScope(r)
 			if ok {
-				if scope == storage.APIKeyScopeIngest {
+				if scope == domain.APIKeyScopeIngest {
 					log.Printf("auth: ingest-only key rejected for %s %s", r.Method, r.URL.Path)
 					http.Error(w, "forbidden: ingest-only key cannot access this endpoint", http.StatusForbidden)
 					return
@@ -268,19 +292,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// API key and session requests — it auto-creates the project if unknown,
 		// so a single shared API key can route events to any project via the header.
 		if slug := r.Header.Get("X-BugBarn-Project"); slug != "" {
-			if proj, err := s.store.EnsureProject(r.Context(), slug); err == nil {
+			if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
 				resolvedProjectID = proj.ID
 			}
 		} else if usingAPIKey && apiKeyProjectID > 0 {
 			resolvedProjectID = apiKeyProjectID
 		} else if usingSession && r.Method != http.MethodGet {
-			// Issue mutations (resolve/reopen/mute/unmute) operate on a globally-unique
-			// numeric row ID, so project context is not needed — leave projectID = 0 so
-			// the storage layer skips the project_id WHERE filter.
-			// All other non-GET writes default to the "default" project so that UI
-			// operations like creating releases or alerts still land somewhere sensible.
 			if !isIssueAction(r) {
-				if proj, err := s.store.ProjectBySlug(r.Context(), "default"); err == nil {
+				if proj, err := s.projects.BySlug(r.Context(), "default"); err == nil {
 					resolvedProjectID = proj.ID
 				}
 			}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -32,6 +33,7 @@ type Server struct {
 	alerts        *alertsvc.Service
 	logs          *logsvc.Service
 	analytics     *analyticssvc.Service
+	logger        *slog.Logger
 
 	users              *auth.UserAuthenticator
 	sessions           *auth.SessionManager
@@ -100,28 +102,36 @@ func (s *Server) SetAutoApproveProjects(auto bool) {
 	s.autoApproveProjects = auto
 }
 
-func NewServer(ingestHandler *ingest.Handler, store *storage.Store) *Server {
+func NewServer(ingestHandler *ingest.Handler, store *storage.Store, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Server{
 		ingestHandler:     ingestHandler,
-		issues:            issuesvc.New(store),
-		projects:          projectsvc.New(store),
-		releases:          releasesvc.New(store),
-		alerts:            alertsvc.New(store),
-		logs:              logsvc.New(store),
-		analytics:         analyticssvc.New(store),
+		issues:            issuesvc.New(store, logger),
+		projects:          projectsvc.New(store, logger),
+		releases:          releasesvc.New(store, logger),
+		alerts:            alertsvc.New(store, logger),
+		logs:              logsvc.New(store, logger),
+		analytics:         analyticssvc.New(store, logger),
+		logger:            logger.With("component", "api"),
 		maxSourceMapBytes: defaultMaxSourceMapBytes,
 	}
 }
 
-func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string) *Server {
+func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, users *auth.UserAuthenticator, sessions *auth.SessionManager, allowedOrigins []string, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	s := &Server{
 		ingestHandler:     ingestHandler,
-		issues:            issuesvc.New(store),
-		projects:          projectsvc.New(store),
-		releases:          releasesvc.New(store),
-		alerts:            alertsvc.New(store),
-		logs:              logsvc.New(store),
-		analytics:         analyticssvc.New(store),
+		issues:            issuesvc.New(store, logger),
+		projects:          projectsvc.New(store, logger),
+		releases:          releasesvc.New(store, logger),
+		alerts:            alertsvc.New(store, logger),
+		logs:              logsvc.New(store, logger),
+		analytics:         analyticssvc.New(store, logger),
+		logger:            logger.With("component", "api"),
 		users:             users,
 		sessions:          sessions,
 		allowedOrigins:    allowedOrigins,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -81,7 +81,7 @@ func TestServeHTTPQueryEndpoints(t *testing.T) {
 		},
 	})
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	t.Run("list issues", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -232,7 +232,7 @@ func TestServeHTTPStatefulEndpoints(t *testing.T) {
 		},
 	})
 
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	t.Run("resolve and reopen issue", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -332,7 +332,7 @@ func TestServeHTTPUserAuthentication(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessions := auth.NewSessionManager("test-secret", time.Hour)
-	server := NewServerWithAuth(nil, store, userAuth, sessions, nil)
+	server := NewServerWithAuth(nil, store, userAuth, sessions, nil, nil)
 
 	t.Run("query endpoints require session", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -418,7 +418,7 @@ func TestIngestOnlyKeyScope(t *testing.T) {
 	ingestHandler := ingest.NewHandler(authorizer, nil, 1<<20)
 	userAuth, _ := auth.NewUserAuthenticator("admin", "pass", "")
 	sessions := auth.NewSessionManager("secret", time.Hour)
-	server := NewServerWithAuth(ingestHandler, store, userAuth, sessions, nil)
+	server := NewServerWithAuth(ingestHandler, store, userAuth, sessions, nil, nil)
 
 	t.Run("ingest-only key is blocked from protected endpoints", func(t *testing.T) {
 		for _, path := range []string{"/api/v1/issues", "/api/v1/releases", "/api/v1/settings", "/api/v1/apikeys"} {
@@ -457,7 +457,7 @@ func TestIngestCORSHeaders(t *testing.T) {
 
 	store := mustOpenStore(t)
 	defer store.Close()
-	server := NewServer(nil, store)
+	server := NewServer(nil, store, nil)
 
 	t.Run("OPTIONS preflight returns wildcard ACAO", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -7,7 +7,7 @@ func (s *Server) serveSettingsRoute(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		settings, err := s.projects.GetSettings(r.Context())
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"settings": settings})
@@ -18,12 +18,12 @@ func (s *Server) serveSettingsRoute(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := s.projects.UpdateSettings(r.Context(), values); err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		settings, err := s.projects.GetSettings(r.Context())
 		if err != nil {
-			writeStorageError(w, err)
+			writeServiceError(w, err)
 			return
 		}
 		writeJSON(w, map[string]any{"settings": settings})

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -3,13 +3,9 @@ package api
 import "net/http"
 
 func (s *Server) serveSettingsRoute(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	switch r.Method {
 	case http.MethodGet:
-		settings, err := s.service.GetSettings(r.Context())
+		settings, err := s.projects.GetSettings(r.Context())
 		if err != nil {
 			writeStorageError(w, err)
 			return
@@ -21,11 +17,11 @@ func (s *Server) serveSettingsRoute(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid settings payload", http.StatusBadRequest)
 			return
 		}
-		if err := s.service.UpdateSettings(r.Context(), values); err != nil {
+		if err := s.projects.UpdateSettings(r.Context(), values); err != nil {
 			writeStorageError(w, err)
 			return
 		}
-		settings, err := s.service.GetSettings(r.Context())
+		settings, err := s.projects.GetSettings(r.Context())
 		if err != nil {
 			writeStorageError(w, err)
 			return

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func (s *Server) setupKey(slug string) string {
@@ -30,23 +30,18 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.store == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-
 	rawKey := s.setupKey(slug)
 	if rawKey == "" {
 		http.Error(w, "setup not configured (BUGBARN_SESSION_SECRET required)", http.StatusServiceUnavailable)
 		return
 	}
 
-	var proj storage.Project
+	var proj domain.Project
 	var err error
 	if s.autoApproveProjects {
-		proj, err = s.store.EnsureProject(r.Context(), slug)
+		proj, err = s.projects.Ensure(r.Context(), slug)
 	} else {
-		proj, err = s.store.EnsureProjectPending(r.Context(), slug)
+		proj, err = s.projects.EnsurePending(r.Context(), slug)
 	}
 	if err != nil {
 		log.Printf("setup: failed to ensure project %q: %v", slug, err)
@@ -54,9 +49,8 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure the setup API key exists (idempotent via UNIQUE key_sha256)
 	keySHA := hex.EncodeToString(sha256Sum(rawKey))
-	_ = s.store.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA)
+	_ = s.projects.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA)
 
 	endpoint := s.publicURL
 	if endpoint == "" {

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -5,30 +5,22 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func (s *Server) listSourceMaps(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
-	items, err := s.service.ListSourceMaps(r.Context())
+	items, err := s.releases.ListSourceMaps(r.Context())
 	if err != nil {
 		writeStorageError(w, err)
 		return
 	}
 	if items == nil {
-		items = []storage.SourceMapMeta{}
+		items = []domain.SourceMapMeta{}
 	}
 	writeJSON(w, map[string]any{"sourceMaps": items})
 }
 
 func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil || s.service == nil {
-		http.Error(w, "storage unavailable", http.StatusServiceUnavailable)
-		return
-	}
 	limit := s.maxSourceMapBytes
 	if limit <= 0 {
 		limit = defaultMaxSourceMapBytes
@@ -61,7 +53,7 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upload := storage.SourceMapUpload{
+	upload := domain.SourceMapUpload{
 		Release:     r.FormValue("release"),
 		Dist:        r.FormValue("dist"),
 		BundleURL:   r.FormValue("bundle_url"),
@@ -69,7 +61,7 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 		ContentType: header.Header.Get("Content-Type"),
 		Blob:        blob,
 	}
-	item, err := s.service.UploadSourceMap(r.Context(), upload)
+	item, err := s.releases.UploadSourceMap(r.Context(), upload)
 	if err != nil {
 		writeStorageError(w, err)
 		return

--- a/internal/api/sourcemaps.go
+++ b/internal/api/sourcemaps.go
@@ -11,7 +11,7 @@ import (
 func (s *Server) listSourceMaps(w http.ResponseWriter, r *http.Request) {
 	items, err := s.releases.ListSourceMaps(r.Context())
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	if items == nil {
@@ -63,7 +63,7 @@ func (s *Server) uploadSourceMap(w http.ResponseWriter, r *http.Request) {
 	}
 	item, err := s.releases.UploadSourceMap(r.Context(), upload)
 	if err != nil {
-		writeStorageError(w, err)
+		writeServiceError(w, err)
 		return
 	}
 	writeJSONStatus(w, http.StatusAccepted, map[string]any{

--- a/internal/apperr/errors.go
+++ b/internal/apperr/errors.go
@@ -1,0 +1,52 @@
+package apperr
+
+import "fmt"
+
+type Error struct {
+	Code    string
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Code, e.Message, e.Err)
+	}
+	if e.Message != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	return e.Code
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+func (e *Error) Is(target error) bool {
+	t, ok := target.(*Error)
+	if !ok {
+		return false
+	}
+	return e.Code == t.Code
+}
+
+var (
+	ErrNotFound     = &Error{Code: "not_found"}
+	ErrConflict     = &Error{Code: "conflict"}
+	ErrInvalidInput = &Error{Code: "invalid_input"}
+	ErrInternal     = &Error{Code: "internal"}
+)
+
+func NotFound(msg string, cause error) *Error {
+	return &Error{Code: "not_found", Message: msg, Err: cause}
+}
+
+func Conflict(msg string, cause error) *Error {
+	return &Error{Code: "conflict", Message: msg, Err: cause}
+}
+
+func InvalidInput(msg string, cause error) *Error {
+	return &Error{Code: "invalid_input", Message: msg, Err: cause}
+}
+
+func Internal(msg string, cause error) *Error {
+	return &Error{Code: "internal", Message: msg, Err: cause}
+}

--- a/internal/apperr/errors_test.go
+++ b/internal/apperr/errors_test.go
@@ -1,0 +1,95 @@
+package apperr_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+)
+
+func TestErrorIs(t *testing.T) {
+	t.Parallel()
+
+	err := apperr.NotFound("issue not found", fmt.Errorf("sql: no rows"))
+
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Error("expected NotFound error to match ErrNotFound sentinel")
+	}
+	if errors.Is(err, apperr.ErrConflict) {
+		t.Error("NotFound error should not match ErrConflict")
+	}
+	if errors.Is(err, apperr.ErrInvalidInput) {
+		t.Error("NotFound error should not match ErrInvalidInput")
+	}
+}
+
+func TestErrorAs(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("underlying db error")
+	err := apperr.Internal("query failed", cause)
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatal("expected errors.As to succeed")
+	}
+	if appErr.Code != "internal" {
+		t.Errorf("code: got %q, want %q", appErr.Code, "internal")
+	}
+	if appErr.Message != "query failed" {
+		t.Errorf("message: got %q, want %q", appErr.Message, "query failed")
+	}
+}
+
+func TestErrorUnwrap(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("connection reset")
+	err := apperr.Internal("db error", cause)
+
+	if !errors.Is(err, cause) {
+		t.Error("expected Unwrap to expose the underlying cause")
+	}
+}
+
+func TestErrorString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *apperr.Error
+		want string
+	}{
+		{"with cause", apperr.NotFound("issue", fmt.Errorf("no rows")), "not_found: issue: no rows"},
+		{"without cause", apperr.InvalidInput("bad id", nil), "invalid_input: bad id"},
+		{"sentinel", apperr.ErrConflict, "conflict"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWrappedInStandardError(t *testing.T) {
+	t.Parallel()
+
+	inner := apperr.NotFound("user", nil)
+	wrapped := fmt.Errorf("service: %w", inner)
+
+	if !errors.Is(wrapped, apperr.ErrNotFound) {
+		t.Error("expected wrapped error to match ErrNotFound via errors.Is")
+	}
+
+	var appErr *apperr.Error
+	if !errors.As(wrapped, &appErr) {
+		t.Fatal("expected errors.As to find *apperr.Error through wrapping")
+	}
+	if appErr.Code != "not_found" {
+		t.Errorf("code: got %q, want %q", appErr.Code, "not_found")
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -10,36 +10,26 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 // Config controls when and how the digest is delivered.
-// Toggle email via Mail.Enabled; toggle webhook by setting/clearing WebhookURL.
-// Neither channel starting means no scheduler goroutine is launched.
 type Config struct {
-	// Scheduling (UTC)
-	Day  int // 0=Sunday … 6=Saturday
-	Hour int // 0–23
-
-	// Webhook delivery — set to "" to disable
+	Day        int // 0=Sunday … 6=Saturday
+	Hour       int // 0–23
 	WebhookURL string
-
-	// Email delivery — set Mail.Enabled=false to disable without losing credentials
-	Mail MailConfig
-
-	// Display
-	PublicURL string
+	Mail       MailConfig
+	PublicURL  string
 }
 
-// Enabled reports whether at least one delivery channel is active.
 func (c Config) Enabled() bool {
 	return c.WebhookURL != "" || c.Mail.active()
 }
 
-// Store is the subset of storage.Store used by the digest.
+// Store is the subset of storage needed by the digest.
 type Store interface {
-	WeeklyDigest(ctx context.Context, projectID int64, since time.Time) (storage.DigestData, error)
-	ListProjects(ctx context.Context) ([]storage.Project, error)
+	WeeklyDigest(ctx context.Context, projectID int64, since time.Time) (domain.DigestData, error)
+	ListProjects(ctx context.Context) ([]domain.Project, error)
 }
 
 // payload is the JSON shape POSTed to the webhook.
@@ -72,7 +62,7 @@ type issueBlock struct {
 	URL        string `json:"url,omitempty"`
 }
 
-func buildSection(cfg Config, slug string, data storage.DigestData) projectSection {
+func buildSection(cfg Config, slug string, data domain.DigestData) projectSection {
 	sec := projectSection{
 		Project: slug,
 		Stats: statsBlock{

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -1,0 +1,192 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/event"
+)
+
+// Issue represents a grouped error occurrence.
+type Issue struct {
+	ID                     string
+	IssueNumber            int
+	Fingerprint            string
+	FingerprintMaterial    string
+	FingerprintExplanation []string
+	Title                  string
+	NormalizedTitle        string
+	ExceptionType          string
+	Status                 string
+	MuteMode               string // "until_regression" | "forever" | ""
+	ResolvedAt             time.Time
+	ReopenedAt             time.Time
+	LastRegressedAt        time.Time
+	RegressionCount        int
+	FirstSeen              time.Time
+	LastSeen               time.Time
+	EventCount             int
+	RepresentativeEvent    event.Event
+	ProjectSlug            string `json:"project_slug,omitempty"`
+}
+
+// IssueFilter holds optional filters and sort order for listing issues.
+type IssueFilter struct {
+	Sort   string
+	Status string
+	Query  string
+	Facets map[string]string
+	Limit  int
+	Offset int
+}
+
+// Event represents a single captured error event.
+type Event struct {
+	ID                     string
+	IssueID                string
+	Fingerprint            string
+	FingerprintMaterial    string
+	FingerprintExplanation []string
+	ReceivedAt             time.Time
+	ObservedAt             time.Time
+	Severity               string
+	Message                string
+	Regressed              bool
+	Payload                event.Event
+}
+
+// Project represents a project row.
+type Project struct {
+	ID           int64
+	Name         string
+	Slug         string
+	Status       string
+	IssuePrefix  string
+	IssueCounter int
+	CreatedAt    time.Time
+}
+
+// Scope constants for API keys.
+const (
+	APIKeyScopeFull   = "full"
+	APIKeyScopeIngest = "ingest"
+)
+
+// APIKey represents an API key row (the plaintext key is never stored).
+type APIKey struct {
+	ID         int64
+	Name       string
+	ProjectID  int64
+	KeySHA256  string
+	Scope      string
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+}
+
+// Release represents a software release row.
+type Release struct {
+	ID          string
+	Name        string
+	Environment string
+	ObservedAt  time.Time
+	Version     string
+	CommitSHA   string
+	URL         string
+	Notes       string
+	CreatedBy   string
+	CreatedAt   time.Time
+}
+
+// Alert represents a project alert row.
+type Alert struct {
+	ID              string         `json:"id"`
+	Name            string         `json:"name"`
+	Enabled         bool           `json:"enabled"`
+	Severity        string         `json:"severity,omitempty"`
+	Rule            map[string]any `json:"rule,omitempty"`
+	WebhookURL      string         `json:"webhook_url,omitempty"`
+	Condition       string         `json:"condition,omitempty"`
+	Threshold       int            `json:"threshold,omitempty"`
+	CooldownMinutes int            `json:"cooldown_minutes,omitempty"`
+	LastFiredAt     time.Time      `json:"last_fired_at,omitempty"`
+	CreatedAt       time.Time      `json:"created_at,omitempty"`
+	UpdatedAt       time.Time      `json:"updated_at,omitempty"`
+	ProjectSlug     string         `json:"project_slug,omitempty"`
+}
+
+// LogEntry represents a single structured log line stored per project.
+type LogEntry struct {
+	ID          int64          `json:"id"`
+	ProjectID   int64          `json:"project_id,omitempty"`
+	ProjectSlug string         `json:"project_slug,omitempty"`
+	ReceivedAt  time.Time      `json:"received_at"`
+	LevelNum    int            `json:"level_num"`
+	Level       string         `json:"level"`
+	Message     string         `json:"message"`
+	Data        map[string]any `json:"data,omitempty"`
+}
+
+// Setting represents a project setting row.
+type Setting struct {
+	Key       string
+	Value     string
+	UpdatedAt time.Time
+}
+
+// User represents an admin user stored in the database.
+type User struct {
+	ID             int64
+	Username       string
+	PasswordBcrypt string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// SourceMap represents a stored source map file.
+type SourceMap struct {
+	ID          string
+	Release     string
+	Dist        string
+	BundleURL   string
+	Name        string
+	ContentType string
+	SizeBytes   int64
+	UploadedAt  time.Time
+}
+
+// SourceMapMeta holds the metadata columns for a source map row (no blob).
+type SourceMapMeta struct {
+	ID        string    `json:"id"`
+	Release   string    `json:"release"`
+	Dist      string    `json:"dist"`
+	BundleURL string    `json:"bundleUrl"`
+	Name      string    `json:"name"`
+	SizeBytes int64     `json:"size"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// SourceMapUpload represents a source map upload request.
+type SourceMapUpload struct {
+	Release     string
+	Dist        string
+	BundleURL   string
+	Name        string
+	ContentType string
+	Blob        []byte
+}
+
+// DigestIssue is a summary of a single issue for the weekly digest.
+type DigestIssue struct {
+	ID         string
+	Title      string
+	EventCount int
+	Status     string
+}
+
+// DigestData holds aggregate stats for the weekly digest.
+type DigestData struct {
+	TotalEvents    int
+	NewIssues      int
+	ResolvedIssues int
+	Regressions    int
+	TopIssues      []DigestIssue
+}

--- a/internal/domainevents/events.go
+++ b/internal/domainevents/events.go
@@ -1,16 +1,16 @@
 package domainevents
 
-import "github.com/wiebe-xyz/bugbarn/internal/storage"
+import "github.com/wiebe-xyz/bugbarn/internal/domain"
 
 // IssueCreated is published when a brand-new issue is persisted.
 type IssueCreated struct {
-	Issue     storage.Issue
+	Issue     domain.Issue
 	ProjectID int64
 }
 
 // IssueRegressed is published when a previously-resolved issue receives a new event.
 type IssueRegressed struct {
-	Issue     storage.Issue
+	Issue     domain.Issue
 	ProjectID int64
 }
 
@@ -18,7 +18,7 @@ type IssueRegressed struct {
 // regardless of whether the issue is new or regressed. Used to evaluate
 // event_count_exceeds alert conditions.
 type IssueEventRecorded struct {
-	Issue     storage.Issue
+	Issue     domain.Issue
 	ProjectID int64
 }
 

--- a/internal/logstream/hub.go
+++ b/internal/logstream/hub.go
@@ -3,26 +3,26 @@ package logstream
 import (
 	"sync"
 
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 // Hub fans published log entries out to registered SSE subscribers.
 type Hub struct {
 	mu   sync.RWMutex
-	subs map[int64][]chan storage.LogEntry // projectID → channels
+	subs map[int64][]chan domain.LogEntry // projectID → channels
 }
 
 // NewHub creates a new Hub ready for use.
 func NewHub() *Hub {
 	return &Hub{
-		subs: make(map[int64][]chan storage.LogEntry),
+		subs: make(map[int64][]chan domain.LogEntry),
 	}
 }
 
 // Subscribe returns a channel that receives entries for projectID, and a cancel func.
 // Buffer size 64; slow consumers miss entries (non-blocking send).
-func (h *Hub) Subscribe(projectID int64) (<-chan storage.LogEntry, func()) {
-	ch := make(chan storage.LogEntry, 64)
+func (h *Hub) Subscribe(projectID int64) (<-chan domain.LogEntry, func()) {
+	ch := make(chan domain.LogEntry, 64)
 
 	h.mu.Lock()
 	h.subs[projectID] = append(h.subs[projectID], ch)
@@ -50,10 +50,10 @@ func (h *Hub) Subscribe(projectID int64) (<-chan storage.LogEntry, func()) {
 // Publish sends an entry to all current subscribers for that project,
 // and also to all-projects subscribers (those subscribed with projectID=0).
 // Uses non-blocking sends so slow consumers do not block the publisher.
-func (h *Hub) Publish(projectID int64, entry storage.LogEntry) {
+func (h *Hub) Publish(projectID int64, entry domain.LogEntry) {
 	h.mu.RLock()
 	chans := h.subs[projectID]
-	var allChans []chan storage.LogEntry
+	var allChans []chan domain.LogEntry
 	if projectID != 0 {
 		allChans = h.subs[0]
 	}

--- a/internal/selflog/handler.go
+++ b/internal/selflog/handler.go
@@ -1,0 +1,35 @@
+package selflog
+
+import (
+	"context"
+	"log/slog"
+
+	bb "github.com/wiebe-xyz/bugbarn-go"
+)
+
+type Handler struct {
+	inner slog.Handler
+}
+
+func NewHandler(inner slog.Handler) *Handler {
+	return &Handler{inner: inner}
+}
+
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelError {
+		bb.CaptureMessage(r.Message)
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Handler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h *Handler) WithGroup(name string) slog.Handler {
+	return &Handler{inner: h.inner.WithGroup(name)}
+}

--- a/internal/service/alerts/service.go
+++ b/internal/service/alerts/service.go
@@ -1,0 +1,44 @@
+package alerts
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// Repository defines the data access contract for alert operations.
+type Repository interface {
+	ListAlerts(context.Context) ([]domain.Alert, error)
+	GetAlert(context.Context, string) (domain.Alert, error)
+	CreateAlert(context.Context, domain.Alert) (domain.Alert, error)
+	UpdateAlert(context.Context, string, domain.Alert) (domain.Alert, error)
+	DeleteAlert(context.Context, string) error
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) List(ctx context.Context) ([]domain.Alert, error) {
+	return s.repo.ListAlerts(ctx)
+}
+
+func (s *Service) Get(ctx context.Context, id string) (domain.Alert, error) {
+	return s.repo.GetAlert(ctx, id)
+}
+
+func (s *Service) Create(ctx context.Context, alert domain.Alert) (domain.Alert, error) {
+	return s.repo.CreateAlert(ctx, alert)
+}
+
+func (s *Service) Update(ctx context.Context, id string, alert domain.Alert) (domain.Alert, error) {
+	return s.repo.UpdateAlert(ctx, id, alert)
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return s.repo.DeleteAlert(ctx, id)
+}

--- a/internal/service/alerts/service.go
+++ b/internal/service/alerts/service.go
@@ -2,11 +2,11 @@ package alerts
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
-// Repository defines the data access contract for alert operations.
 type Repository interface {
 	ListAlerts(context.Context) ([]domain.Alert, error)
 	GetAlert(context.Context, string) (domain.Alert, error)
@@ -16,11 +16,15 @@ type Repository interface {
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "alerts")}
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Alert, error) {
@@ -28,17 +32,38 @@ func (s *Service) List(ctx context.Context) ([]domain.Alert, error) {
 }
 
 func (s *Service) Get(ctx context.Context, id string) (domain.Alert, error) {
-	return s.repo.GetAlert(ctx, id)
+	alert, err := s.repo.GetAlert(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "get alert", "alert_id", id, "error", err)
+		return domain.Alert{}, err
+	}
+	return alert, nil
 }
 
 func (s *Service) Create(ctx context.Context, alert domain.Alert) (domain.Alert, error) {
-	return s.repo.CreateAlert(ctx, alert)
+	created, err := s.repo.CreateAlert(ctx, alert)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "create alert", "name", alert.Name, "error", err)
+		return domain.Alert{}, err
+	}
+	s.logger.InfoContext(ctx, "alert created", "alert_id", created.ID, "name", created.Name)
+	return created, nil
 }
 
 func (s *Service) Update(ctx context.Context, id string, alert domain.Alert) (domain.Alert, error) {
-	return s.repo.UpdateAlert(ctx, id, alert)
+	updated, err := s.repo.UpdateAlert(ctx, id, alert)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "update alert", "alert_id", id, "error", err)
+		return domain.Alert{}, err
+	}
+	return updated, nil
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
-	return s.repo.DeleteAlert(ctx, id)
+	if err := s.repo.DeleteAlert(ctx, id); err != nil {
+		s.logger.ErrorContext(ctx, "delete alert", "alert_id", id, "error", err)
+		return err
+	}
+	s.logger.InfoContext(ctx, "alert deleted", "alert_id", id)
+	return nil
 }

--- a/internal/service/alerts/service_test.go
+++ b/internal/service/alerts/service_test.go
@@ -1,0 +1,105 @@
+package alerts
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+type fakeRepo struct {
+	alerts map[string]domain.Alert
+	err    error
+}
+
+func (f *fakeRepo) ListAlerts(context.Context) ([]domain.Alert, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) GetAlert(_ context.Context, id string) (domain.Alert, error) {
+	if f.err != nil {
+		return domain.Alert{}, f.err
+	}
+	a, ok := f.alerts[id]
+	if !ok {
+		return domain.Alert{}, apperr.NotFound("alert not found", nil)
+	}
+	return a, nil
+}
+
+func (f *fakeRepo) CreateAlert(_ context.Context, a domain.Alert) (domain.Alert, error) {
+	if f.err != nil {
+		return domain.Alert{}, f.err
+	}
+	a.ID = "alert-1"
+	f.alerts[a.ID] = a
+	return a, nil
+}
+
+func (f *fakeRepo) UpdateAlert(_ context.Context, id string, a domain.Alert) (domain.Alert, error) {
+	return domain.Alert{}, f.err
+}
+
+func (f *fakeRepo) DeleteAlert(_ context.Context, id string) error {
+	if f.err != nil {
+		return f.err
+	}
+	if _, ok := f.alerts[id]; !ok {
+		return apperr.NotFound("alert not found", nil)
+	}
+	delete(f.alerts, id)
+	return nil
+}
+
+func TestCreate_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{alerts: map[string]domain.Alert{}}
+	svc := New(repo, nil)
+
+	input := domain.Alert{Name: "High error rate", Enabled: true}
+	got, err := svc.Create(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if got.Name != "High error rate" {
+		t.Errorf("Name: got %q, want %q", got.Name, "High error rate")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{alerts: map[string]domain.Alert{}}
+	svc := New(repo, nil)
+
+	_, err := svc.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDelete_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{alerts: map[string]domain.Alert{
+		"alert-1": {ID: "alert-1", Name: "test"},
+	}}
+	svc := New(repo, nil)
+
+	err := svc.Delete(context.Background(), "alert-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := repo.alerts["alert-1"]; ok {
+		t.Error("expected alert to be deleted from repo")
+	}
+}

--- a/internal/service/analytics/service.go
+++ b/internal/service/analytics/service.go
@@ -1,0 +1,64 @@
+package analytics
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/bugbarn/internal/analytics"
+)
+
+// Repository defines the data access contract for analytics operations.
+type Repository interface {
+	InsertPageView(context.Context, analytics.PageView) error
+	QueryOverview(context.Context, analytics.Query) (analytics.OverviewResult, error)
+	QueryPages(context.Context, analytics.Query) ([]analytics.PageStat, error)
+	QueryTimeline(context.Context, analytics.Query, string) ([]analytics.TimelineBucket, error)
+	QueryReferrers(context.Context, analytics.Query) ([]analytics.ReferrerStat, error)
+	QuerySegments(context.Context, analytics.Query, string) ([]analytics.SegmentBucket, error)
+	QueryPageFlow(context.Context, analytics.Query, string) (analytics.PageFlowResult, error)
+	QueryScrollDepth(context.Context, analytics.Query, string) (analytics.ScrollDepthResult, error)
+	QueryDropout(context.Context, analytics.Query) ([]analytics.DropoutStat, error)
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) InsertPageView(ctx context.Context, pv analytics.PageView) error {
+	return s.repo.InsertPageView(ctx, pv)
+}
+
+func (s *Service) QueryOverview(ctx context.Context, q analytics.Query) (analytics.OverviewResult, error) {
+	return s.repo.QueryOverview(ctx, q)
+}
+
+func (s *Service) QueryPages(ctx context.Context, q analytics.Query) ([]analytics.PageStat, error) {
+	return s.repo.QueryPages(ctx, q)
+}
+
+func (s *Service) QueryTimeline(ctx context.Context, q analytics.Query, granularity string) ([]analytics.TimelineBucket, error) {
+	return s.repo.QueryTimeline(ctx, q, granularity)
+}
+
+func (s *Service) QueryReferrers(ctx context.Context, q analytics.Query) ([]analytics.ReferrerStat, error) {
+	return s.repo.QueryReferrers(ctx, q)
+}
+
+func (s *Service) QuerySegments(ctx context.Context, q analytics.Query, dimKey string) ([]analytics.SegmentBucket, error) {
+	return s.repo.QuerySegments(ctx, q, dimKey)
+}
+
+func (s *Service) QueryPageFlow(ctx context.Context, q analytics.Query, pathname string) (analytics.PageFlowResult, error) {
+	return s.repo.QueryPageFlow(ctx, q, pathname)
+}
+
+func (s *Service) QueryScrollDepth(ctx context.Context, q analytics.Query, pathname string) (analytics.ScrollDepthResult, error) {
+	return s.repo.QueryScrollDepth(ctx, q, pathname)
+}
+
+func (s *Service) QueryDropout(ctx context.Context, q analytics.Query) ([]analytics.DropoutStat, error) {
+	return s.repo.QueryDropout(ctx, q)
+}

--- a/internal/service/analytics/service.go
+++ b/internal/service/analytics/service.go
@@ -2,11 +2,11 @@ package analytics
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/analytics"
 )
 
-// Repository defines the data access contract for analytics operations.
 type Repository interface {
 	InsertPageView(context.Context, analytics.PageView) error
 	QueryOverview(context.Context, analytics.Query) (analytics.OverviewResult, error)
@@ -20,11 +20,15 @@ type Repository interface {
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "analytics")}
 }
 
 func (s *Service) InsertPageView(ctx context.Context, pv analytics.PageView) error {
@@ -32,7 +36,12 @@ func (s *Service) InsertPageView(ctx context.Context, pv analytics.PageView) err
 }
 
 func (s *Service) QueryOverview(ctx context.Context, q analytics.Query) (analytics.OverviewResult, error) {
-	return s.repo.QueryOverview(ctx, q)
+	result, err := s.repo.QueryOverview(ctx, q)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "query overview", "error", err)
+		return analytics.OverviewResult{}, err
+	}
+	return result, nil
 }
 
 func (s *Service) QueryPages(ctx context.Context, q analytics.Query) ([]analytics.PageStat, error) {

--- a/internal/service/issues/service.go
+++ b/internal/service/issues/service.go
@@ -1,0 +1,96 @@
+package issues
+
+import (
+	"context"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// Repository defines the data access contract for issue operations.
+type Repository interface {
+	ListIssues(context.Context) ([]domain.Issue, error)
+	ListIssuesFiltered(context.Context, domain.IssueFilter) ([]domain.Issue, error)
+	GetIssue(context.Context, string) (domain.Issue, error)
+	ResolveIssue(context.Context, string) (domain.Issue, error)
+	ReopenIssue(context.Context, string) (domain.Issue, error)
+	MuteIssue(ctx context.Context, id, muteMode string) (domain.Issue, error)
+	UnmuteIssue(context.Context, string) (domain.Issue, error)
+	HourlyEventCounts(context.Context, []int64) (map[int64][24]int, error)
+	IssueRowIDByDisplayID(context.Context, string) (int64, error)
+	ListIssueEvents(ctx context.Context, issueID string, limit int, beforeID int64) ([]domain.Event, bool, error)
+	GetEvent(context.Context, string) (domain.Event, error)
+	ListRecentEvents(ctx context.Context, limit int, since time.Time) ([]domain.Event, error)
+	ListFacetKeys(ctx context.Context, projectID int64) ([]string, error)
+	ListFacetValues(ctx context.Context, projectID int64, key string) ([]string, error)
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) List(ctx context.Context) ([]domain.Issue, error) {
+	return s.repo.ListIssues(ctx)
+}
+
+func (s *Service) ListFiltered(ctx context.Context, filter domain.IssueFilter) ([]domain.Issue, error) {
+	return s.repo.ListIssuesFiltered(ctx, filter)
+}
+
+func (s *Service) Get(ctx context.Context, id string) (domain.Issue, error) {
+	return s.repo.GetIssue(ctx, id)
+}
+
+func (s *Service) Resolve(ctx context.Context, id string) (domain.Issue, error) {
+	return s.repo.ResolveIssue(ctx, id)
+}
+
+func (s *Service) Reopen(ctx context.Context, id string) (domain.Issue, error) {
+	return s.repo.ReopenIssue(ctx, id)
+}
+
+func (s *Service) Mute(ctx context.Context, id, muteMode string) (domain.Issue, error) {
+	return s.repo.MuteIssue(ctx, id, muteMode)
+}
+
+func (s *Service) Unmute(ctx context.Context, id string) (domain.Issue, error) {
+	return s.repo.UnmuteIssue(ctx, id)
+}
+
+func (s *Service) HourlyEventCounts(ctx context.Context, issueIDs []int64) (map[int64][24]int, error) {
+	return s.repo.HourlyEventCounts(ctx, issueIDs)
+}
+
+func (s *Service) RowIDByDisplayID(ctx context.Context, displayID string) (int64, error) {
+	return s.repo.IssueRowIDByDisplayID(ctx, displayID)
+}
+
+func (s *Service) ListEvents(ctx context.Context, issueID string, limit int, beforeID int64) ([]domain.Event, bool, error) {
+	return s.repo.ListIssueEvents(ctx, issueID, limit, beforeID)
+}
+
+func (s *Service) GetEvent(ctx context.Context, id string) (domain.Event, error) {
+	return s.repo.GetEvent(ctx, id)
+}
+
+func (s *Service) ListLiveEvents(ctx context.Context, limit int, since time.Time) ([]domain.Event, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	if since.IsZero() {
+		since = time.Now().UTC().Add(-15 * time.Minute)
+	}
+	return s.repo.ListRecentEvents(ctx, limit, since)
+}
+
+func (s *Service) ListFacetKeys(ctx context.Context, projectID int64) ([]string, error) {
+	return s.repo.ListFacetKeys(ctx, projectID)
+}
+
+func (s *Service) ListFacetValues(ctx context.Context, projectID int64, key string) ([]string, error) {
+	return s.repo.ListFacetValues(ctx, projectID, key)
+}

--- a/internal/service/issues/service.go
+++ b/internal/service/issues/service.go
@@ -2,12 +2,12 @@ package issues
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
-// Repository defines the data access contract for issue operations.
 type Repository interface {
 	ListIssues(context.Context) ([]domain.Issue, error)
 	ListIssuesFiltered(context.Context, domain.IssueFilter) ([]domain.Issue, error)
@@ -26,43 +26,91 @@ type Repository interface {
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "issues")}
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Issue, error) {
-	return s.repo.ListIssues(ctx)
+	issues, err := s.repo.ListIssues(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "list issues", "error", err)
+		return nil, err
+	}
+	return issues, nil
 }
 
 func (s *Service) ListFiltered(ctx context.Context, filter domain.IssueFilter) ([]domain.Issue, error) {
-	return s.repo.ListIssuesFiltered(ctx, filter)
+	issues, err := s.repo.ListIssuesFiltered(ctx, filter)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "list issues filtered", "error", err)
+		return nil, err
+	}
+	return issues, nil
 }
 
 func (s *Service) Get(ctx context.Context, id string) (domain.Issue, error) {
-	return s.repo.GetIssue(ctx, id)
+	issue, err := s.repo.GetIssue(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "get issue", "issue_id", id, "error", err)
+		return domain.Issue{}, err
+	}
+	return issue, nil
 }
 
 func (s *Service) Resolve(ctx context.Context, id string) (domain.Issue, error) {
-	return s.repo.ResolveIssue(ctx, id)
+	issue, err := s.repo.ResolveIssue(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "resolve issue", "issue_id", id, "error", err)
+		return domain.Issue{}, err
+	}
+	s.logger.InfoContext(ctx, "issue resolved", "issue_id", id)
+	return issue, nil
 }
 
 func (s *Service) Reopen(ctx context.Context, id string) (domain.Issue, error) {
-	return s.repo.ReopenIssue(ctx, id)
+	issue, err := s.repo.ReopenIssue(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "reopen issue", "issue_id", id, "error", err)
+		return domain.Issue{}, err
+	}
+	s.logger.InfoContext(ctx, "issue reopened", "issue_id", id)
+	return issue, nil
 }
 
 func (s *Service) Mute(ctx context.Context, id, muteMode string) (domain.Issue, error) {
-	return s.repo.MuteIssue(ctx, id, muteMode)
+	issue, err := s.repo.MuteIssue(ctx, id, muteMode)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "mute issue", "issue_id", id, "mute_mode", muteMode, "error", err)
+		return domain.Issue{}, err
+	}
+	s.logger.InfoContext(ctx, "issue muted", "issue_id", id, "mute_mode", muteMode)
+	return issue, nil
 }
 
 func (s *Service) Unmute(ctx context.Context, id string) (domain.Issue, error) {
-	return s.repo.UnmuteIssue(ctx, id)
+	issue, err := s.repo.UnmuteIssue(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "unmute issue", "issue_id", id, "error", err)
+		return domain.Issue{}, err
+	}
+	s.logger.InfoContext(ctx, "issue unmuted", "issue_id", id)
+	return issue, nil
 }
 
 func (s *Service) HourlyEventCounts(ctx context.Context, issueIDs []int64) (map[int64][24]int, error) {
-	return s.repo.HourlyEventCounts(ctx, issueIDs)
+	counts, err := s.repo.HourlyEventCounts(ctx, issueIDs)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "hourly event counts", "error", err)
+		return nil, err
+	}
+	return counts, nil
 }
 
 func (s *Service) RowIDByDisplayID(ctx context.Context, displayID string) (int64, error) {
@@ -70,11 +118,21 @@ func (s *Service) RowIDByDisplayID(ctx context.Context, displayID string) (int64
 }
 
 func (s *Service) ListEvents(ctx context.Context, issueID string, limit int, beforeID int64) ([]domain.Event, bool, error) {
-	return s.repo.ListIssueEvents(ctx, issueID, limit, beforeID)
+	events, hasMore, err := s.repo.ListIssueEvents(ctx, issueID, limit, beforeID)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "list events", "issue_id", issueID, "error", err)
+		return nil, false, err
+	}
+	return events, hasMore, nil
 }
 
 func (s *Service) GetEvent(ctx context.Context, id string) (domain.Event, error) {
-	return s.repo.GetEvent(ctx, id)
+	evt, err := s.repo.GetEvent(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "get event", "event_id", id, "error", err)
+		return domain.Event{}, err
+	}
+	return evt, nil
 }
 
 func (s *Service) ListLiveEvents(ctx context.Context, limit int, since time.Time) ([]domain.Event, error) {
@@ -84,7 +142,12 @@ func (s *Service) ListLiveEvents(ctx context.Context, limit int, since time.Time
 	if since.IsZero() {
 		since = time.Now().UTC().Add(-15 * time.Minute)
 	}
-	return s.repo.ListRecentEvents(ctx, limit, since)
+	events, err := s.repo.ListRecentEvents(ctx, limit, since)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "list live events", "error", err)
+		return nil, err
+	}
+	return events, nil
 }
 
 func (s *Service) ListFacetKeys(ctx context.Context, projectID int64) ([]string, error) {

--- a/internal/service/issues/service_test.go
+++ b/internal/service/issues/service_test.go
@@ -1,0 +1,228 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// fakeRepo implements Repository for testing.
+type fakeRepo struct {
+	issues map[string]domain.Issue
+	events []domain.Event
+	err    error
+}
+
+func (f *fakeRepo) ListIssues(context.Context) ([]domain.Issue, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) ListIssuesFiltered(context.Context, domain.IssueFilter) ([]domain.Issue, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) GetIssue(_ context.Context, id string) (domain.Issue, error) {
+	if f.err != nil {
+		return domain.Issue{}, f.err
+	}
+	iss, ok := f.issues[id]
+	if !ok {
+		return domain.Issue{}, apperr.NotFound("issue not found", nil)
+	}
+	return iss, nil
+}
+
+func (f *fakeRepo) ResolveIssue(_ context.Context, id string) (domain.Issue, error) {
+	return domain.Issue{}, f.err
+}
+
+func (f *fakeRepo) ReopenIssue(_ context.Context, id string) (domain.Issue, error) {
+	return domain.Issue{}, f.err
+}
+
+func (f *fakeRepo) MuteIssue(_ context.Context, id, muteMode string) (domain.Issue, error) {
+	if f.err != nil {
+		return domain.Issue{}, f.err
+	}
+	iss, ok := f.issues[id]
+	if !ok {
+		return domain.Issue{}, apperr.NotFound("issue not found", nil)
+	}
+	iss.MuteMode = muteMode
+	f.issues[id] = iss
+	return iss, nil
+}
+
+func (f *fakeRepo) UnmuteIssue(_ context.Context, id string) (domain.Issue, error) {
+	return domain.Issue{}, f.err
+}
+
+func (f *fakeRepo) HourlyEventCounts(context.Context, []int64) (map[int64][24]int, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) IssueRowIDByDisplayID(context.Context, string) (int64, error) {
+	return 0, f.err
+}
+
+func (f *fakeRepo) ListIssueEvents(_ context.Context, _ string, _ int, _ int64) ([]domain.Event, bool, error) {
+	return nil, false, f.err
+}
+
+func (f *fakeRepo) GetEvent(context.Context, string) (domain.Event, error) {
+	return domain.Event{}, f.err
+}
+
+func (f *fakeRepo) ListRecentEvents(_ context.Context, limit int, since time.Time) ([]domain.Event, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.events, nil
+}
+
+func (f *fakeRepo) ListFacetKeys(_ context.Context, _ int64) ([]string, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) ListFacetValues(_ context.Context, _ int64, _ string) ([]string, error) {
+	return nil, f.err
+}
+
+func TestGet_Happy(t *testing.T) {
+	t.Parallel()
+
+	want := domain.Issue{ID: "iss-1", Title: "NPE in handler"}
+	repo := &fakeRepo{issues: map[string]domain.Issue{"iss-1": want}}
+	svc := New(repo, nil)
+
+	got, err := svc.Get(context.Background(), "iss-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, want.ID)
+	}
+	if got.Title != want.Title {
+		t.Errorf("Title: got %q, want %q", got.Title, want.Title)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{issues: map[string]domain.Issue{}}
+	svc := New(repo, nil)
+
+	_, err := svc.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMute_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{issues: map[string]domain.Issue{
+		"iss-1": {ID: "iss-1", Title: "test"},
+	}}
+	svc := New(repo, nil)
+
+	got, err := svc.Mute(context.Background(), "iss-1", "until_regression")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.MuteMode != "until_regression" {
+		t.Errorf("MuteMode: got %q, want %q", got.MuteMode, "until_regression")
+	}
+}
+
+func TestMute_InvalidInput(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{err: apperr.InvalidInput("bad mute mode", nil)}
+	svc := New(repo, nil)
+
+	_, err := svc.Mute(context.Background(), "iss-1", "bogus")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+}
+
+func TestListLiveEvents_LimitClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     int
+		wantClamp int
+	}{
+		{"zero becomes 50", 0, 50},
+		{"negative becomes 50", -1, 50},
+		{"over 100 becomes 50", 200, 50},
+		{"valid stays", 25, 25},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedLimit int
+			repo := &fakeRepo{}
+			// Override ListRecentEvents to capture the limit.
+			svc := New(&limitCapture{fakeRepo: repo, capturedLimit: &capturedLimit}, nil)
+
+			_, _ = svc.ListLiveEvents(context.Background(), tc.input, time.Now())
+			if capturedLimit != tc.wantClamp {
+				t.Errorf("limit: got %d, want %d", capturedLimit, tc.wantClamp)
+			}
+		})
+	}
+}
+
+// limitCapture wraps fakeRepo to capture the limit passed to ListRecentEvents.
+type limitCapture struct {
+	*fakeRepo
+	capturedLimit *int
+}
+
+func (lc *limitCapture) ListRecentEvents(_ context.Context, limit int, _ time.Time) ([]domain.Event, error) {
+	*lc.capturedLimit = limit
+	return nil, nil
+}
+
+func TestListLiveEvents_DefaultSince(t *testing.T) {
+	t.Parallel()
+
+	var capturedSince time.Time
+	repo := &fakeRepo{}
+	svc := New(&sinceCapture{fakeRepo: repo, capturedSince: &capturedSince}, nil)
+
+	before := time.Now().UTC().Add(-15 * time.Minute)
+	_, _ = svc.ListLiveEvents(context.Background(), 10, time.Time{})
+	after := time.Now().UTC().Add(-15 * time.Minute)
+
+	if capturedSince.Before(before.Add(-time.Second)) || capturedSince.After(after.Add(time.Second)) {
+		t.Errorf("expected since ~15min ago, got %v", capturedSince)
+	}
+}
+
+// sinceCapture wraps fakeRepo to capture the since passed to ListRecentEvents.
+type sinceCapture struct {
+	*fakeRepo
+	capturedSince *time.Time
+}
+
+func (sc *sinceCapture) ListRecentEvents(_ context.Context, _ int, since time.Time) ([]domain.Event, error) {
+	*sc.capturedSince = since
+	return nil, nil
+}

--- a/internal/service/logs/service.go
+++ b/internal/service/logs/service.go
@@ -2,28 +2,41 @@ package logs
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
-// Repository defines the data access contract for log entry operations.
 type Repository interface {
 	InsertLogEntries(context.Context, []domain.LogEntry) error
 	ListLogEntries(ctx context.Context, projectID int64, levelMin int, query string, limit int, beforeID int64) ([]domain.LogEntry, error)
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "logs")}
 }
 
 func (s *Service) Insert(ctx context.Context, entries []domain.LogEntry) error {
-	return s.repo.InsertLogEntries(ctx, entries)
+	if err := s.repo.InsertLogEntries(ctx, entries); err != nil {
+		s.logger.ErrorContext(ctx, "insert log entries", "count", len(entries), "error", err)
+		return err
+	}
+	return nil
 }
 
 func (s *Service) List(ctx context.Context, projectID int64, levelMin int, query string, limit int, beforeID int64) ([]domain.LogEntry, error) {
-	return s.repo.ListLogEntries(ctx, projectID, levelMin, query, limit, beforeID)
+	entries, err := s.repo.ListLogEntries(ctx, projectID, levelMin, query, limit, beforeID)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "list log entries", "project_id", projectID, "error", err)
+		return nil, err
+	}
+	return entries, nil
 }

--- a/internal/service/logs/service.go
+++ b/internal/service/logs/service.go
@@ -1,0 +1,29 @@
+package logs
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// Repository defines the data access contract for log entry operations.
+type Repository interface {
+	InsertLogEntries(context.Context, []domain.LogEntry) error
+	ListLogEntries(ctx context.Context, projectID int64, levelMin int, query string, limit int, beforeID int64) ([]domain.LogEntry, error)
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) Insert(ctx context.Context, entries []domain.LogEntry) error {
+	return s.repo.InsertLogEntries(ctx, entries)
+}
+
+func (s *Service) List(ctx context.Context, projectID int64, levelMin int, query string, limit int, beforeID int64) ([]domain.LogEntry, error) {
+	return s.repo.ListLogEntries(ctx, projectID, levelMin, query, limit, beforeID)
+}

--- a/internal/service/logs/service_test.go
+++ b/internal/service/logs/service_test.go
@@ -1,0 +1,83 @@
+package logs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+type fakeRepo struct {
+	entries []domain.LogEntry
+	err     error
+}
+
+func (f *fakeRepo) InsertLogEntries(_ context.Context, entries []domain.LogEntry) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.entries = append(f.entries, entries...)
+	return nil
+}
+
+func (f *fakeRepo) ListLogEntries(_ context.Context, _ int64, _ int, _ string, _ int, _ int64) ([]domain.LogEntry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.entries, nil
+}
+
+func TestInsert_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{}
+	svc := New(repo, nil)
+
+	entries := []domain.LogEntry{
+		{Message: "hello", Level: "info", LevelNum: 4},
+		{Message: "world", Level: "warn", LevelNum: 8},
+	}
+
+	err := svc.Insert(context.Background(), entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.entries) != 2 {
+		t.Errorf("entries stored: got %d, want 2", len(repo.entries))
+	}
+}
+
+func TestInsert_Error(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{err: apperr.Internal("db write failed", nil)}
+	svc := New(repo, nil)
+
+	err := svc.Insert(context.Background(), []domain.LogEntry{{Message: "fail"}})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrInternal) {
+		t.Errorf("expected ErrInternal, got %v", err)
+	}
+}
+
+func TestList_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{entries: []domain.LogEntry{
+		{ID: 1, Message: "log line 1"},
+		{ID: 2, Message: "log line 2"},
+	}}
+	svc := New(repo, nil)
+
+	got, err := svc.List(context.Background(), 1, 0, "", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("entries: got %d, want 2", len(got))
+	}
+}

--- a/internal/service/projects/service.go
+++ b/internal/service/projects/service.go
@@ -2,11 +2,11 @@ package projects
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
-// Repository defines the data access contract for project and API key operations.
 type Repository interface {
 	ListProjects(context.Context) ([]domain.Project, error)
 	CreateProject(ctx context.Context, name, slug string) (domain.Project, error)
@@ -28,11 +28,15 @@ type Repository interface {
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "projects")}
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Project, error) {
@@ -40,7 +44,13 @@ func (s *Service) List(ctx context.Context) ([]domain.Project, error) {
 }
 
 func (s *Service) Create(ctx context.Context, name, slug string) (domain.Project, error) {
-	return s.repo.CreateProject(ctx, name, slug)
+	proj, err := s.repo.CreateProject(ctx, name, slug)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "create project", "slug", slug, "error", err)
+		return domain.Project{}, err
+	}
+	s.logger.InfoContext(ctx, "project created", "slug", slug, "id", proj.ID)
+	return proj, nil
 }
 
 func (s *Service) Ensure(ctx context.Context, slug string) (domain.Project, error) {
@@ -52,11 +62,21 @@ func (s *Service) EnsurePending(ctx context.Context, slug string) (domain.Projec
 }
 
 func (s *Service) Approve(ctx context.Context, slug string) error {
-	return s.repo.ApproveProject(ctx, slug)
+	if err := s.repo.ApproveProject(ctx, slug); err != nil {
+		s.logger.ErrorContext(ctx, "approve project", "slug", slug, "error", err)
+		return err
+	}
+	s.logger.InfoContext(ctx, "project approved", "slug", slug)
+	return nil
 }
 
 func (s *Service) BySlug(ctx context.Context, slug string) (domain.Project, error) {
-	return s.repo.ProjectBySlug(ctx, slug)
+	proj, err := s.repo.ProjectBySlug(ctx, slug)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "project by slug", "slug", slug, "error", err)
+		return domain.Project{}, err
+	}
+	return proj, nil
 }
 
 func (s *Service) DefaultProjectID() int64 {
@@ -68,11 +88,21 @@ func (s *Service) ListAPIKeys(ctx context.Context) ([]domain.APIKey, error) {
 }
 
 func (s *Service) CreateAPIKey(ctx context.Context, name string, projectID int64, keySHA256, scope string) (domain.APIKey, error) {
-	return s.repo.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
+	key, err := s.repo.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "create api key", "name", name, "error", err)
+		return domain.APIKey{}, err
+	}
+	s.logger.InfoContext(ctx, "api key created", "name", name, "project_id", projectID)
+	return key, nil
 }
 
 func (s *Service) DeleteAPIKey(ctx context.Context, id int64) error {
-	return s.repo.DeleteAPIKey(ctx, id)
+	if err := s.repo.DeleteAPIKey(ctx, id); err != nil {
+		s.logger.ErrorContext(ctx, "delete api key", "id", id, "error", err)
+		return err
+	}
+	return nil
 }
 
 func (s *Service) EnsureSetupAPIKey(ctx context.Context, name string, projectID int64, keySHA256 string) error {
@@ -92,5 +122,9 @@ func (s *Service) GetSettings(ctx context.Context) (map[string]string, error) {
 }
 
 func (s *Service) UpdateSettings(ctx context.Context, values map[string]string) error {
-	return s.repo.UpdateSettings(ctx, values)
+	if err := s.repo.UpdateSettings(ctx, values); err != nil {
+		s.logger.ErrorContext(ctx, "update settings", "error", err)
+		return err
+	}
+	return nil
 }

--- a/internal/service/projects/service.go
+++ b/internal/service/projects/service.go
@@ -1,0 +1,96 @@
+package projects
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// Repository defines the data access contract for project and API key operations.
+type Repository interface {
+	ListProjects(context.Context) ([]domain.Project, error)
+	CreateProject(ctx context.Context, name, slug string) (domain.Project, error)
+	EnsureProject(ctx context.Context, slug string) (domain.Project, error)
+	EnsureProjectPending(ctx context.Context, slug string) (domain.Project, error)
+	ApproveProject(ctx context.Context, slug string) error
+	ProjectBySlug(ctx context.Context, slug string) (domain.Project, error)
+	DefaultProjectID() int64
+
+	ListAPIKeys(context.Context) ([]domain.APIKey, error)
+	CreateAPIKey(ctx context.Context, name string, projectID int64, keySHA256, scope string) (domain.APIKey, error)
+	DeleteAPIKey(ctx context.Context, id int64) error
+	EnsureSetupAPIKey(ctx context.Context, name string, projectID int64, keySHA256 string) error
+	ValidAPIKeySHA256(ctx context.Context, keySHA256 string) (projectID int64, scope string, found bool, err error)
+	TouchAPIKey(ctx context.Context, keySHA256 string) error
+
+	GetSettings(context.Context) (map[string]string, error)
+	UpdateSettings(context.Context, map[string]string) error
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) List(ctx context.Context) ([]domain.Project, error) {
+	return s.repo.ListProjects(ctx)
+}
+
+func (s *Service) Create(ctx context.Context, name, slug string) (domain.Project, error) {
+	return s.repo.CreateProject(ctx, name, slug)
+}
+
+func (s *Service) Ensure(ctx context.Context, slug string) (domain.Project, error) {
+	return s.repo.EnsureProject(ctx, slug)
+}
+
+func (s *Service) EnsurePending(ctx context.Context, slug string) (domain.Project, error) {
+	return s.repo.EnsureProjectPending(ctx, slug)
+}
+
+func (s *Service) Approve(ctx context.Context, slug string) error {
+	return s.repo.ApproveProject(ctx, slug)
+}
+
+func (s *Service) BySlug(ctx context.Context, slug string) (domain.Project, error) {
+	return s.repo.ProjectBySlug(ctx, slug)
+}
+
+func (s *Service) DefaultProjectID() int64 {
+	return s.repo.DefaultProjectID()
+}
+
+func (s *Service) ListAPIKeys(ctx context.Context) ([]domain.APIKey, error) {
+	return s.repo.ListAPIKeys(ctx)
+}
+
+func (s *Service) CreateAPIKey(ctx context.Context, name string, projectID int64, keySHA256, scope string) (domain.APIKey, error) {
+	return s.repo.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
+}
+
+func (s *Service) DeleteAPIKey(ctx context.Context, id int64) error {
+	return s.repo.DeleteAPIKey(ctx, id)
+}
+
+func (s *Service) EnsureSetupAPIKey(ctx context.Context, name string, projectID int64, keySHA256 string) error {
+	return s.repo.EnsureSetupAPIKey(ctx, name, projectID, keySHA256)
+}
+
+func (s *Service) ValidAPIKeySHA256(ctx context.Context, keySHA256 string) (projectID int64, scope string, found bool, err error) {
+	return s.repo.ValidAPIKeySHA256(ctx, keySHA256)
+}
+
+func (s *Service) TouchAPIKey(ctx context.Context, keySHA256 string) error {
+	return s.repo.TouchAPIKey(ctx, keySHA256)
+}
+
+func (s *Service) GetSettings(ctx context.Context) (map[string]string, error) {
+	return s.repo.GetSettings(ctx)
+}
+
+func (s *Service) UpdateSettings(ctx context.Context, values map[string]string) error {
+	return s.repo.UpdateSettings(ctx, values)
+}

--- a/internal/service/projects/service_test.go
+++ b/internal/service/projects/service_test.go
@@ -1,0 +1,154 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+type fakeRepo struct {
+	projects map[string]domain.Project
+	err      error
+}
+
+func (f *fakeRepo) ListProjects(context.Context) ([]domain.Project, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) CreateProject(_ context.Context, name, slug string) (domain.Project, error) {
+	if f.err != nil {
+		return domain.Project{}, f.err
+	}
+	p := domain.Project{ID: 1, Name: name, Slug: slug, CreatedAt: time.Now()}
+	return p, nil
+}
+
+func (f *fakeRepo) EnsureProject(_ context.Context, slug string) (domain.Project, error) {
+	return domain.Project{}, f.err
+}
+
+func (f *fakeRepo) EnsureProjectPending(_ context.Context, slug string) (domain.Project, error) {
+	return domain.Project{}, f.err
+}
+
+func (f *fakeRepo) ApproveProject(_ context.Context, slug string) error {
+	if f.err != nil {
+		return f.err
+	}
+	if _, ok := f.projects[slug]; !ok {
+		return apperr.NotFound("project not found", nil)
+	}
+	return nil
+}
+
+func (f *fakeRepo) ProjectBySlug(_ context.Context, slug string) (domain.Project, error) {
+	if f.err != nil {
+		return domain.Project{}, f.err
+	}
+	p, ok := f.projects[slug]
+	if !ok {
+		return domain.Project{}, apperr.NotFound("project not found", nil)
+	}
+	return p, nil
+}
+
+func (f *fakeRepo) DefaultProjectID() int64 { return 1 }
+
+func (f *fakeRepo) ListAPIKeys(context.Context) ([]domain.APIKey, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) CreateAPIKey(_ context.Context, _ string, _ int64, _, _ string) (domain.APIKey, error) {
+	return domain.APIKey{}, f.err
+}
+
+func (f *fakeRepo) DeleteAPIKey(_ context.Context, _ int64) error {
+	return f.err
+}
+
+func (f *fakeRepo) EnsureSetupAPIKey(_ context.Context, _ string, _ int64, _ string) error {
+	return f.err
+}
+
+func (f *fakeRepo) ValidAPIKeySHA256(_ context.Context, _ string) (int64, string, bool, error) {
+	return 0, "", false, f.err
+}
+
+func (f *fakeRepo) TouchAPIKey(_ context.Context, _ string) error {
+	return f.err
+}
+
+func (f *fakeRepo) GetSettings(context.Context) (map[string]string, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) UpdateSettings(context.Context, map[string]string) error {
+	return f.err
+}
+
+func TestCreate_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{projects: map[string]domain.Project{}}
+	svc := New(repo, nil)
+
+	got, err := svc.Create(context.Background(), "My Project", "my-project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Slug != "my-project" {
+		t.Errorf("Slug: got %q, want %q", got.Slug, "my-project")
+	}
+	if got.Name != "My Project" {
+		t.Errorf("Name: got %q, want %q", got.Name, "My Project")
+	}
+}
+
+func TestCreate_Conflict(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{err: apperr.Conflict("slug taken", nil)}
+	svc := New(repo, nil)
+
+	_, err := svc.Create(context.Background(), "Dup", "dup")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrConflict) {
+		t.Errorf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestBySlug_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{projects: map[string]domain.Project{}}
+	svc := New(repo, nil)
+
+	_, err := svc.BySlug(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestApprove_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{projects: map[string]domain.Project{}}
+	svc := New(repo, nil)
+
+	err := svc.Approve(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/service/releases/service.go
+++ b/internal/service/releases/service.go
@@ -1,0 +1,55 @@
+package releases
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// Repository defines the data access contract for releases and source maps.
+type Repository interface {
+	ListReleases(context.Context) ([]domain.Release, error)
+	GetRelease(context.Context, string) (domain.Release, error)
+	CreateRelease(context.Context, domain.Release) (domain.Release, error)
+	UpdateRelease(context.Context, string, domain.Release) (domain.Release, error)
+	DeleteRelease(context.Context, string) error
+
+	UploadSourceMap(context.Context, domain.SourceMapUpload) (domain.SourceMap, error)
+	ListSourceMaps(context.Context) ([]domain.SourceMapMeta, error)
+}
+
+type Service struct {
+	repo Repository
+}
+
+func New(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) List(ctx context.Context) ([]domain.Release, error) {
+	return s.repo.ListReleases(ctx)
+}
+
+func (s *Service) Get(ctx context.Context, id string) (domain.Release, error) {
+	return s.repo.GetRelease(ctx, id)
+}
+
+func (s *Service) Create(ctx context.Context, release domain.Release) (domain.Release, error) {
+	return s.repo.CreateRelease(ctx, release)
+}
+
+func (s *Service) Update(ctx context.Context, id string, release domain.Release) (domain.Release, error) {
+	return s.repo.UpdateRelease(ctx, id, release)
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	return s.repo.DeleteRelease(ctx, id)
+}
+
+func (s *Service) UploadSourceMap(ctx context.Context, upload domain.SourceMapUpload) (domain.SourceMap, error) {
+	return s.repo.UploadSourceMap(ctx, upload)
+}
+
+func (s *Service) ListSourceMaps(ctx context.Context) ([]domain.SourceMapMeta, error) {
+	return s.repo.ListSourceMaps(ctx)
+}

--- a/internal/service/releases/service.go
+++ b/internal/service/releases/service.go
@@ -2,11 +2,11 @@ package releases
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
-// Repository defines the data access contract for releases and source maps.
 type Repository interface {
 	ListReleases(context.Context) ([]domain.Release, error)
 	GetRelease(context.Context, string) (domain.Release, error)
@@ -19,11 +19,15 @@ type Repository interface {
 }
 
 type Service struct {
-	repo Repository
+	repo   Repository
+	logger *slog.Logger
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+func New(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger.With("service", "releases")}
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Release, error) {
@@ -31,23 +35,50 @@ func (s *Service) List(ctx context.Context) ([]domain.Release, error) {
 }
 
 func (s *Service) Get(ctx context.Context, id string) (domain.Release, error) {
-	return s.repo.GetRelease(ctx, id)
+	release, err := s.repo.GetRelease(ctx, id)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "get release", "release_id", id, "error", err)
+		return domain.Release{}, err
+	}
+	return release, nil
 }
 
 func (s *Service) Create(ctx context.Context, release domain.Release) (domain.Release, error) {
-	return s.repo.CreateRelease(ctx, release)
+	created, err := s.repo.CreateRelease(ctx, release)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "create release", "name", release.Name, "error", err)
+		return domain.Release{}, err
+	}
+	s.logger.InfoContext(ctx, "release created", "release_id", created.ID, "name", created.Name)
+	return created, nil
 }
 
 func (s *Service) Update(ctx context.Context, id string, release domain.Release) (domain.Release, error) {
-	return s.repo.UpdateRelease(ctx, id, release)
+	updated, err := s.repo.UpdateRelease(ctx, id, release)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "update release", "release_id", id, "error", err)
+		return domain.Release{}, err
+	}
+	return updated, nil
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {
-	return s.repo.DeleteRelease(ctx, id)
+	if err := s.repo.DeleteRelease(ctx, id); err != nil {
+		s.logger.ErrorContext(ctx, "delete release", "release_id", id, "error", err)
+		return err
+	}
+	s.logger.InfoContext(ctx, "release deleted", "release_id", id)
+	return nil
 }
 
 func (s *Service) UploadSourceMap(ctx context.Context, upload domain.SourceMapUpload) (domain.SourceMap, error) {
-	return s.repo.UploadSourceMap(ctx, upload)
+	sm, err := s.repo.UploadSourceMap(ctx, upload)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "upload source map", "release", upload.Release, "error", err)
+		return domain.SourceMap{}, err
+	}
+	s.logger.InfoContext(ctx, "source map uploaded", "release", upload.Release, "bundle_url", upload.BundleURL)
+	return sm, nil
 }
 
 func (s *Service) ListSourceMaps(ctx context.Context) ([]domain.SourceMapMeta, error) {

--- a/internal/service/releases/service_test.go
+++ b/internal/service/releases/service_test.go
@@ -1,0 +1,89 @@
+package releases
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+type fakeRepo struct {
+	releases map[string]domain.Release
+	err      error
+}
+
+func (f *fakeRepo) ListReleases(context.Context) ([]domain.Release, error) {
+	return nil, f.err
+}
+
+func (f *fakeRepo) GetRelease(_ context.Context, id string) (domain.Release, error) {
+	if f.err != nil {
+		return domain.Release{}, f.err
+	}
+	r, ok := f.releases[id]
+	if !ok {
+		return domain.Release{}, apperr.NotFound("release not found", nil)
+	}
+	return r, nil
+}
+
+func (f *fakeRepo) CreateRelease(_ context.Context, r domain.Release) (domain.Release, error) {
+	if f.err != nil {
+		return domain.Release{}, f.err
+	}
+	r.ID = "rel-1"
+	f.releases[r.ID] = r
+	return r, nil
+}
+
+func (f *fakeRepo) UpdateRelease(_ context.Context, id string, r domain.Release) (domain.Release, error) {
+	return domain.Release{}, f.err
+}
+
+func (f *fakeRepo) DeleteRelease(_ context.Context, id string) error {
+	return f.err
+}
+
+func (f *fakeRepo) UploadSourceMap(_ context.Context, _ domain.SourceMapUpload) (domain.SourceMap, error) {
+	return domain.SourceMap{}, f.err
+}
+
+func (f *fakeRepo) ListSourceMaps(context.Context) ([]domain.SourceMapMeta, error) {
+	return nil, f.err
+}
+
+func TestCreate_Happy(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{releases: map[string]domain.Release{}}
+	svc := New(repo, nil)
+
+	input := domain.Release{Name: "v1.0.0", Version: "1.0.0"}
+	got, err := svc.Create(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if got.Name != "v1.0.0" {
+		t.Errorf("Name: got %q, want %q", got.Name, "v1.0.0")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{releases: map[string]domain.Release{}}
+	svc := New(repo, nil)
+
+	_, err := svc.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,183 +1,28 @@
 package service
 
 import (
-	"context"
-	"time"
-
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
-	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
-type Repository interface {
-	ListIssues(context.Context) ([]storage.Issue, error)
-	ListIssuesFiltered(context.Context, storage.IssueFilter) ([]storage.Issue, error)
-	GetIssue(context.Context, string) (storage.Issue, error)
-	ListIssueEvents(context.Context, string, int, int64) ([]storage.Event, bool, error)
-	GetEvent(context.Context, string) (storage.Event, error)
-	ListRecentEvents(context.Context, int, time.Time) ([]storage.Event, error)
-	ResolveIssue(context.Context, string) (storage.Issue, error)
-	ReopenIssue(context.Context, string) (storage.Issue, error)
-	MuteIssue(context.Context, string, string) (storage.Issue, error)
-	UnmuteIssue(context.Context, string) (storage.Issue, error)
-	HourlyEventCounts(context.Context, []int64) (map[int64][24]int, error)
-	ListReleases(context.Context) ([]storage.Release, error)
-	GetRelease(context.Context, string) (storage.Release, error)
-	CreateRelease(context.Context, storage.Release) (storage.Release, error)
-	UpdateRelease(context.Context, string, storage.Release) (storage.Release, error)
-	DeleteRelease(context.Context, string) error
-	ListAlerts(context.Context) ([]storage.Alert, error)
-	GetAlert(context.Context, string) (storage.Alert, error)
-	CreateAlert(context.Context, storage.Alert) (storage.Alert, error)
-	UpdateAlert(context.Context, string, storage.Alert) (storage.Alert, error)
-	DeleteAlert(context.Context, string) error
-	GetSettings(context.Context) (map[string]string, error)
-	UpdateSettings(context.Context, map[string]string) error
-	UploadSourceMap(context.Context, storage.SourceMapUpload) (storage.SourceMap, error)
-	ListSourceMaps(context.Context) ([]storage.SourceMapMeta, error)
-	ListFacetKeys(context.Context, int64) ([]string, error)
-	ListFacetValues(context.Context, int64, string) ([]string, error)
+// EventPublisher publishes domain events after successful event persistence.
+type EventPublisher struct {
+	bus *domainevents.Bus
 }
 
-type Service struct {
-	repo Repository
-	bus  *domainevents.Bus
+func NewEventPublisher(bus *domainevents.Bus) *EventPublisher {
+	return &EventPublisher{bus: bus}
 }
 
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
-}
-
-// NewWithBus creates a Service that publishes domain events on the given bus.
-func NewWithBus(repo Repository, bus *domainevents.Bus) *Service {
-	return &Service{repo: repo, bus: bus}
-}
-
-// PublishIssueEvent publishes domain events after a successful event persist.
-// Safe to call when bus is nil.
-func (s *Service) PublishIssueEvent(issue storage.Issue, projectID int64, isNew bool, isRegressed bool) {
-	if s.bus == nil {
+func (p *EventPublisher) PublishIssueEvent(issue domain.Issue, projectID int64, isNew bool, isRegressed bool) {
+	if p.bus == nil {
 		return
 	}
 	if isNew {
-		s.bus.Publish(domainevents.IssueCreated{Issue: issue, ProjectID: projectID})
+		p.bus.Publish(domainevents.IssueCreated{Issue: issue, ProjectID: projectID})
 	}
 	if isRegressed {
-		s.bus.Publish(domainevents.IssueRegressed{Issue: issue, ProjectID: projectID})
+		p.bus.Publish(domainevents.IssueRegressed{Issue: issue, ProjectID: projectID})
 	}
-	// Always publish so event_count_exceeds rules can be evaluated.
-	s.bus.Publish(domainevents.IssueEventRecorded{Issue: issue, ProjectID: projectID})
-}
-
-func (s *Service) ListIssues(ctx context.Context) ([]storage.Issue, error) {
-	return s.repo.ListIssues(ctx)
-}
-
-func (s *Service) ListIssuesFiltered(ctx context.Context, filter storage.IssueFilter) ([]storage.Issue, error) {
-	return s.repo.ListIssuesFiltered(ctx, filter)
-}
-
-func (s *Service) GetIssue(ctx context.Context, id string) (storage.Issue, error) {
-	return s.repo.GetIssue(ctx, id)
-}
-
-func (s *Service) ListIssueEvents(ctx context.Context, issueID string, limit int, beforeID int64) ([]storage.Event, bool, error) {
-	return s.repo.ListIssueEvents(ctx, issueID, limit, beforeID)
-}
-
-func (s *Service) GetEvent(ctx context.Context, id string) (storage.Event, error) {
-	return s.repo.GetEvent(ctx, id)
-}
-
-func (s *Service) ListLiveEvents(ctx context.Context, limit int, since time.Time) ([]storage.Event, error) {
-	if limit <= 0 || limit > 100 {
-		limit = 50
-	}
-	if since.IsZero() {
-		since = time.Now().UTC().Add(-15 * time.Minute)
-	}
-	return s.repo.ListRecentEvents(ctx, limit, since)
-}
-
-func (s *Service) ResolveIssue(ctx context.Context, id string) (storage.Issue, error) {
-	return s.repo.ResolveIssue(ctx, id)
-}
-
-func (s *Service) ReopenIssue(ctx context.Context, id string) (storage.Issue, error) {
-	return s.repo.ReopenIssue(ctx, id)
-}
-
-func (s *Service) MuteIssue(ctx context.Context, id, muteMode string) (storage.Issue, error) {
-	return s.repo.MuteIssue(ctx, id, muteMode)
-}
-
-func (s *Service) UnmuteIssue(ctx context.Context, id string) (storage.Issue, error) {
-	return s.repo.UnmuteIssue(ctx, id)
-}
-
-func (s *Service) HourlyEventCounts(ctx context.Context, issueIDs []int64) (map[int64][24]int, error) {
-	return s.repo.HourlyEventCounts(ctx, issueIDs)
-}
-
-func (s *Service) ListReleases(ctx context.Context) ([]storage.Release, error) {
-	return s.repo.ListReleases(ctx)
-}
-
-func (s *Service) GetRelease(ctx context.Context, id string) (storage.Release, error) {
-	return s.repo.GetRelease(ctx, id)
-}
-
-func (s *Service) CreateRelease(ctx context.Context, release storage.Release) (storage.Release, error) {
-	return s.repo.CreateRelease(ctx, release)
-}
-
-func (s *Service) UpdateRelease(ctx context.Context, id string, release storage.Release) (storage.Release, error) {
-	return s.repo.UpdateRelease(ctx, id, release)
-}
-
-func (s *Service) DeleteRelease(ctx context.Context, id string) error {
-	return s.repo.DeleteRelease(ctx, id)
-}
-
-func (s *Service) ListAlerts(ctx context.Context) ([]storage.Alert, error) {
-	return s.repo.ListAlerts(ctx)
-}
-
-func (s *Service) GetAlert(ctx context.Context, id string) (storage.Alert, error) {
-	return s.repo.GetAlert(ctx, id)
-}
-
-func (s *Service) CreateAlert(ctx context.Context, alert storage.Alert) (storage.Alert, error) {
-	return s.repo.CreateAlert(ctx, alert)
-}
-
-func (s *Service) UpdateAlert(ctx context.Context, id string, alert storage.Alert) (storage.Alert, error) {
-	return s.repo.UpdateAlert(ctx, id, alert)
-}
-
-func (s *Service) DeleteAlert(ctx context.Context, id string) error {
-	return s.repo.DeleteAlert(ctx, id)
-}
-
-func (s *Service) GetSettings(ctx context.Context) (map[string]string, error) {
-	return s.repo.GetSettings(ctx)
-}
-
-func (s *Service) UpdateSettings(ctx context.Context, values map[string]string) error {
-	return s.repo.UpdateSettings(ctx, values)
-}
-
-func (s *Service) UploadSourceMap(ctx context.Context, upload storage.SourceMapUpload) (storage.SourceMap, error) {
-	return s.repo.UploadSourceMap(ctx, upload)
-}
-
-func (s *Service) ListSourceMaps(ctx context.Context) ([]storage.SourceMapMeta, error) {
-	return s.repo.ListSourceMaps(ctx)
-}
-
-func (s *Service) ListFacetKeys(ctx context.Context, projectID int64) ([]string, error) {
-	return s.repo.ListFacetKeys(ctx, projectID)
-}
-
-func (s *Service) ListFacetValues(ctx context.Context, projectID int64, key string) ([]string, error) {
-	return s.repo.ListFacetValues(ctx, projectID, key)
+	p.bus.Publish(domainevents.IssueEventRecorded{Issue: issue, ProjectID: projectID})
 }

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
 )
 
 const (
@@ -112,7 +114,7 @@ ORDER BY observed_at DESC, id DESC`,
 func (s *Store) GetRelease(ctx context.Context, releaseID string) (Release, error) {
 	rowID, err := parseID(releaseIDPrefix, releaseID)
 	if err != nil {
-		return Release{}, err
+		return Release{}, apperr.InvalidInput("invalid release ID", err)
 	}
 
 	projectID, ok := ProjectIDFromContext(ctx)
@@ -137,12 +139,16 @@ WHERE project_id = ? AND id = ?`,
 		projectID,
 		rowID,
 	)
-	return scanRelease(row)
+	release, err := scanRelease(row)
+	if err != nil {
+		return Release{}, wrapNotFound(err, "release not found")
+	}
+	return release, nil
 }
 
 func (s *Store) CreateRelease(ctx context.Context, release Release) (Release, error) {
 	if strings.TrimSpace(release.Name) == "" {
-		return Release{}, errors.New("release name is required")
+		return Release{}, apperr.InvalidInput("release name is required", nil)
 	}
 	if release.ObservedAt.IsZero() {
 		release.ObservedAt = time.Now().UTC()
@@ -190,10 +196,10 @@ INSERT INTO releases (
 func (s *Store) UpdateRelease(ctx context.Context, releaseID string, release Release) (Release, error) {
 	rowID, err := parseID(releaseIDPrefix, releaseID)
 	if err != nil {
-		return Release{}, err
+		return Release{}, apperr.InvalidInput("invalid release ID", err)
 	}
 	if strings.TrimSpace(release.Name) == "" {
-		return Release{}, errors.New("release name is required")
+		return Release{}, apperr.InvalidInput("release name is required", nil)
 	}
 	if release.ObservedAt.IsZero() {
 		release.ObservedAt = time.Now().UTC()
@@ -341,12 +347,16 @@ WHERE a.project_id = ? AND a.id = ?`, projectID, rowID)
 		row = s.readDB().QueryRowContext(ctx, sel+`
 WHERE a.id = ?`, rowID)
 	}
-	return scanAlertWithProject(row)
+	alert, err := scanAlertWithProject(row)
+	if err != nil {
+		return Alert{}, wrapNotFound(err, "alert not found")
+	}
+	return alert, nil
 }
 
 func (s *Store) CreateAlert(ctx context.Context, alert Alert) (Alert, error) {
 	if strings.TrimSpace(alert.Name) == "" {
-		return Alert{}, errors.New("alert name is required")
+		return Alert{}, apperr.InvalidInput("alert name is required", nil)
 	}
 	if alert.Rule == nil {
 		alert.Rule = map[string]any{}
@@ -394,10 +404,10 @@ INSERT INTO alerts (
 func (s *Store) UpdateAlert(ctx context.Context, alertID string, alert Alert) (Alert, error) {
 	rowID, err := parseID(alertIDPrefix, alertID)
 	if err != nil {
-		return Alert{}, err
+		return Alert{}, apperr.InvalidInput("invalid alert ID", err)
 	}
 	if strings.TrimSpace(alert.Name) == "" {
-		return Alert{}, errors.New("alert name is required")
+		return Alert{}, apperr.InvalidInput("alert name is required", nil)
 	}
 	if alert.Rule == nil {
 		alert.Rule = map[string]any{}
@@ -502,10 +512,10 @@ ON CONFLICT(project_id, key) DO UPDATE SET value = excluded.value, updated_at = 
 
 func (s *Store) UploadSourceMap(ctx context.Context, upload SourceMapUpload) (SourceMap, error) {
 	if strings.TrimSpace(upload.Release) == "" {
-		return SourceMap{}, errors.New("source map release is required")
+		return SourceMap{}, apperr.InvalidInput("source map release is required", nil)
 	}
 	if strings.TrimSpace(upload.BundleURL) == "" {
-		return SourceMap{}, errors.New("source map bundle URL is required")
+		return SourceMap{}, apperr.InvalidInput("source map bundle URL is required", nil)
 	}
 	now := time.Now().UTC()
 	projectID, ok := ProjectIDFromContext(ctx)

--- a/internal/storage/admin.go
+++ b/internal/storage/admin.go
@@ -15,25 +15,6 @@ const (
 	sourceMapPrefix = "sourcemap-"
 )
 
-type SourceMap struct {
-	ID          string
-	Release     string
-	Dist        string
-	BundleURL   string
-	Name        string
-	ContentType string
-	SizeBytes   int64
-	UploadedAt  time.Time
-}
-
-type SourceMapUpload struct {
-	Release     string
-	Dist        string
-	BundleURL   string
-	Name        string
-	ContentType string
-	Blob        []byte
-}
 
 func (s *Store) ResolveIssue(ctx context.Context, issueID string) (Issue, error) {
 	return s.setIssueStatus(ctx, issueID, "resolved")
@@ -598,16 +579,6 @@ LIMIT 1`,
 	return blob, nil
 }
 
-// SourceMapMeta holds the metadata columns for a source map row (no blob).
-type SourceMapMeta struct {
-	ID        string    `json:"id"`
-	Release   string    `json:"release"`
-	Dist      string    `json:"dist"`
-	BundleURL string    `json:"bundleUrl"`
-	Name      string    `json:"name"`
-	SizeBytes int64     `json:"size"`
-	CreatedAt time.Time `json:"createdAt"`
-}
 
 // ListSourceMaps returns metadata for all source maps in the project (no blob).
 func (s *Store) ListSourceMaps(ctx context.Context) ([]SourceMapMeta, error) {

--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -214,7 +214,7 @@ func (s *Store) QueryPages(ctx context.Context, q analytics.Query) ([]analytics.
 	}
 	defer rows.Close()
 
-	var out []analytics.PageStat
+	out := []analytics.PageStat{}
 	for rows.Next() {
 		var p analytics.PageStat
 		if err := rows.Scan(&p.Pathname, &p.Pageviews, &p.Sessions); err != nil {
@@ -257,7 +257,7 @@ func (s *Store) QueryTimeline(ctx context.Context, q analytics.Query, granularit
 	}
 	defer rows.Close()
 
-	var out []analytics.TimelineBucket
+	out := []analytics.TimelineBucket{}
 	for rows.Next() {
 		var b analytics.TimelineBucket
 		if err := rows.Scan(&b.Date, &b.Pageviews, &b.Sessions); err != nil {
@@ -290,7 +290,7 @@ func (s *Store) QueryReferrers(ctx context.Context, q analytics.Query) ([]analyt
 	}
 	defer rows.Close()
 
-	var out []analytics.ReferrerStat
+	out := []analytics.ReferrerStat{}
 	for rows.Next() {
 		var r analytics.ReferrerStat
 		if err := rows.Scan(&r.Host, &r.Pageviews, &r.Sessions); err != nil {
@@ -305,7 +305,7 @@ func (s *Store) QueryReferrers(ctx context.Context, q analytics.Query) ([]analyt
 // We use the raw table because props are not pre-aggregated beyond referrer_host.
 func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey string) ([]analytics.SegmentBucket, error) {
 	if strings.TrimSpace(dimKey) == "" {
-		return nil, nil
+		return []analytics.SegmentBucket{}, nil
 	}
 	limit := queryLimit(q)
 
@@ -332,7 +332,7 @@ func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey str
 	}
 	defer rows.Close()
 
-	var out []analytics.SegmentBucket
+	out := []analytics.SegmentBucket{}
 	for rows.Next() {
 		var b analytics.SegmentBucket
 		if err := rows.Scan(&b.Value, &b.Pageviews, &b.Sessions); err != nil {
@@ -345,7 +345,11 @@ func (s *Store) QuerySegments(ctx context.Context, q analytics.Query, dimKey str
 
 // QueryPageFlow returns page-flow data for a given pathname.
 func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname string) (analytics.PageFlowResult, error) {
-	result := analytics.PageFlowResult{Pathname: pathname}
+	result := analytics.PageFlowResult{
+		Pathname: pathname,
+		CameFrom: []analytics.FlowEntry{},
+		WentTo:   []analytics.FlowEntry{},
+	}
 
 	// WentTo — aggregate exit_pathname from raw pageviews
 	wentToRows, err := s.readDB().QueryContext(ctx, `
@@ -429,7 +433,10 @@ func (s *Store) QueryPageFlow(ctx context.Context, q analytics.Query, pathname s
 
 // QueryScrollDepth returns scroll-depth bucket counts for a pathname.
 func (s *Store) QueryScrollDepth(ctx context.Context, q analytics.Query, pathname string) (analytics.ScrollDepthResult, error) {
-	result := analytics.ScrollDepthResult{Pathname: pathname}
+	result := analytics.ScrollDepthResult{
+		Pathname: pathname,
+		Buckets:  []analytics.ScrollBucket{},
+	}
 
 	rows, err := s.readDB().QueryContext(ctx, `
 		SELECT
@@ -493,7 +500,7 @@ func (s *Store) QueryDropout(ctx context.Context, q analytics.Query) ([]analytic
 	}
 	defer rows.Close()
 
-	var out []analytics.DropoutStat
+	out := []analytics.DropoutStat{}
 	for rows.Next() {
 		var s analytics.DropoutStat
 		if err := rows.Scan(&s.Pathname, &s.Pageviews, &s.BouncedSessions); err != nil {

--- a/internal/storage/digest.go
+++ b/internal/storage/digest.go
@@ -6,22 +6,6 @@ import (
 	"time"
 )
 
-// DigestIssue is a summary of a single issue for the weekly digest.
-type DigestIssue struct {
-	ID         string
-	Title      string
-	EventCount int
-	Status     string
-}
-
-// DigestData holds aggregate stats for the weekly digest.
-type DigestData struct {
-	TotalEvents    int
-	NewIssues      int
-	ResolvedIssues int
-	Regressions    int
-	TopIssues      []DigestIssue
-}
 
 // WeeklyDigest returns aggregate error stats for the given project since the
 // given time. All queries run under the provided context deadline.

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+)
+
+func wrapErr(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return apperr.NotFound(msg, err)
+	}
+	if isUniqueViolation(err) {
+		return apperr.Conflict(msg, err)
+	}
+	return apperr.Internal(msg, err)
+}
+
+func wrapNotFound(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return apperr.NotFound(msg, err)
+	}
+	return apperr.Internal(msg, err)
+}
+
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/storage/errors_test.go
+++ b/internal/storage/errors_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
+)
+
+func TestWrapErr_NoRows(t *testing.T) {
+	t.Parallel()
+
+	err := wrapErr(sql.ErrNoRows, "not found")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestWrapErr_UniqueViolation(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("UNIQUE constraint failed: projects.slug")
+	err := wrapErr(cause, "duplicate")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrConflict) {
+		t.Errorf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestWrapErr_Generic(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("connection refused")
+	err := wrapErr(cause, "db error")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrInternal) {
+		t.Errorf("expected ErrInternal, got %v", err)
+	}
+}
+
+func TestWrapErr_Nil(t *testing.T) {
+	t.Parallel()
+
+	err := wrapErr(nil, "should not matter")
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestWrapNotFound_NoRows(t *testing.T) {
+	t.Parallel()
+
+	err := wrapNotFound(sql.ErrNoRows, "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestWrapNotFound_Other(t *testing.T) {
+	t.Parallel()
+
+	cause := fmt.Errorf("timeout")
+	err := wrapNotFound(cause, "db error")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, apperr.ErrInternal) {
+		t.Errorf("expected ErrInternal, got %v", err)
+	}
+}

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -133,7 +133,11 @@ WHERE e.project_id = ? AND e.id = ?`, projectID, rowID)
 WHERE e.id = ?`, rowID)
 	}
 
-	return scanEvent(row)
+	evt, err := scanEvent(row)
+	if err != nil {
+		return Event{}, wrapNotFound(err, "event not found")
+	}
+	return evt, nil
 }
 
 func (s *Store) ListRecentEvents(ctx context.Context, limit int, since time.Time) ([]Event, error) {

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
 	"github.com/wiebe-xyz/bugbarn/internal/event"
 	"github.com/wiebe-xyz/bugbarn/internal/worker"
 )
@@ -199,7 +200,11 @@ WHERE i.project_id = ? AND i.id = ?`, projectID, rowID)
 WHERE i.id = ?`, rowID)
 	}
 
-	return scanIssue(row)
+	issue, err := scanIssue(row)
+	if err != nil {
+		return Issue{}, wrapNotFound(err, "issue not found")
+	}
+	return issue, nil
 }
 
 func (s *Store) upsertIssue(ctx context.Context, projectID int64, processed worker.ProcessedEvent) (Issue, int64, bool, error) {
@@ -556,7 +561,7 @@ func scanIssue(scanner interface {
 // muteMode must be one of "until_regression" or "forever".
 func (s *Store) MuteIssue(ctx context.Context, issueID string, muteMode string) (Issue, error) {
 	if muteMode != "until_regression" && muteMode != "forever" {
-		return Issue{}, fmt.Errorf("invalid mute_mode %q: must be 'until_regression' or 'forever'", muteMode)
+		return Issue{}, apperr.InvalidInput(fmt.Sprintf("invalid mute_mode %q: must be 'until_regression' or 'forever'", muteMode), nil)
 	}
 	rowID, err := s.IssueRowIDByDisplayID(ctx, issueID)
 	if err != nil {

--- a/internal/storage/projects.go
+++ b/internal/storage/projects.go
@@ -2,9 +2,10 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/apperr"
 )
 
 // CreateProject inserts a new project row; returns an error if the slug already exists.
@@ -19,7 +20,7 @@ INSERT INTO projects (name, slug, status, issue_prefix, issue_counter, created_a
 		name, slug, prefix, now,
 	)
 	if err != nil {
-		return Project{}, err
+		return Project{}, wrapErr(err, "create project")
 	}
 	id, err := res.LastInsertId()
 	if err != nil {
@@ -56,7 +57,7 @@ func (s *Store) ProjectBySlug(ctx context.Context, slug string) (Project, error)
 	err := s.readDB().QueryRowContext(ctx, `SELECT id, name, slug, status, issue_prefix, issue_counter, created_at FROM projects WHERE slug = ?`, slug).
 		Scan(&p.ID, &p.Name, &p.Slug, &p.Status, &p.IssuePrefix, &p.IssueCounter, &createdAt)
 	if err != nil {
-		return Project{}, err
+		return Project{}, wrapNotFound(err, "project not found")
 	}
 	p.CreatedAt, _ = parseTime(createdAt)
 	return p, nil
@@ -110,7 +111,7 @@ func (s *Store) ApproveProject(ctx context.Context, slug string) error {
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return sql.ErrNoRows
+		return apperr.NotFound("project not found", nil)
 	}
 	return nil
 }
@@ -151,7 +152,7 @@ SELECT i.id FROM issues i
 JOIN projects p ON p.id = i.project_id
 WHERE p.issue_prefix = ? AND i.issue_number = ?`, prefix, number).Scan(&rowID)
 	if err != nil {
-		return 0, err
+		return 0, wrapNotFound(err, "issue not found")
 	}
 	return rowID, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -34,10 +34,6 @@ var (
 	trimPunctuation = regexp.MustCompile(`^[\s:;,_\-]+|[\s:;,_\-]+$`)
 )
 
-var (
-	errNotFound = sql.ErrNoRows
-	errConflict = errors.New("conflict")
-)
 
 func Open(path string) (*Store, error) {
 	if strings.TrimSpace(path) == "" {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -2,9 +2,8 @@ package storage
 
 import (
 	"database/sql"
-	"time"
 
-	"github.com/wiebe-xyz/bugbarn/internal/event"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 // Store is the primary database access object. It holds a single-connection
@@ -16,28 +15,29 @@ type Store struct {
 	defaultProjectID int64
 }
 
-// Issue represents a grouped error occurrence.
-type Issue struct {
-	ID                     string
-	IssueNumber            int
-	Fingerprint            string
-	FingerprintMaterial    string
-	FingerprintExplanation []string
-	Title                  string
-	NormalizedTitle        string
-	ExceptionType          string
-	Status                 string
-	MuteMode               string // "until_regression" | "forever" | ""
-	ResolvedAt             time.Time
-	ReopenedAt             time.Time
-	LastRegressedAt        time.Time
-	RegressionCount        int
-	FirstSeen              time.Time
-	LastSeen               time.Time
-	EventCount             int
-	RepresentativeEvent    event.Event
-	ProjectSlug            string `json:"project_slug,omitempty"`
-}
+// Domain type aliases — storage consumers can keep using storage.Issue etc.
+// while the canonical definitions live in the domain package.
+type Issue = domain.Issue
+type IssueFilter = domain.IssueFilter
+type Event = domain.Event
+type Project = domain.Project
+type APIKey = domain.APIKey
+type Release = domain.Release
+type Alert = domain.Alert
+type LogEntry = domain.LogEntry
+type Setting = domain.Setting
+type User = domain.User
+type SourceMap = domain.SourceMap
+type SourceMapMeta = domain.SourceMapMeta
+type SourceMapUpload = domain.SourceMapUpload
+type DigestIssue = domain.DigestIssue
+type DigestData = domain.DigestData
+
+// Scope constants for API keys.
+const (
+	APIKeyScopeFull   = domain.APIKeyScopeFull
+	APIKeyScopeIngest = domain.APIKeyScopeIngest
+)
 
 // IssueHourlyCounts holds per-issue 24-hour event frequency data.
 type IssueHourlyCounts struct {
@@ -45,132 +45,9 @@ type IssueHourlyCounts struct {
 	Counts  [24]int // index 0 = 23h ago, index 23 = current partial hour
 }
 
-// Event represents a single captured error event.
-type Event struct {
-	ID                     string
-	IssueID                string
-	Fingerprint            string
-	FingerprintMaterial    string
-	FingerprintExplanation []string
-	ReceivedAt             time.Time
-	ObservedAt             time.Time
-	Severity               string
-	Message                string
-	Regressed              bool
-	Payload                event.Event
-}
-
-// IssueFilter holds optional filters and sort order for ListIssuesFiltered.
-type IssueFilter struct {
-	// Sort is one of "last_seen", "first_seen", "event_count". Default: "last_seen".
-	Sort string
-	// Status filters by issue status:
-	//   "open"     → status IN ('unresolved', 'regressed')  (default, excludes muted)
-	//   "muted"    → status = 'muted'
-	//   "resolved" → status = 'resolved'
-	//   "all" or "" → no status filter
-	Status string
-	// Query is a case-insensitive substring matched against title and normalized_title.
-	Query string
-	// Facets is an optional map of facet key→value pairs to filter by.
-	// Issues must match ALL provided facet filters (AND semantics).
-	Facets map[string]string
-	// Limit caps the number of returned issues. 0 means no limit.
-	Limit int
-	// Offset skips the first N results (for pagination).
-	Offset int
-}
-
-// User represents an admin user stored in the database.
-type User struct {
-	ID             int64
-	Username       string
-	PasswordBcrypt string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-}
-
-// Project represents a project row.
-type Project struct {
-	ID           int64
-	Name         string
-	Slug         string
-	Status       string
-	IssuePrefix  string
-	IssueCounter int
-	CreatedAt    time.Time
-}
-
-// Scope constants for API keys.
-const (
-	APIKeyScopeFull   = "full"   // full access to all endpoints
-	APIKeyScopeIngest = "ingest" // write-only: POST /api/v1/events only
-)
-
-// APIKey represents an API key row (the plaintext key is never stored).
-type APIKey struct {
-	ID         int64
-	Name       string
-	ProjectID  int64
-	KeySHA256  string
-	Scope      string
-	CreatedAt  time.Time
-	LastUsedAt time.Time
-}
-
-// Release represents a software release row.
-type Release struct {
-	ID          string
-	Name        string
-	Environment string
-	ObservedAt  time.Time
-	Version     string
-	CommitSHA   string
-	URL         string
-	Notes       string
-	CreatedBy   string
-	CreatedAt   time.Time
-}
-
-// Alert represents a project alert row.
-type Alert struct {
-	ID              string         `json:"id"`
-	Name            string         `json:"name"`
-	Enabled         bool           `json:"enabled"`
-	Severity        string         `json:"severity,omitempty"`
-	Rule            map[string]any `json:"rule,omitempty"`
-	WebhookURL      string         `json:"webhook_url,omitempty"`
-	Condition       string         `json:"condition,omitempty"`
-	Threshold       int            `json:"threshold,omitempty"`
-	CooldownMinutes int            `json:"cooldown_minutes,omitempty"`
-	LastFiredAt     time.Time      `json:"last_fired_at,omitempty"`
-	CreatedAt       time.Time      `json:"created_at,omitempty"`
-	UpdatedAt       time.Time      `json:"updated_at,omitempty"`
-	ProjectSlug     string         `json:"project_slug,omitempty"`
-}
-
-// Setting represents a project setting row.
-type Setting struct {
-	Key       string
-	Value     string
-	UpdatedAt time.Time
-}
-
 // facetRow is an internal struct used when inserting raw facets.
 type facetRow struct {
 	section string
 	key     string
 	value   string
-}
-
-// LogEntry represents a single structured log line stored per project.
-type LogEntry struct {
-	ID          int64          `json:"id"`
-	ProjectID   int64          `json:"project_id,omitempty"`
-	ProjectSlug string         `json:"project_slug,omitempty"`
-	ReceivedAt  time.Time      `json:"received_at"`
-	LevelNum    int            `json:"level_num"`
-	Level       string         `json:"level"`
-	Message     string         `json:"message"`
-	Data        map[string]any `json:"data,omitempty"`
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1226,8 +1226,9 @@ button:disabled {
   .app-frame {
     display: flex;
     flex-direction: column;
+    min-height: 0;
+    height: 100vh;
     height: 100dvh;
-    height: 100vh; /* fallback for older browsers */
     overflow: hidden;
   }
 


### PR DESCRIPTION
## Summary
- **Repository pattern refactoring**: Split monolithic `service.Service` into 6 focused packages (`issues`, `projects`, `releases`, `alerts`, `logs`, `analytics`), each with its own narrow `Repository` interface. Extracted canonical domain types to `internal/domain/types.go`. API handlers route through services — no direct store access.
- **Error boundaries**: New `internal/apperr` package with typed errors (`NotFound`, `Conflict`, `InvalidInput`, `Internal`). Storage wraps DB errors into apperr types. Services log at the boundary. API maps apperr codes to HTTP status (404, 409, 400, 500). No layer leaks its implementation details.
- **Structured logging**: `log/slog` with JSON output, injected via constructors. Self-reporting handler (`internal/selflog`) forwards error-level logs to BugBarn's own ingest when self-reporting is enabled.
- **Service unit tests**: All 6 service packages have tests with fakeRepos covering happy paths and error paths. Storage error wrapping and apperr semantics also tested.
- **PWA bottom tab bar fix**: CSS height declaration order and missing `min-height: 0` override.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 19 packages pass (0 failures)
- [x] Invalid mute mode now returns 400 instead of 500
- [ ] Open PWA on mobile — bottom tab bar stays pinned
- [ ] Verify self-reporting works when `BUGBARN_SELF_*` env vars are set