### PR TITLE
fix: fall back to rawScrubbed for fingerprinting when exception is empty

### DIFF
--- a/internal/fingerprint/fingerprint.go
+++ b/internal/fingerprint/fingerprint.go
@@ -72,6 +72,19 @@ func SnapshotFor(evt event.Event) Snapshot {
 		normalizedMessage = normalize(evt.Message)
 	}
 
+	// When exception is empty but rawScrubbed has data, use it as fallback
+	// for fingerprinting. This handles browser errors like promise rejections
+	// and cross-origin errors that arrive with exception: {}.
+	if normalizedExceptionType == "" && normalizedMessage == "" && len(evt.Exception.Stacktrace) == 0 {
+		if raw := rawScrubbedFallback(evt.RawScrubbed); raw.name != "" || raw.message != "" {
+			normalizedExceptionType = normalize(raw.name)
+			normalizedMessage = normalize(raw.message)
+			if normalizedMessage == "" {
+				normalizedMessage = normalize(raw.source)
+			}
+		}
+	}
+
 	frameParts := make([]string, 0, len(evt.Exception.Stacktrace))
 	explanation := make([]string, 0, 8+len(evt.Exception.Stacktrace))
 
@@ -218,6 +231,29 @@ func normalizePath(value string) string {
 	value = strings.ReplaceAll(value, "\\", "/")
 	value = pathNumberSegment.ReplaceAllString(value, "/:num")
 	return normalize(value)
+}
+
+type rawScrubbedData struct {
+	name    string
+	message string
+	source  string
+}
+
+func rawScrubbedFallback(rawScrubbed map[string]any) rawScrubbedData {
+	if rawScrubbed == nil {
+		return rawScrubbedData{}
+	}
+	name, _ := rawScrubbed["name"].(string)
+	props, _ := rawScrubbed["properties"].(map[string]any)
+	if props == nil {
+		return rawScrubbedData{name: name}
+	}
+	message, _ := props["message"].(string)
+	source, _ := props["source"].(string)
+	if source == "" {
+		source, _ = props["url"].(string)
+	}
+	return rawScrubbedData{name: name, message: message, source: source}
 }
 
 func normalize(value string) string {

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -60,3 +60,80 @@ func TestFingerprintChangesForDifferentExceptionType(t *testing.T) {
 		t.Fatal("expected different fingerprints")
 	}
 }
+
+func TestFingerprintFallsBackToRawScrubbed(t *testing.T) {
+	// Events with empty exception but different rawScrubbed messages should
+	// produce different fingerprints.
+	first := event.Event{
+		RawScrubbed: map[string]any{
+			"exception": map[string]any{},
+			"name":      "error",
+			"properties": map[string]any{
+				"message": "Failed to register a ServiceWorker",
+				"source":  "window.onunhandledrejection",
+			},
+		},
+	}
+	second := event.Event{
+		RawScrubbed: map[string]any{
+			"exception": map[string]any{},
+			"name":      "error",
+			"properties": map[string]any{
+				"message": "Network request failed",
+				"source":  "window.onerror",
+			},
+		},
+	}
+
+	fp1 := Fingerprint(first)
+	fp2 := Fingerprint(second)
+	if fp1 == fp2 {
+		t.Fatalf("expected different fingerprints for different rawScrubbed messages:\n%s\n%s", Material(first), Material(second))
+	}
+}
+
+func TestFingerprintRawScrubbedSameMessageProducesSameFingerprint(t *testing.T) {
+	// Same error from same source should be deterministic.
+	first := event.Event{
+		RawScrubbed: map[string]any{
+			"name": "error",
+			"properties": map[string]any{
+				"message": "Failed to register a ServiceWorker",
+				"source":  "window.onunhandledrejection",
+			},
+		},
+	}
+	second := event.Event{
+		RawScrubbed: map[string]any{
+			"name": "error",
+			"properties": map[string]any{
+				"message": "Failed to register a ServiceWorker",
+				"source":  "window.onunhandledrejection",
+			},
+		},
+	}
+
+	if Fingerprint(first) != Fingerprint(second) {
+		t.Fatalf("expected same fingerprint for identical rawScrubbed:\n%s\n%s", Material(first), Material(second))
+	}
+}
+
+func TestFingerprintRawScrubbedNotUsedWhenExceptionPresent(t *testing.T) {
+	// When exception has data, rawScrubbed should be ignored for fingerprinting.
+	withException := event.Event{
+		Exception: event.Exception{Type: "TypeError", Message: "boom"},
+		RawScrubbed: map[string]any{
+			"name": "error",
+			"properties": map[string]any{
+				"message": "different message",
+			},
+		},
+	}
+	withoutRawScrubbed := event.Event{
+		Exception: event.Exception{Type: "TypeError", Message: "boom"},
+	}
+
+	if Fingerprint(withException) != Fingerprint(withoutRawScrubbed) {
+		t.Fatal("rawScrubbed should not affect fingerprint when exception is present")
+	}
+}

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -50,6 +50,14 @@ func Normalize(raw []byte, ingestID string, receivedAt time.Time) (event.Event, 
 	if evt.Message == "" {
 		evt.Message = evt.Exception.Message
 	}
+	// When exception is empty, fall back to rawScrubbed.properties.message.
+	// Browser errors (promise rejections, cross-origin) often arrive with
+	// exception: {} but carry actual details in rawScrubbed.
+	if evt.Message == "" {
+		if props := objectValue(scrubbed["properties"]); props != nil {
+			evt.Message = stringValue(props["message"])
+		}
+	}
 	if evt.Severity == "" {
 		evt.Severity = "ERROR"
 	}

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -160,3 +160,29 @@ func boolToInt(value bool) int {
 	}
 	return 0
 }
+
+type rawScrubbedData struct {
+	name    string
+	message string
+	source  string
+}
+
+// rawScrubbedFallback extracts error details from the rawScrubbed payload.
+// Browser errors (promise rejections, cross-origin errors) often arrive with
+// exception: {} but carry actual details in rawScrubbed.
+func rawScrubbedFallback(rawScrubbed map[string]any) rawScrubbedData {
+	if rawScrubbed == nil {
+		return rawScrubbedData{}
+	}
+	name, _ := rawScrubbed["name"].(string)
+	props, _ := rawScrubbed["properties"].(map[string]any)
+	if props == nil {
+		return rawScrubbedData{name: name}
+	}
+	message, _ := props["message"].(string)
+	source, _ := props["source"].(string)
+	if source == "" {
+		source, _ = props["url"].(string)
+	}
+	return rawScrubbedData{name: name, message: message, source: source}
+}

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -705,6 +705,16 @@ func issueDetails(evt event.Event) (title, normalizedTitle, exceptionType string
 		message = strings.TrimSpace(evt.Message)
 	}
 
+	// When exception is empty, fall back to rawScrubbed data. This handles
+	// browser errors (promise rejections, cross-origin) that arrive with
+	// exception: {} but have details in rawScrubbed.
+	if exceptionType == "" && message == "" {
+		if raw := rawScrubbedFallback(evt.RawScrubbed); raw.name != "" || raw.message != "" {
+			exceptionType = strings.TrimSpace(raw.name)
+			message = strings.TrimSpace(raw.message)
+		}
+	}
+
 	switch {
 	case exceptionType != "" && message != "":
 		title = exceptionType + ": " + message


### PR DESCRIPTION
## Summary

Fixes #58 — events with empty `exception: {}` (browser promise rejections, cross-origin errors) no longer collapse into a single untitled issue.

- **Fingerprinting**: Falls back to `rawScrubbed.name`, `rawScrubbed.properties.message`, and `source/url` when exception is empty
- **Issue titles**: Falls back to rawScrubbed name + message (e.g. "error: Failed to register ServiceWorker...")
- **Event message**: Falls back to `rawScrubbed.properties.message`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass
- [x] 3 new fingerprint tests: different messages → different fingerprints; identical messages → same fingerprint; rawScrubbed ignored when exception has data