### PR TITLE
fix: CLI project filter, read-scoped API keys, llms.txt

### DIFF
--- a/cmd/bb/client.go
+++ b/cmd/bb/client.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Client struct {
-	base   string
-	http   *http.Client
-	config Config
+	base    string
+	http    *http.Client
+	config  Config
+	project string // project slug to send as X-BugBarn-Project header
 }
 
 func newClient() (*Client, error) {
@@ -56,6 +57,9 @@ func (c *Client) do(method, path string, body any) (json.RawMessage, error) {
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.project != "" {
+		req.Header.Set("X-BugBarn-Project", c.project)
 	}
 
 	switch c.config.Auth.Type {

--- a/cmd/bb/commands.go
+++ b/cmd/bb/commands.go
@@ -139,16 +139,44 @@ func cmdIssues(args []string) error {
 		return err
 	}
 
+	// Resolve project slug from flag or config default.
+	projectSlug := *project
+	if projectSlug == "" {
+		projectSlug = client.config.Project
+	}
+
+	// If a project is specified, validate it exists before querying issues.
+	if projectSlug != "" {
+		data, err := client.get("/api/v1/projects")
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Projects []struct {
+				Slug string `json:"slug"`
+			} `json:"projects"`
+		}
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return fmt.Errorf("parse projects response: %w", err)
+		}
+		found := false
+		for _, p := range resp.Projects {
+			if p.Slug == projectSlug {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("project %q not found — run 'bb projects' to see available projects", projectSlug)
+		}
+		client.project = projectSlug
+	}
+
 	params := url.Values{}
 	params.Set("status", *status)
 	params.Set("sort", *sort)
 	if *query != "" {
 		params.Set("q", *query)
-	}
-	if *project != "" {
-		params.Set("project_slug", *project)
-	} else if client.config.Project != "" {
-		params.Set("project_slug", client.config.Project)
 	}
 
 	data, err := client.get("/api/v1/issues?" + params.Encode())

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -432,7 +432,7 @@ func runAPIKeyCmd(cfg config, args []string) error {
 		fs := flag.NewFlagSet("apikey create", flag.ContinueOnError)
 		projectSlug := fs.String("project", "default", "project slug")
 		name := fs.String("name", "", "key name/label")
-		scope := fs.String("scope", storage.APIKeyScopeFull, "key scope: full or ingest")
+		scope := fs.String("scope", storage.APIKeyScopeFull, "key scope: full, ingest, or read")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -440,8 +440,8 @@ func runAPIKeyCmd(cfg config, args []string) error {
 		if *name == "" {
 			return fmt.Errorf("--name is required")
 		}
-		if *scope != storage.APIKeyScopeFull && *scope != storage.APIKeyScopeIngest {
-			return fmt.Errorf("--scope must be %q or %q", storage.APIKeyScopeFull, storage.APIKeyScopeIngest)
+		if *scope != storage.APIKeyScopeFull && *scope != storage.APIKeyScopeIngest && *scope != storage.APIKeyScopeRead {
+			return fmt.Errorf("--scope must be %q, %q, or %q", storage.APIKeyScopeFull, storage.APIKeyScopeIngest, storage.APIKeyScopeRead)
 		}
 		store, err := storage.Open(cfg.dbPath)
 		if err != nil {

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
 // serveIssueRoute handles /api/v1/issues/{id} and sub-paths.
@@ -28,6 +29,15 @@ func (s *Server) serveIssueRoute(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
+
+	// Accept project_slug query param as a fallback for the X-BugBarn-Project header.
+	// This lets the CLI and other clients filter by project without needing to set the header.
+	if slug := q.Get("project_slug"); slug != "" && r.Header.Get("X-BugBarn-Project") == "" {
+		if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
+			r = r.WithContext(storage.WithProjectID(r.Context(), proj.ID))
+		}
+	}
+
 	filter := domain.IssueFilter{
 		Sort:   q.Get("sort"),
 		Status: q.Get("status"),
@@ -48,7 +58,7 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	}
 	requestedLimit := filter.Limit
 	filter.Limit = requestedLimit + 1
-	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true}
+	knownParams := map[string]bool{"sort": true, "status": true, "q": true, "limit": true, "offset": true, "project_slug": true}
 	for key, vals := range q {
 		if knownParams[key] || len(vals) == 0 || strings.TrimSpace(vals[0]) == "" {
 			continue
@@ -62,6 +72,10 @@ func (s *Server) listIssues(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeServiceError(w, err)
 		return
+	}
+	// Ensure non-nil slice so JSON serializes as [] instead of null.
+	if issues == nil {
+		issues = []domain.Issue{}
 	}
 
 	hasMore := len(issues) > requestedLimit

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -263,6 +263,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, "forbidden: ingest-only key cannot access this endpoint", http.StatusForbidden)
 					return
 				}
+				if scope == domain.APIKeyScopeRead {
+					if r.Method != http.MethodGet {
+						s.logger.Warn("auth: read-only key rejected non-GET", "method", r.Method, "path", r.URL.Path)
+						http.Error(w, "forbidden: read-only key cannot modify data", http.StatusForbidden)
+						return
+					}
+					if strings.HasPrefix(r.URL.Path, "/api/v1/settings") || strings.HasPrefix(r.URL.Path, "/api/v1/apikeys") {
+						s.logger.Warn("auth: read-only key rejected settings/apikeys", "method", r.Method, "path", r.URL.Path)
+						http.Error(w, "forbidden: read-only key cannot access this endpoint", http.StatusForbidden)
+						return
+					}
+				}
 				usingAPIKey = true
 				apiKeyProjectID = pid
 			}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -452,6 +452,81 @@ func TestIngestOnlyKeyScope(t *testing.T) {
 	})
 }
 
+func TestReadOnlyKeyScope(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	// Generate a plaintext key and store it as read-scope.
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		t.Fatal(err)
+	}
+	plaintext := hex.EncodeToString(raw[:])
+	sum := sha256.Sum256([]byte(plaintext))
+	keySHA256 := hex.EncodeToString(sum[:])
+
+	proj, err := store.ProjectBySlug(context.Background(), "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateAPIKey(context.Background(), "test-read-key", proj.ID, keySHA256, storage.APIKeyScopeRead); err != nil {
+		t.Fatal(err)
+	}
+
+	authorizer := auth.New("").WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
+	ingestHandler := ingest.NewHandler(authorizer, nil, 1<<20)
+	userAuth, _ := auth.NewUserAuthenticator("admin", "pass", "")
+	sessions := auth.NewSessionManager("secret", time.Hour)
+	server := NewServerWithAuth(ingestHandler, store, userAuth, sessions, nil, nil)
+
+	t.Run("read-only key can GET protected endpoints", func(t *testing.T) {
+		for _, path := range []string{"/api/v1/issues", "/api/v1/releases", "/api/v1/projects", "/api/v1/logs"} {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("x-bugbarn-api-key", plaintext)
+			server.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Errorf("GET %s: got %d want %d body=%q", path, rr.Code, http.StatusOK, rr.Body.String())
+			}
+		}
+	})
+
+	t.Run("read-only key is blocked from POST/PUT/DELETE", func(t *testing.T) {
+		methods := []struct {
+			method string
+			path   string
+		}{
+			{http.MethodPost, "/api/v1/releases"},
+			{http.MethodDelete, "/api/v1/projects/default"},
+			{http.MethodPut, "/api/v1/settings"},
+		}
+		for _, tc := range methods {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader("{}"))
+			req.Header.Set("x-bugbarn-api-key", plaintext)
+			req.Header.Set("Content-Type", "application/json")
+			server.ServeHTTP(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Errorf("%s %s: got %d want %d", tc.method, tc.path, rr.Code, http.StatusForbidden)
+			}
+		}
+	})
+
+	t.Run("read-only key is blocked from settings and apikeys", func(t *testing.T) {
+		for _, path := range []string{"/api/v1/settings", "/api/v1/apikeys"} {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("x-bugbarn-api-key", plaintext)
+			server.ServeHTTP(rr, req)
+			if rr.Code != http.StatusForbidden {
+				t.Errorf("GET %s: got %d want %d", path, rr.Code, http.StatusForbidden)
+			}
+		}
+	})
+}
+
 func TestIngestCORSHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -78,6 +78,7 @@ type ProjectGroup struct {
 const (
 	APIKeyScopeFull   = "full"
 	APIKeyScopeIngest = "ingest"
+	APIKeyScopeRead   = "read"
 )
 
 // APIKey represents an API key row (the plaintext key is never stored).

--- a/internal/storage/apikeys.go
+++ b/internal/storage/apikeys.go
@@ -10,7 +10,7 @@ import (
 // CreateAPIKey stores an API key's SHA-256 hash and returns the resulting row.
 // scope must be APIKeyScopeFull or APIKeyScopeIngest.
 func (s *Store) CreateAPIKey(ctx context.Context, name string, projectID int64, keySHA256, scope string) (APIKey, error) {
-	if scope != APIKeyScopeFull && scope != APIKeyScopeIngest {
+	if scope != APIKeyScopeFull && scope != APIKeyScopeIngest && scope != APIKeyScopeRead {
 		scope = APIKeyScopeFull
 	}
 	now := formatTime(time.Now().UTC())

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -38,6 +38,7 @@ type ProjectGroup = domain.ProjectGroup
 const (
 	APIKeyScopeFull   = domain.APIKeyScopeFull
 	APIKeyScopeIngest = domain.APIKeyScopeIngest
+	APIKeyScopeRead   = domain.APIKeyScopeRead
 )
 
 // IssueHourlyCounts holds per-issue 24-hour event frequency data.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,237 @@
+# BugBarn
+
+> Self-hosted error tracking and analytics platform. Ingests errors from client SDKs, groups them by fingerprint, and provides a web dashboard for triaging issues. Built with Go, vanilla TypeScript SPA, and SQLite.
+
+## Architecture
+
+- **Backend**: Go HTTP server (`cmd/bugbarn/`) with no framework dependencies
+- **Frontend**: Vanilla TypeScript single-page application (`web/`)
+- **Storage**: SQLite with a single `storage.Store` struct
+- **Durability**: On-disk spool queue (`internal/spool/`) buffers ingested events before a background worker persists them to SQLite
+- **Background worker**: Reads from the spool, deduplicates via fingerprinting, persists events, and publishes domain events for alerting
+
+## SDKs
+
+Four official SDKs are available:
+
+| Language | Package | Install |
+|---|---|---|
+| Go | `github.com/wiebe-xyz/bugbarn-go` | `go get github.com/wiebe-xyz/bugbarn-go` |
+| TypeScript | `@bugbarn/typescript` | `npm install @bugbarn/typescript` |
+| Python | `bugbarn-python` | `pip install bugbarn-python` |
+| PHP | `bugbarn/bugbarn-php` | `composer require bugbarn/bugbarn-php` |
+
+### Go SDK
+
+```go
+import bb "github.com/wiebe-xyz/bugbarn-go"
+
+bb.Init(bb.Options{
+    APIKey:   "your-api-key",
+    Endpoint: "https://bugbarn.example.com/api/v1/events",
+})
+defer bb.Shutdown(2 * time.Second)
+
+bb.CaptureError(err)
+bb.CaptureMessage("something happened")
+```
+
+HTTP middleware for panic recovery: `bb.RecoverMiddleware(handler)`
+
+### TypeScript SDK
+
+```typescript
+import { init, captureException, shutdown } from "@bugbarn/typescript";
+
+init({
+  apiKey: "your-api-key",
+  endpoint: "https://bugbarn.example.com/api/v1/events",
+  project: "my-app",           // optional project slug
+  release: "1.0.0",            // optional release version
+  installDefaultHandlers: true, // catches uncaughtException and unhandledRejection
+  autoBreadcrumbs: true,        // auto-captures console, http, and fetch breadcrumbs
+});
+
+await captureException(new Error("something broke"));
+await shutdown();
+```
+
+### Python SDK
+
+```python
+import bugbarn
+
+bugbarn.init(
+    api_key="your-api-key",
+    endpoint="https://bugbarn.example.com/api/v1/events",
+    install_excepthook=True,  # optional: auto-capture unhandled exceptions
+)
+
+bugbarn.capture_exception(exception)
+bugbarn.shutdown(timeout=2.0)
+```
+
+### PHP SDK
+
+```php
+use BugBarn\Client;
+
+Client::init(
+    apiKey: 'your-api-key',
+    endpoint: 'https://bugbarn.example.com/api/v1/events',
+    installHandlers: true,  // captures uncaught exceptions and fatal errors
+    projectSlug: 'my-app',
+);
+
+Client::captureThrowable($exception);
+Client::captureMessage('something happened');
+Client::flush();
+```
+
+## HTTP API
+
+Base URL: `https://your-bugbarn-instance.example.com`
+
+### Authentication
+
+- **API key**: Pass via `X-BugBarn-API-Key` header. Keys have either `ingest` scope (can only POST events/logs) or `full` scope (all endpoints).
+- **Session cookie**: Web UI uses `bugbarn_session` cookie with CSRF protection via `X-BugBarn-CSRF` header.
+- **Project routing**: Set `X-BugBarn-Project` header to route events to a specific project by slug.
+
+### Ingest (public, wildcard CORS)
+
+- `POST /api/v1/events` -- Ingest an error event (also available as `/api/v1/ingest`)
+- `POST /api/v1/logs` -- Ingest structured log entries
+- `POST /api/v1/analytics/collect` -- Collect page view analytics
+
+### Issues
+
+- `GET /api/v1/issues` -- List issues (supports `?status=`, `?query=`, `?project=` filters)
+- `GET /api/v1/issues/sparklines` -- Get sparkline data for issues
+- `GET /api/v1/issues/{id}` -- Get issue detail
+- `PATCH /api/v1/issues/{id}` -- Update issue (resolve, ignore, etc.)
+- `GET /api/v1/issues/{id}/events` -- List events for an issue
+
+### Events
+
+- `GET /api/v1/events/{id}` -- Get a single event
+- `GET /api/v1/events/stream` -- SSE stream of new events
+- `GET /api/v1/live/events` -- List recent events
+
+### Projects
+
+- `GET /api/v1/projects` -- List projects
+- `POST /api/v1/projects` -- Create a project
+- `PUT /api/v1/projects/{id}` -- Rename a project
+- `DELETE /api/v1/projects/{id}` -- Delete a project
+- `POST /api/v1/projects/{id}/merge` -- Merge project into another
+- `POST /api/v1/projects/{id}/approve` -- Approve a pending project
+
+### Releases
+
+- `GET /api/v1/releases` -- List releases
+- `POST /api/v1/releases` -- Create a release
+
+### Alerts
+
+- `GET /api/v1/alerts` -- List alert rules
+- `POST /api/v1/alerts` -- Create an alert rule
+- `PUT /api/v1/alerts/{id}` -- Update an alert rule
+- `DELETE /api/v1/alerts/{id}` -- Delete an alert rule
+
+### Source Maps
+
+- `GET /api/v1/source-maps` -- List uploaded source maps
+- `POST /api/v1/source-maps` -- Upload a source map (multipart, max 32 MiB)
+
+### Logs
+
+- `GET /api/v1/logs` -- Query structured logs
+- `GET /api/v1/logs/stream` -- SSE stream of live logs
+
+### Analytics
+
+- `GET /api/v1/analytics/{query}` -- Run an analytics query
+
+### Other
+
+- `GET /api/v1/health` -- Health check (no auth required)
+- `GET /api/v1/apikeys` -- List API keys
+- `DELETE /api/v1/apikeys/{id}` -- Delete an API key
+- `GET /api/v1/groups` -- List issue groups
+- `GET /api/v1/facets/{field}` -- Get facet values for filtering
+
+## Event Envelope Format
+
+POST a JSON body to `/api/v1/events`:
+
+```json
+{
+  "timestamp": "2025-01-15T10:30:00Z",
+  "severityText": "ERROR",
+  "body": "null pointer dereference",
+  "exception": {
+    "type": "NullPointerError",
+    "message": "null pointer dereference",
+    "stacktrace": [
+      { "function": "main.handler", "file": "main.go", "line": 42 }
+    ]
+  },
+  "attributes": { "key": "value" },
+  "tags": { "environment": "production" },
+  "user": { "id": "123", "email": "user@example.com" },
+  "breadcrumbs": [
+    { "timestamp": "2025-01-15T10:29:59Z", "category": "http", "message": "GET /api/users" }
+  ],
+  "release": "1.0.0",
+  "sender": { "sdk": { "name": "bugbarn.go", "version": "0.1.0" } }
+}
+```
+
+## Configuration
+
+Environment variables for the server:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BUGBARN_ADDR` | `:8080` | Listen address |
+| `BUGBARN_DB_PATH` | `.data/bugbarn.db` | SQLite database path |
+| `BUGBARN_SPOOL_DIR` | `.data/spool` | On-disk event spool directory |
+| `BUGBARN_API_KEY` | (none) | Shared API key for ingest authentication |
+| `BUGBARN_API_KEY_SHA256` | (none) | SHA-256 hash of API key (preferred over plaintext) |
+| `BUGBARN_ADMIN_USERNAME` | (none) | Web UI admin username |
+| `BUGBARN_ADMIN_PASSWORD` | (none) | Web UI admin password (plaintext) |
+| `BUGBARN_ADMIN_PASSWORD_BCRYPT` | (none) | Web UI admin password (bcrypt hash, preferred) |
+| `BUGBARN_SESSION_SECRET` | (none) | Secret for session cookie signing |
+| `BUGBARN_SESSION_TTL_SECONDS` | `43200` | Session lifetime in seconds (default 12h) |
+| `BUGBARN_ALLOWED_ORIGINS` | (none) | Comma-separated allowed CORS origins for dashboard |
+| `BUGBARN_TRUSTED_PROXIES` | (none) | Comma-separated CIDRs for trusting X-Forwarded-For |
+| `BUGBARN_PUBLIC_URL` | (none) | Public-facing URL (used in alerts and digests) |
+| `BUGBARN_MAX_BODY_BYTES` | `1048576` | Max ingest request body size (1 MiB) |
+| `BUGBARN_MAX_SPOOL_BYTES` | (none) | Max spool file size before rotation |
+| `BUGBARN_MAX_SOURCE_MAP_BYTES` | `33554432` | Max source map upload size (32 MiB) |
+| `BUGBARN_SELF_ENDPOINT` | (none) | Endpoint for self-reporting errors (dogfooding) |
+| `BUGBARN_SELF_API_KEY` | (none) | API key for self-reporting |
+| `BUGBARN_SELF_PROJECT` | (none) | Project slug for self-reporting |
+| `BUGBARN_AUTO_APPROVE_PROJECTS` | `false` | Auto-approve new projects from SDK headers |
+| `BUGBARN_ANALYTICS_RETENTION_DAYS` | `90` | Days to retain analytics data |
+
+Config files are also supported at `/etc/bugbarn/bugbarn.conf` and `~/.config/bugbarn/bugbarn.conf` (KEY=VALUE format).
+
+## CLI Management
+
+The `bugbarn` binary includes management subcommands:
+
+```bash
+bugbarn user create --username=admin --password=secret
+bugbarn project create --name="My App" --slug=my-app
+bugbarn apikey create --project=my-app --name=production --scope=ingest
+```
+
+## Self-Hosting Quick Start
+
+1. Build: `go build -o bugbarn ./cmd/bugbarn/`
+2. Set required env vars: `BUGBARN_API_KEY`, `BUGBARN_ADMIN_USERNAME`, `BUGBARN_ADMIN_PASSWORD`
+3. Run: `./bugbarn`
+4. Dashboard available at `http://localhost:8080`
+5. Point your SDK to `http://localhost:8080/api/v1/events`

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,237 @@
+# BugBarn
+
+> Self-hosted error tracking and analytics platform. Ingests errors from client SDKs, groups them by fingerprint, and provides a web dashboard for triaging issues. Built with Go, vanilla TypeScript SPA, and SQLite.
+
+## Architecture
+
+- **Backend**: Go HTTP server (`cmd/bugbarn/`) with no framework dependencies
+- **Frontend**: Vanilla TypeScript single-page application (`web/`)
+- **Storage**: SQLite with a single `storage.Store` struct
+- **Durability**: On-disk spool queue (`internal/spool/`) buffers ingested events before a background worker persists them to SQLite
+- **Background worker**: Reads from the spool, deduplicates via fingerprinting, persists events, and publishes domain events for alerting
+
+## SDKs
+
+Four official SDKs are available:
+
+| Language | Package | Install |
+|---|---|---|
+| Go | `github.com/wiebe-xyz/bugbarn-go` | `go get github.com/wiebe-xyz/bugbarn-go` |
+| TypeScript | `@bugbarn/typescript` | `npm install @bugbarn/typescript` |
+| Python | `bugbarn-python` | `pip install bugbarn-python` |
+| PHP | `bugbarn/bugbarn-php` | `composer require bugbarn/bugbarn-php` |
+
+### Go SDK
+
+```go
+import bb "github.com/wiebe-xyz/bugbarn-go"
+
+bb.Init(bb.Options{
+    APIKey:   "your-api-key",
+    Endpoint: "https://bugbarn.example.com/api/v1/events",
+})
+defer bb.Shutdown(2 * time.Second)
+
+bb.CaptureError(err)
+bb.CaptureMessage("something happened")
+```
+
+HTTP middleware for panic recovery: `bb.RecoverMiddleware(handler)`
+
+### TypeScript SDK
+
+```typescript
+import { init, captureException, shutdown } from "@bugbarn/typescript";
+
+init({
+  apiKey: "your-api-key",
+  endpoint: "https://bugbarn.example.com/api/v1/events",
+  project: "my-app",           // optional project slug
+  release: "1.0.0",            // optional release version
+  installDefaultHandlers: true, // catches uncaughtException and unhandledRejection
+  autoBreadcrumbs: true,        // auto-captures console, http, and fetch breadcrumbs
+});
+
+await captureException(new Error("something broke"));
+await shutdown();
+```
+
+### Python SDK
+
+```python
+import bugbarn
+
+bugbarn.init(
+    api_key="your-api-key",
+    endpoint="https://bugbarn.example.com/api/v1/events",
+    install_excepthook=True,  # optional: auto-capture unhandled exceptions
+)
+
+bugbarn.capture_exception(exception)
+bugbarn.shutdown(timeout=2.0)
+```
+
+### PHP SDK
+
+```php
+use BugBarn\Client;
+
+Client::init(
+    apiKey: 'your-api-key',
+    endpoint: 'https://bugbarn.example.com/api/v1/events',
+    installHandlers: true,  // captures uncaught exceptions and fatal errors
+    projectSlug: 'my-app',
+);
+
+Client::captureThrowable($exception);
+Client::captureMessage('something happened');
+Client::flush();
+```
+
+## HTTP API
+
+Base URL: `https://your-bugbarn-instance.example.com`
+
+### Authentication
+
+- **API key**: Pass via `X-BugBarn-API-Key` header. Keys have either `ingest` scope (can only POST events/logs) or `full` scope (all endpoints).
+- **Session cookie**: Web UI uses `bugbarn_session` cookie with CSRF protection via `X-BugBarn-CSRF` header.
+- **Project routing**: Set `X-BugBarn-Project` header to route events to a specific project by slug.
+
+### Ingest (public, wildcard CORS)
+
+- `POST /api/v1/events` -- Ingest an error event (also available as `/api/v1/ingest`)
+- `POST /api/v1/logs` -- Ingest structured log entries
+- `POST /api/v1/analytics/collect` -- Collect page view analytics
+
+### Issues
+
+- `GET /api/v1/issues` -- List issues (supports `?status=`, `?query=`, `?project=` filters)
+- `GET /api/v1/issues/sparklines` -- Get sparkline data for issues
+- `GET /api/v1/issues/{id}` -- Get issue detail
+- `PATCH /api/v1/issues/{id}` -- Update issue (resolve, ignore, etc.)
+- `GET /api/v1/issues/{id}/events` -- List events for an issue
+
+### Events
+
+- `GET /api/v1/events/{id}` -- Get a single event
+- `GET /api/v1/events/stream` -- SSE stream of new events
+- `GET /api/v1/live/events` -- List recent events
+
+### Projects
+
+- `GET /api/v1/projects` -- List projects
+- `POST /api/v1/projects` -- Create a project
+- `PUT /api/v1/projects/{id}` -- Rename a project
+- `DELETE /api/v1/projects/{id}` -- Delete a project
+- `POST /api/v1/projects/{id}/merge` -- Merge project into another
+- `POST /api/v1/projects/{id}/approve` -- Approve a pending project
+
+### Releases
+
+- `GET /api/v1/releases` -- List releases
+- `POST /api/v1/releases` -- Create a release
+
+### Alerts
+
+- `GET /api/v1/alerts` -- List alert rules
+- `POST /api/v1/alerts` -- Create an alert rule
+- `PUT /api/v1/alerts/{id}` -- Update an alert rule
+- `DELETE /api/v1/alerts/{id}` -- Delete an alert rule
+
+### Source Maps
+
+- `GET /api/v1/source-maps` -- List uploaded source maps
+- `POST /api/v1/source-maps` -- Upload a source map (multipart, max 32 MiB)
+
+### Logs
+
+- `GET /api/v1/logs` -- Query structured logs
+- `GET /api/v1/logs/stream` -- SSE stream of live logs
+
+### Analytics
+
+- `GET /api/v1/analytics/{query}` -- Run an analytics query
+
+### Other
+
+- `GET /api/v1/health` -- Health check (no auth required)
+- `GET /api/v1/apikeys` -- List API keys
+- `DELETE /api/v1/apikeys/{id}` -- Delete an API key
+- `GET /api/v1/groups` -- List issue groups
+- `GET /api/v1/facets/{field}` -- Get facet values for filtering
+
+## Event Envelope Format
+
+POST a JSON body to `/api/v1/events`:
+
+```json
+{
+  "timestamp": "2025-01-15T10:30:00Z",
+  "severityText": "ERROR",
+  "body": "null pointer dereference",
+  "exception": {
+    "type": "NullPointerError",
+    "message": "null pointer dereference",
+    "stacktrace": [
+      { "function": "main.handler", "file": "main.go", "line": 42 }
+    ]
+  },
+  "attributes": { "key": "value" },
+  "tags": { "environment": "production" },
+  "user": { "id": "123", "email": "user@example.com" },
+  "breadcrumbs": [
+    { "timestamp": "2025-01-15T10:29:59Z", "category": "http", "message": "GET /api/users" }
+  ],
+  "release": "1.0.0",
+  "sender": { "sdk": { "name": "bugbarn.go", "version": "0.1.0" } }
+}
+```
+
+## Configuration
+
+Environment variables for the server:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BUGBARN_ADDR` | `:8080` | Listen address |
+| `BUGBARN_DB_PATH` | `.data/bugbarn.db` | SQLite database path |
+| `BUGBARN_SPOOL_DIR` | `.data/spool` | On-disk event spool directory |
+| `BUGBARN_API_KEY` | (none) | Shared API key for ingest authentication |
+| `BUGBARN_API_KEY_SHA256` | (none) | SHA-256 hash of API key (preferred over plaintext) |
+| `BUGBARN_ADMIN_USERNAME` | (none) | Web UI admin username |
+| `BUGBARN_ADMIN_PASSWORD` | (none) | Web UI admin password (plaintext) |
+| `BUGBARN_ADMIN_PASSWORD_BCRYPT` | (none) | Web UI admin password (bcrypt hash, preferred) |
+| `BUGBARN_SESSION_SECRET` | (none) | Secret for session cookie signing |
+| `BUGBARN_SESSION_TTL_SECONDS` | `43200` | Session lifetime in seconds (default 12h) |
+| `BUGBARN_ALLOWED_ORIGINS` | (none) | Comma-separated allowed CORS origins for dashboard |
+| `BUGBARN_TRUSTED_PROXIES` | (none) | Comma-separated CIDRs for trusting X-Forwarded-For |
+| `BUGBARN_PUBLIC_URL` | (none) | Public-facing URL (used in alerts and digests) |
+| `BUGBARN_MAX_BODY_BYTES` | `1048576` | Max ingest request body size (1 MiB) |
+| `BUGBARN_MAX_SPOOL_BYTES` | (none) | Max spool file size before rotation |
+| `BUGBARN_MAX_SOURCE_MAP_BYTES` | `33554432` | Max source map upload size (32 MiB) |
+| `BUGBARN_SELF_ENDPOINT` | (none) | Endpoint for self-reporting errors (dogfooding) |
+| `BUGBARN_SELF_API_KEY` | (none) | API key for self-reporting |
+| `BUGBARN_SELF_PROJECT` | (none) | Project slug for self-reporting |
+| `BUGBARN_AUTO_APPROVE_PROJECTS` | `false` | Auto-approve new projects from SDK headers |
+| `BUGBARN_ANALYTICS_RETENTION_DAYS` | `90` | Days to retain analytics data |
+
+Config files are also supported at `/etc/bugbarn/bugbarn.conf` and `~/.config/bugbarn/bugbarn.conf` (KEY=VALUE format).
+
+## CLI Management
+
+The `bugbarn` binary includes management subcommands:
+
+```bash
+bugbarn user create --username=admin --password=secret
+bugbarn project create --name="My App" --slug=my-app
+bugbarn apikey create --project=my-app --name=production --scope=ingest
+```
+
+## Self-Hosting Quick Start
+
+1. Build: `go build -o bugbarn ./cmd/bugbarn/`
+2. Set required env vars: `BUGBARN_API_KEY`, `BUGBARN_ADMIN_USERNAME`, `BUGBARN_ADMIN_PASSWORD`
+3. Run: `./bugbarn`
+4. Dashboard available at `http://localhost:8080`
+5. Point your SDK to `http://localhost:8080/api/v1/events`


### PR DESCRIPTION
## Summary

- **Fix CLI project filter (#54, #52)**: `bb issues --project <slug>` now sends `X-BugBarn-Project` header correctly. Server also accepts `project_slug` query param as fallback. Empty results return `[]` instead of `null`. Project slug is validated before querying — unknown slugs get a clear error. Auth errors are no longer silently swallowed.

- **Add read-scoped API keys (#3)**: New `read` scope allows GET access to all protected endpoints (issues, events, projects, releases, alerts, logs, analytics) but blocks POST/PUT/DELETE and sensitive endpoints (settings, apikeys). CLI `--scope read` flag added.

- **Add llms.txt (#7)**: Structured AI-assistant context file at repo root and `site/public/llms.txt` covering architecture, SDKs, API reference, and configuration.

Also closes #24, #25, #26, #27, #31 — all analytics features verified as already implemented.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all 21 test packages pass
- [x] New `TestReadOnlyKeyScope` test covers read-scope enforcement (GET allowed, POST/DELETE blocked, settings/apikeys blocked)
- [ ] Deploy to testing and verify CLI project filter works with `bb issues --project <slug>`
- [ ] Verify read-scoped API key can GET issues but cannot POST events
- [ ] Verify llms.txt is accessible at `/llms.txt` on the marketing site