### PR TITLE
fix: consistent default endpoint across all SDKs

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -143,7 +143,7 @@ func NewServerWithAuth(ingestHandler *ingest.Handler, store *storage.Store, user
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Ingest endpoint uses wildcard CORS so browser SDKs can POST from any origin
 	// without credentials. The ingest-only key scope ensures read access is impossible.
-	if r.URL.Path == "/api/v1/events" || r.URL.Path == "/api/v1/ingest" {
+	if r.URL.Path == "/api/v1/events" {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "content-type, x-bugbarn-api-key, x-bugbarn-project")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/sdks/go/bugbarn.go
+++ b/sdks/go/bugbarn.go
@@ -1,14 +1,17 @@
 package bugbarn
 
 import (
+	"strings"
 	"sync"
 	"time"
 )
 
+const DefaultEndpoint = "/api/v1/events"
+
 // Options configures the SDK.
 type Options struct {
 	APIKey      string
-	Endpoint    string
+	Endpoint    string // Full URL or base URL (DefaultEndpoint path is appended if no path present)
 	ProjectSlug string
 	Release     string
 	Environment string
@@ -52,6 +55,11 @@ func Init(o Options) {
 	}
 	if o.QueueSize <= 0 {
 		o.QueueSize = 256
+	}
+	if o.Endpoint == "" {
+		o.Endpoint = DefaultEndpoint
+	} else if !strings.Contains(o.Endpoint, "/api/") {
+		o.Endpoint = strings.TrimRight(o.Endpoint, "/") + DefaultEndpoint
 	}
 	opts = o
 	tp = newTransport(o.APIKey, o.Endpoint, o.ProjectSlug, o.QueueSize)

--- a/sdks/go/bugbarn_test.go
+++ b/sdks/go/bugbarn_test.go
@@ -53,6 +53,30 @@ func TestCaptureMessageAfterInit(t *testing.T) {
 	}
 }
 
+func TestEndpointResolution(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "/api/v1/events"},
+		{"https://bugbarn.example.com", "https://bugbarn.example.com/api/v1/events"},
+		{"https://bugbarn.example.com/", "https://bugbarn.example.com/api/v1/events"},
+		{"https://bugbarn.example.com/api/v1/events", "https://bugbarn.example.com/api/v1/events"},
+		{"http://localhost:8080/api/v1/events", "http://localhost:8080/api/v1/events"},
+	}
+	for _, tt := range tests {
+		resetGlobal()
+		Init(Options{APIKey: "k", Endpoint: tt.input})
+		mu.Lock()
+		got := opts.Endpoint
+		mu.Unlock()
+		if got != tt.want {
+			t.Errorf("Init(Endpoint=%q): got %q, want %q", tt.input, got, tt.want)
+		}
+	}
+	resetGlobal()
+}
+
 func TestFlushNoopWhenNotInited(t *testing.T) {
 	resetGlobal()
 	// Should return true (nothing to drain) and not panic.

--- a/sdks/php/src/BugBarn/Client.php
+++ b/sdks/php/src/BugBarn/Client.php
@@ -6,21 +6,28 @@ namespace BugBarn;
 
 final class Client
 {
+    public const DEFAULT_ENDPOINT = '/api/v1/events';
+
     private static ?Transport $transport    = null;
     private static bool       $handlersInstalled = false;
 
     /**
      * Initialise the SDK.
      *
+     * @param string $endpoint Full URL or base URL (path appended automatically if missing)
      * @param bool $installHandlers  When true, installs set_exception_handler and a
      *                               register_shutdown_function to capture fatal errors.
      */
     public static function init(
         string $apiKey,
-        string $endpoint,
+        string $endpoint = self::DEFAULT_ENDPOINT,
         bool   $installHandlers = false,
         string $projectSlug     = '',
     ): void {
+        if (!str_contains($endpoint, '/api/')) {
+            $endpoint = rtrim($endpoint, '/') . self::DEFAULT_ENDPOINT;
+        }
+
         self::$transport = new Transport(
             apiKey:      $apiKey,
             endpoint:    $endpoint,

--- a/sdks/python/src/bugbarn/client.py
+++ b/sdks/python/src/bugbarn/client.py
@@ -72,7 +72,10 @@ class Envelope:
 class Transport:
     def __init__(self, api_key: str, endpoint: str = DEFAULT_ENDPOINT, maxsize: int = 256) -> None:
         self.api_key = api_key
-        self.endpoint = endpoint
+        if endpoint and "/api/" not in endpoint:
+            self.endpoint = endpoint.rstrip("/") + DEFAULT_ENDPOINT
+        else:
+            self.endpoint = endpoint
         self.queue: "queue.Queue[Envelope]" = queue.Queue(maxsize=maxsize)
         self._closed = threading.Event()
         self._worker = threading.Thread(target=self._run, name="bugbarn-transport", daemon=True)

--- a/sdks/typescript/src/transport.ts
+++ b/sdks/typescript/src/transport.ts
@@ -5,6 +5,9 @@ const DEFAULT_FLUSH_TIMEOUT_MS = 2000;
 
 function resolveUrl(endpoint: string): string {
   if (endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
+    if (!endpoint.includes("/api/")) {
+      return endpoint.replace(/\/+$/, "") + DEFAULT_ENDPOINT;
+    }
     return endpoint;
   }
 


### PR DESCRIPTION
## Summary
- All SDKs now auto-append `/api/v1/events` when given a bare base URL (e.g. `https://bugbarn.wiebe.xyz`)
- Go SDK: added `DefaultEndpoint` constant, path appended in `Init()` if missing
- PHP SDK: added `DEFAULT_ENDPOINT` constant, made `$endpoint` parameter optional with auto-resolution
- TypeScript/Python: added path detection in `resolveUrl()`/`Transport.__init__()`
- Reverted `/api/v1/ingest` server alias (funnelbarn updated to use correct endpoint)

## Test plan
- [x] Go SDK: `TestEndpointResolution` covers all cases (empty, base URL, full URL)
- [x] All existing Go SDK tests pass
- [x] All project tests pass (`go test ./...`)
- [ ] Verify funnelbarn still reports successfully after deploy