### PR TITLE
fix: PWA respects Android rotation lock

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -6,7 +6,6 @@
   "display": "standalone",
   "background_color": "#0f1117",
   "theme_color": "#0f1117",
-  "orientation": "any",
   "icons": [
     {
       "src": "/icons/icon-192.png",


### PR DESCRIPTION
Remove orientation: any from manifest so PWA defers to OS rotation lock.