### PR TITLE
fix: reader litestream restore path mismatch and empty DB bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,18 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             set -euo pipefail
             kubectl apply -k /tmp/bugbarn-deploy/deploy/k8s/staging
-            kubectl -n ${NAMESPACE} set image deployment/bugbarn \
+
+            # Delete the old single deployment if it still exists (migration to CQRS split).
+            kubectl -n ${NAMESPACE} delete deployment/bugbarn --ignore-not-found=true
+
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-writer \
+              bugbarn=${SERVICE_IMAGE}:${VERSION}
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-reader \
               bugbarn=${SERVICE_IMAGE}:${VERSION}
             kubectl -n ${NAMESPACE} set image deployment/bugbarn-web \
               bugbarn-web=${WEB_IMAGE}:${VERSION}
-            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-reader --timeout=180s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-web --timeout=180s
           "
 

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -185,7 +185,19 @@ func run() error {
 func runReader(cfg config.Config, logger *slog.Logger) error {
 	store, err := storage.OpenReadOnly(cfg.DBPath)
 	if err != nil {
-		return fmt.Errorf("open read-only storage: %w", err)
+		// DB file may not exist yet (no Litestream replica available).
+		// Bootstrap an empty schema so the reader can serve empty results
+		// until the first restore loop succeeds.
+		logger.Warn("read-only open failed, bootstrapping empty database", "error", err)
+		bootstrap, bErr := storage.Open(cfg.DBPath)
+		if bErr != nil {
+			return fmt.Errorf("bootstrap empty database: %w", bErr)
+		}
+		bootstrap.Close()
+		store, err = storage.OpenReadOnly(cfg.DBPath)
+		if err != nil {
+			return fmt.Errorf("open read-only storage after bootstrap: %w", err)
+		}
 	}
 	defer store.Close()
 

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
 	"github.com/wiebe-xyz/bugbarn/internal/issues"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
+	"github.com/wiebe-xyz/bugbarn/internal/reader"
 	"github.com/wiebe-xyz/bugbarn/internal/selflog"
 	"github.com/wiebe-xyz/bugbarn/internal/service"
 	"github.com/wiebe-xyz/bugbarn/internal/spool"
@@ -68,6 +69,10 @@ func run() error {
 		case "apikey":
 			return cli.RunAPIKey(cfg, os.Args[2:])
 		}
+	}
+
+	if cfg.Mode == "reader" {
+		return runReader(cfg, logger)
 	}
 
 	if cfg.SessionSecret == "" {
@@ -166,6 +171,75 @@ func run() error {
 		if selfReporting {
 			bb.Shutdown(2 * time.Second)
 		}
+		return server.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+// runReader starts the server in read-only mode. It opens a read-only SQLite
+// copy (restored from Litestream) and forwards all writes to the writer pod.
+func runReader(cfg config.Config, logger *slog.Logger) error {
+	store, err := storage.OpenReadOnly(cfg.DBPath)
+	if err != nil {
+		return fmt.Errorf("open read-only storage: %w", err)
+	}
+	defer store.Close()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	forwarder := api.NewWriteForwarder(cfg.WriterURL)
+
+	apiAuthorizer, err := newAPIAuthorizer(cfg, store)
+	if err != nil {
+		return err
+	}
+	userAuth, err := auth.NewUserAuthenticator(cfg.AdminUsername, cfg.AdminPassword, cfg.AdminPasswordBcrypt)
+	if err != nil {
+		return err
+	}
+	sessionManager := auth.NewSessionManager(cfg.SessionSecret, cfg.SessionTTL)
+
+	// Reader needs the ingest handler for API key validation on GET requests,
+	// but with nil spool since writes are forwarded to the writer.
+	handler := ingest.NewHandler(apiAuthorizer, nil, cfg.MaxBodyBytes)
+
+	logHub := logstream.NewHub()
+	apiServer := api.NewServerWithAuth(handler, store, userAuth, sessionManager, cfg.AllowedOrigins, logger)
+	apiServer.SetLogHub(logHub)
+	apiServer.SetSetupConfig(cfg.SessionSecret, cfg.PublicURL)
+	apiServer.SetWriteForwarder(forwarder)
+	if len(cfg.TrustedProxies) > 0 {
+		apiServer.SetTrustedProxies(cfg.TrustedProxies)
+	}
+	apiServer.SetAutoApproveProjects(cfg.AutoApproveProjects)
+	apiServer.SetFunnelBarnConfig(cfg.FunnelBarnEndpoint, cfg.FunnelBarnAPIKey)
+	if cfg.MaxSourceMapBytes > 0 {
+		apiServer.SetMaxSourceMapBytes(cfg.MaxSourceMapBytes)
+	}
+
+	server := &http.Server{
+		Addr:    cfg.Addr,
+		Handler: apiServer,
+	}
+
+	go reader.StartRestoreLoop(ctx, store, cfg.DBPath, logger)
+
+	logger.Info("starting in reader mode", "addr", cfg.Addr, "writer_url", cfg.WriterURL)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		return server.Shutdown(shutdownCtx)
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,18 +1,35 @@
 #!/bin/sh
 set -eu
 
-if [ -z "${LITESTREAM_ACCESS_KEY_ID:-}" ]; then
-  exec bugbarn
-fi
+case "${BUGBARN_MODE:-}" in
+  reader)
+    # Reader mode: restore a snapshot from Litestream, then run read-only.
+    # The binary's internal restore loop handles periodic refreshes.
+    if [ -n "${LITESTREAM_ACCESS_KEY_ID:-}" ]; then
+      echo "Reader: restoring database from Litestream replica..."
+      litestream restore \
+        -config /etc/litestream.yml \
+        -if-replica-exists \
+        "$BUGBARN_DB_PATH" || echo "No replica found, starting with empty DB."
+    fi
+    exec bugbarn
+    ;;
+  writer|"")
+    # Writer or legacy mode: replicate to S3 via Litestream.
+    if [ -z "${LITESTREAM_ACCESS_KEY_ID:-}" ]; then
+      exec bugbarn
+    fi
 
-if [ ! -f "$BUGBARN_DB_PATH" ]; then
-  echo "Restoring database from Litestream replica (${LITESTREAM_REPLICA_PATH})..."
-  litestream restore \
-    -config /etc/litestream.yml \
-    -if-replica-exists \
-    "$BUGBARN_DB_PATH" || echo "No replica found, starting fresh."
-fi
+    if [ ! -f "$BUGBARN_DB_PATH" ]; then
+      echo "Restoring database from Litestream replica (${LITESTREAM_REPLICA_PATH})..."
+      litestream restore \
+        -config /etc/litestream.yml \
+        -if-replica-exists \
+        "$BUGBARN_DB_PATH" || echo "No replica found, starting fresh."
+    fi
 
-exec litestream replicate \
-  -config /etc/litestream.yml \
-  -exec "bugbarn"
+    exec litestream replicate \
+      -config /etc/litestream.yml \
+      -exec "bugbarn"
+    ;;
+esac

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -5,12 +5,15 @@ case "${BUGBARN_MODE:-}" in
   reader)
     # Reader mode: restore a snapshot from Litestream, then run read-only.
     # The binary's internal restore loop handles periodic refreshes.
+    # The litestream config references /var/lib/bugbarn/bugbarn.db (writer path),
+    # so we use -o to restore to the reader's DB path instead.
     if [ -n "${LITESTREAM_ACCESS_KEY_ID:-}" ]; then
       echo "Reader: restoring database from Litestream replica..."
       litestream restore \
         -config /etc/litestream.yml \
         -if-replica-exists \
-        "$BUGBARN_DB_PATH" || echo "No replica found, starting with empty DB."
+        -o "$BUGBARN_DB_PATH" \
+        /var/lib/bugbarn/bugbarn.db || echo "No replica found, starting with empty DB."
     fi
     exec bugbarn
     ;;

--- a/deploy/k8s/production/reader-deployment.yaml
+++ b/deploy/k8s/production/reader-deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bugbarn-reader
+spec:
+  replicas: 2
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bugbarn
+      app.kubernetes.io/component: reader
+      app.kubernetes.io/environment: production
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bugbarn
+        app.kubernetes.io/component: reader
+        app.kubernetes.io/environment: production
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: bugbarn
+          image: bugbarn/service
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: BUGBARN_MODE
+              value: reader
+            - name: BUGBARN_WRITER_URL
+              value: http://bugbarn-writer:8080
+            - name: BUGBARN_ADDR
+              value: :8080
+            - name: BUGBARN_PUBLIC_URL
+              value: https://bugbarn.wiebe.xyz
+            - name: BUGBARN_DB_PATH
+              value: /data/bugbarn.db
+            - name: BUGBARN_SESSION_TTL_SECONDS
+              value: "86400"
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_API_KEY
+            - name: BUGBARN_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_USERNAME
+                  optional: true
+            - name: BUGBARN_ADMIN_PASSWORD_BCRYPT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_PASSWORD_BCRYPT
+                  optional: true
+            - name: BUGBARN_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SESSION_SECRET
+                  optional: true
+            - name: LITESTREAM_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: LITESTREAM_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+            - name: LITESTREAM_REPLICA_PATH
+              value: production/bugbarn.db
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: reader-data
+              mountPath: /data
+      volumes:
+        - name: reader-data
+          emptyDir: {}

--- a/deploy/k8s/production/reader-service.yaml
+++ b/deploy/k8s/production/reader-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bugbarn
+spec:
+  selector:
+    app.kubernetes.io/name: bugbarn
+    app.kubernetes.io/component: reader
+    app.kubernetes.io/environment: production
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/k8s/production/writer-deployment.yaml
+++ b/deploy/k8s/production/writer-deployment.yaml
@@ -1,0 +1,169 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bugbarn-writer
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bugbarn
+      app.kubernetes.io/component: writer
+      app.kubernetes.io/environment: production
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bugbarn
+        app.kubernetes.io/component: writer
+        app.kubernetes.io/environment: production
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: layer7-prod
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: bugbarn
+          image: bugbarn/service
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: BUGBARN_MODE
+              value: writer
+            - name: BUGBARN_ADDR
+              value: :8080
+            - name: BUGBARN_PUBLIC_URL
+              value: https://bugbarn.wiebe.xyz
+            - name: BUGBARN_SELF_ENDPOINT
+              value: https://bugbarn.wiebe.xyz
+            - name: BUGBARN_SELF_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SELF_API_KEY
+            - name: BUGBARN_SELF_PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SELF_PROJECT
+            - name: BUGBARN_SPOOL_DIR
+              value: /var/lib/bugbarn/spool
+            - name: BUGBARN_DB_PATH
+              value: /var/lib/bugbarn/bugbarn.db
+            - name: BUGBARN_MAX_SPOOL_BYTES
+              value: "104857600"
+            - name: BUGBARN_SESSION_TTL_SECONDS
+              value: "86400"
+            - name: LITESTREAM_REPLICA_PATH
+              value: production/bugbarn.db
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_API_KEY
+            - name: BUGBARN_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_USERNAME
+                  optional: true
+            - name: BUGBARN_ADMIN_PASSWORD_BCRYPT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_PASSWORD_BCRYPT
+                  optional: true
+            - name: BUGBARN_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SESSION_SECRET
+                  optional: true
+            - name: LITESTREAM_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: LITESTREAM_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_HOST
+                  optional: true
+            - name: SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_PORT
+                  optional: true
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_USER
+                  optional: true
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_PASS
+                  optional: true
+            - name: SMTP_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_FROM
+                  optional: true
+            - name: BUGBARN_DIGEST_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_ENABLED
+                  optional: true
+            - name: BUGBARN_DIGEST_TO
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_TO
+                  optional: true
+            - name: BUGBARN_DIGEST_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_WEBHOOK_URL
+                  optional: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: bugbarn-data
+              mountPath: /var/lib/bugbarn
+      volumes:
+        - name: bugbarn-data
+          persistentVolumeClaim:
+            claimName: bugbarn-data

--- a/deploy/k8s/production/writer-service.yaml
+++ b/deploy/k8s/production/writer-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bugbarn-writer
+spec:
+  selector:
+    app.kubernetes.io/name: bugbarn
+    app.kubernetes.io/component: writer
+    app.kubernetes.io/environment: production
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/k8s/staging/kustomization.yaml
+++ b/deploy/k8s/staging/kustomization.yaml
@@ -4,8 +4,10 @@ namespace: bugbarn-staging
 resources:
   - namespace.yaml
   - pvc.yaml
-  - deployment.yaml
-  - service.yaml
+  - writer-deployment.yaml
+  - writer-service.yaml
+  - reader-deployment.yaml
+  - reader-service.yaml
   - web-deployment.yaml
   - web-service.yaml
   - ingress.yaml

--- a/deploy/k8s/staging/reader-deployment.yaml
+++ b/deploy/k8s/staging/reader-deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bugbarn-reader
+spec:
+  replicas: 2
+  revisionHistoryLimit: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bugbarn
+      app.kubernetes.io/component: reader
+      app.kubernetes.io/environment: staging
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bugbarn
+        app.kubernetes.io/component: reader
+        app.kubernetes.io/environment: staging
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: bugbarn
+          image: bugbarn/service
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: BUGBARN_MODE
+              value: reader
+            - name: BUGBARN_WRITER_URL
+              value: http://bugbarn-writer:8080
+            - name: BUGBARN_ADDR
+              value: :8080
+            - name: BUGBARN_DB_PATH
+              value: /data/bugbarn.db
+            - name: BUGBARN_SESSION_TTL_SECONDS
+              value: "86400"
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_API_KEY
+            - name: BUGBARN_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_USERNAME
+                  optional: true
+            - name: BUGBARN_ADMIN_PASSWORD_BCRYPT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_PASSWORD_BCRYPT
+                  optional: true
+            - name: BUGBARN_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SESSION_SECRET
+                  optional: true
+            - name: LITESTREAM_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: LITESTREAM_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+            - name: LITESTREAM_REPLICA_PATH
+              value: staging/bugbarn.db
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: reader-data
+              mountPath: /data
+      volumes:
+        - name: reader-data
+          emptyDir: {}

--- a/deploy/k8s/staging/reader-service.yaml
+++ b/deploy/k8s/staging/reader-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bugbarn
+spec:
+  selector:
+    app.kubernetes.io/name: bugbarn
+    app.kubernetes.io/component: reader
+    app.kubernetes.io/environment: staging
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/deploy/k8s/staging/writer-deployment.yaml
+++ b/deploy/k8s/staging/writer-deployment.yaml
@@ -1,0 +1,155 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bugbarn-writer
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bugbarn
+      app.kubernetes.io/component: writer
+      app.kubernetes.io/environment: staging
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bugbarn
+        app.kubernetes.io/component: writer
+        app.kubernetes.io/environment: staging
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: k3s1
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: bugbarn
+          image: bugbarn/service
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: BUGBARN_MODE
+              value: writer
+            - name: BUGBARN_ADDR
+              value: :8080
+            - name: BUGBARN_SPOOL_DIR
+              value: /var/lib/bugbarn/spool
+            - name: BUGBARN_DB_PATH
+              value: /var/lib/bugbarn/bugbarn.db
+            - name: BUGBARN_MAX_SPOOL_BYTES
+              value: "104857600"
+            - name: BUGBARN_SESSION_TTL_SECONDS
+              value: "86400"
+            - name: LITESTREAM_REPLICA_PATH
+              value: staging/bugbarn.db
+            - name: BUGBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_API_KEY
+            - name: BUGBARN_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_USERNAME
+                  optional: true
+            - name: BUGBARN_ADMIN_PASSWORD_BCRYPT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_ADMIN_PASSWORD_BCRYPT
+                  optional: true
+            - name: BUGBARN_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_SESSION_SECRET
+                  optional: true
+            - name: LITESTREAM_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_ACCESS_KEY_ID
+            - name: LITESTREAM_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: LITESTREAM_SECRET_ACCESS_KEY
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_HOST
+                  optional: true
+            - name: SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_PORT
+                  optional: true
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_USER
+                  optional: true
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_PASS
+                  optional: true
+            - name: SMTP_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: SMTP_FROM
+                  optional: true
+            - name: BUGBARN_DIGEST_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_ENABLED
+                  optional: true
+            - name: BUGBARN_DIGEST_TO
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_TO
+                  optional: true
+            - name: BUGBARN_DIGEST_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: smtp-secret
+                  key: BUGBARN_DIGEST_WEBHOOK_URL
+                  optional: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: bugbarn-data
+              mountPath: /var/lib/bugbarn
+      volumes:
+        - name: bugbarn-data
+          persistentVolumeClaim:
+            claimName: bugbarn-data

--- a/deploy/k8s/staging/writer-service.yaml
+++ b/deploy/k8s/staging/writer-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bugbarn-writer
+spec:
+  selector:
+    app.kubernetes.io/name: bugbarn
+    app.kubernetes.io/component: writer
+    app.kubernetes.io/environment: staging
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/internal/api/forwarder.go
+++ b/internal/api/forwarder.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// WriteForwarder proxies write requests to an upstream writer instance
+// as part of the CQRS read/write split.
+type WriteForwarder struct {
+	writerURL string
+	client    *http.Client
+}
+
+// NewWriteForwarder creates a forwarder that proxies requests to the given writer URL.
+func NewWriteForwarder(writerURL string) *WriteForwarder {
+	return &WriteForwarder{
+		writerURL: writerURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Forward proxies the incoming request to the upstream writer and streams
+// the response back to the client. On connection failure it returns 502.
+func (f *WriteForwarder) Forward(w http.ResponseWriter, r *http.Request) {
+	upstreamURL := f.writerURL + r.URL.RequestURI()
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, r.Body)
+	if err != nil {
+		http.Error(w, "upstream writer unavailable", http.StatusBadGateway)
+		return
+	}
+
+	// Copy all request headers.
+	for key, vals := range r.Header {
+		for _, v := range vals {
+			upstreamReq.Header.Add(key, v)
+		}
+	}
+
+	// Set Host to the writer's host, not the original.
+	parsed, err := url.Parse(f.writerURL)
+	if err == nil {
+		upstreamReq.Host = parsed.Host
+	}
+
+	resp, err := f.client.Do(upstreamReq)
+	if err != nil {
+		http.Error(w, "upstream writer unavailable", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy all response headers.
+	for key, vals := range resp.Header {
+		for _, v := range vals {
+			w.Header().Add(key, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	// Stream the body without buffering.
+	io.Copy(w, resp.Body)
+}

--- a/internal/api/forwarder_test.go
+++ b/internal/api/forwarder_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteForwarder_Forward(t *testing.T) {
+	// Set up a fake upstream writer that echoes back details.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify method, path, query.
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/events" {
+			t.Errorf("expected path /api/v1/events, got %s", r.URL.Path)
+		}
+		if r.URL.RawQuery != "project=test" {
+			t.Errorf("expected query project=test, got %s", r.URL.RawQuery)
+		}
+
+		// Verify headers passed through.
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		if r.Header.Get("X-BugBarn-Key") != "secret123" {
+			t.Errorf("expected X-BugBarn-Key secret123, got %s", r.Header.Get("X-BugBarn-Key"))
+		}
+		if r.Header.Get("Cookie") != "session=abc" {
+			t.Errorf("expected Cookie session=abc, got %s", r.Header.Get("Cookie"))
+		}
+
+		// Read body.
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != `{"error":"something broke"}` {
+			t.Errorf("unexpected body: %s", string(body))
+		}
+
+		// Send response with custom headers.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "req-42")
+		w.Header().Set("Set-Cookie", "session=xyz; Path=/")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":"evt-1"}`))
+	}))
+	defer upstream.Close()
+
+	fwd := NewWriteForwarder(upstream.URL)
+
+	body := strings.NewReader(`{"error":"something broke"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events?project=test", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-BugBarn-Key", "secret123")
+	req.Header.Set("Cookie", "session=abc")
+
+	rec := httptest.NewRecorder()
+	fwd.Forward(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("expected response Content-Type application/json, got %s", resp.Header.Get("Content-Type"))
+	}
+	if resp.Header.Get("X-Request-Id") != "req-42" {
+		t.Errorf("expected X-Request-Id req-42, got %s", resp.Header.Get("X-Request-Id"))
+	}
+	if resp.Header.Get("Set-Cookie") != "session=xyz; Path=/" {
+		t.Errorf("expected Set-Cookie to be forwarded, got %s", resp.Header.Get("Set-Cookie"))
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if string(respBody) != `{"id":"evt-1"}` {
+		t.Errorf("unexpected response body: %s", string(respBody))
+	}
+}
+
+func TestWriteForwarder_WriterDown(t *testing.T) {
+	// Create a server and immediately close it to get a port that refuses connections.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+
+	fwd := NewWriteForwarder(closedURL)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", nil)
+	rec := httptest.NewRecorder()
+	fwd.Forward(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "upstream writer unavailable") {
+		t.Errorf("expected 'upstream writer unavailable' message, got: %s", string(body))
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -49,7 +49,8 @@ type Server struct {
 	workerStatus       *worker.Status
 	autoApproveProjects bool
 
-	loginLimiter sync.Map // map[string]*loginAttempt
+	loginLimiter    sync.Map // map[string]*loginAttempt
+	writeForwarder  *WriteForwarder
 }
 
 // SetTrustedProxies sets the CIDRs from which X-Forwarded-For is trusted.
@@ -99,6 +100,12 @@ func (s *Server) SetWorkerStatus(ws *worker.Status) {
 // new projects instead of creating them with status=pending.
 func (s *Server) SetAutoApproveProjects(auto bool) {
 	s.autoApproveProjects = auto
+}
+
+// SetWriteForwarder configures the server to forward non-GET requests to
+// an upstream writer instance. Used in reader mode (CQRS split).
+func (s *Server) SetWriteForwarder(f *WriteForwarder) {
+	s.writeForwarder = f
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store, logger *slog.Logger) *Server {
@@ -152,6 +159,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if r.Method == http.MethodPost {
+			if s.writeForwarder != nil {
+				s.writeForwarder.Forward(w, r)
+				return
+			}
 			s.ingestHandler.ServeHTTP(w, r)
 			return
 		}
@@ -164,6 +175,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "content-type, x-bugbarn-api-key, x-bugbarn-project")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		if s.writeForwarder != nil {
+			s.writeForwarder.Forward(w, r)
+			return
+		}
 		// Resolve project from API key / header.
 		var logProjectID int64
 		if s.ingestHandler != nil {
@@ -213,6 +228,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if r.Method == http.MethodPost {
+			if s.writeForwarder != nil {
+				s.writeForwarder.Forward(w, r)
+				return
+			}
 			s.collectPageView(w, r)
 			return
 		}
@@ -246,9 +265,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveRuntimeConfig(w, r)
 		return
 	case r.URL.Path == "/api/v1/login" && r.Method == http.MethodPost:
+		if s.writeForwarder != nil {
+			s.writeForwarder.Forward(w, r)
+			return
+		}
 		s.login(w, r)
 		return
 	case r.URL.Path == "/api/v1/logout" && r.Method == http.MethodPost:
+		if s.writeForwarder != nil {
+			s.writeForwarder.Forward(w, r)
+			return
+		}
 		s.logout(w, r)
 		return
 	case r.URL.Path == "/api/v1/me" && r.Method == http.MethodGet:
@@ -339,6 +366,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			resolvedProjectID = s.projects.DefaultProjectID()
 		}
 		r = r.WithContext(storage.WithProjectID(r.Context(), resolvedProjectID))
+	}
+
+	// In reader mode, forward all authenticated non-GET requests to the writer.
+	if s.writeForwarder != nil && r.Method != http.MethodGet {
+		s.writeForwarder.Forward(w, r)
+		return
 	}
 
 	// Protected route dispatch.

--- a/internal/api/server_forwarding_test.go
+++ b/internal/api/server_forwarding_test.go
@@ -1,0 +1,307 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteForwarder_IngestPOSTForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{"error":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("upstream got method %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/events" {
+		t.Errorf("upstream got path %s, want /api/v1/events", gotPath)
+	}
+	if string(gotBody) != `{"error":"test"}` {
+		t.Errorf("upstream got body %q", gotBody)
+	}
+}
+
+func TestWriteForwarder_IngestOPTIONSNotForwarded(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+	}))
+	defer upstream.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/events", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+	if upstreamCalled {
+		t.Error("upstream should not be called for OPTIONS preflight")
+	}
+}
+
+func TestWriteForwarder_LogPOSTForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs", strings.NewReader(`[{"level":"error","message":"oops"}]`))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotPath != "/api/v1/logs" {
+		t.Errorf("upstream got path %s, want /api/v1/logs", gotPath)
+	}
+}
+
+func TestWriteForwarder_AnalyticsCollectForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/analytics/collect", strings.NewReader(`{"url":"https://example.com","referrer":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotPath != "/api/v1/analytics/collect" {
+		t.Errorf("upstream got path %s, want /api/v1/analytics/collect", gotPath)
+	}
+}
+
+func TestWriteForwarder_GETNotForwarded(t *testing.T) {
+	t.Parallel()
+
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	for _, path := range []string{"/api/v1/issues", "/api/v1/health", "/api/v1/projects"} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		server.ServeHTTP(rr, req)
+
+		if rr.Code == http.StatusBadGateway {
+			t.Errorf("GET %s should not be forwarded, got 502", path)
+		}
+	}
+	if upstreamCalled {
+		t.Error("upstream should not be called for GET requests")
+	}
+}
+
+func TestWriteForwarder_AuthenticatedPOSTForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	// No auth configured — acts like unauthenticated server (all protected routes open).
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"name":"v1.0.0"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/releases", body)
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("upstream got method %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/releases" {
+		t.Errorf("upstream got path %s, want /api/v1/releases", gotPath)
+	}
+}
+
+func TestWriteForwarder_LoginForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Set-Cookie", "bugbarn_session=abc; Path=/")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", strings.NewReader(`{"username":"admin","password":"pass"}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotPath != "/api/v1/login" {
+		t.Errorf("upstream got path %s, want /api/v1/login", gotPath)
+	}
+	if cookie := rr.Header().Get("Set-Cookie"); !strings.Contains(cookie, "bugbarn_session") {
+		t.Errorf("expected session cookie from upstream, got %q", cookie)
+	}
+}
+
+func TestWriteForwarder_DeleteForwarded(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(upstream.URL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/projects/test-proj", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("upstream got method %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v1/projects/test-proj" {
+		t.Errorf("upstream got path %s, want /api/v1/projects/test-proj", gotPath)
+	}
+}
+
+func TestWriteForwarder_WriterDown502(t *testing.T) {
+	t.Parallel()
+
+	// Create and immediately close a server to get a dead URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := srv.URL
+	srv.Close()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+	server.SetWriteForwarder(NewWriteForwarder(deadURL))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 when writer is down, got %d", rr.Code)
+	}
+}
+
+func TestNoForwarder_NormalBehavior(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	// No forwarder set — legacy/writer mode.
+	server := NewServer(nil, store, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues", nil)
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 in normal mode, got %d", rr.Code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	FunnelBarnEndpoint     string // BUGBARN_FUNNELBARN_ENDPOINT
 	FunnelBarnAPIKey       string // BUGBARN_FUNNELBARN_API_KEY
 	AutoApproveProjects    bool   // BUGBARN_AUTO_APPROVE_PROJECTS
+	Mode                   string // BUGBARN_MODE: "", "writer", or "reader"
+	WriterURL              string // BUGBARN_WRITER_URL: writer service URL (required when Mode=="reader")
 }
 
 // Load reads configuration from environment variables and config files.
@@ -64,6 +66,8 @@ func Load() Config {
 		FunnelBarnEndpoint:  os.Getenv("BUGBARN_FUNNELBARN_ENDPOINT"),
 		FunnelBarnAPIKey:    os.Getenv("BUGBARN_FUNNELBARN_API_KEY"),
 		AutoApproveProjects: strings.EqualFold(os.Getenv("BUGBARN_AUTO_APPROVE_PROJECTS"), "true"),
+		Mode:                os.Getenv("BUGBARN_MODE"),
+		WriterURL:           os.Getenv("BUGBARN_WRITER_URL"),
 	}
 
 	if raw := os.Getenv("BUGBARN_ALLOWED_ORIGINS"); raw != "" {
@@ -148,6 +152,16 @@ func Load() Config {
 			From:    os.Getenv("SMTP_FROM"),
 			To:      os.Getenv("BUGBARN_DIGEST_TO"),
 		},
+	}
+
+	// Validate CQRS mode.
+	switch cfg.Mode {
+	case "", "writer", "reader":
+	default:
+		log.Fatalf("invalid BUGBARN_MODE %q: must be \"\", \"writer\", or \"reader\"", cfg.Mode)
+	}
+	if cfg.Mode == "reader" && cfg.WriterURL == "" {
+		log.Fatalf("BUGBARN_WRITER_URL is required when BUGBARN_MODE is \"reader\"")
 	}
 
 	return cfg

--- a/internal/reader/restore.go
+++ b/internal/reader/restore.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	restoreInterval   = 30 * time.Second
-	litestreamConfig  = "/etc/litestream.yml"
+	restoreInterval      = 30 * time.Second
+	litestreamConfig     = "/etc/litestream.yml"
+	litestreamDBPath     = "/var/lib/bugbarn/bugbarn.db"
 )
 
 // StartRestoreLoop periodically restores a fresh SQLite copy from Litestream
@@ -42,7 +43,7 @@ func restoreAndSwap(ctx context.Context, store *storage.Store, dbPath string, lo
 		"-config", litestreamConfig,
 		"-if-replica-exists",
 		"-o", tmpPath,
-		dbPath,
+		litestreamDBPath,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/reader/restore.go
+++ b/internal/reader/restore.go
@@ -1,0 +1,68 @@
+package reader
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+const (
+	restoreInterval   = 30 * time.Second
+	litestreamConfig  = "/etc/litestream.yml"
+)
+
+// StartRestoreLoop periodically restores a fresh SQLite copy from Litestream
+// and swaps the Store's read-only connection to the new file.
+func StartRestoreLoop(ctx context.Context, store *storage.Store, dbPath string, logger *slog.Logger) {
+	ticker := time.NewTicker(restoreInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := restoreAndSwap(ctx, store, dbPath, logger); err != nil {
+				logger.Warn("reader restore failed", "error", err)
+			}
+		}
+	}
+}
+
+func restoreAndSwap(ctx context.Context, store *storage.Store, dbPath string, logger *slog.Logger) error {
+	tmpPath := filepath.Join(filepath.Dir(dbPath), ".bugbarn-restore.db")
+	defer os.Remove(tmpPath)
+
+	cmd := exec.CommandContext(ctx, "litestream", "restore",
+		"-config", litestreamConfig,
+		"-if-replica-exists",
+		"-o", tmpPath,
+		dbPath,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(tmpPath); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, dbPath); err != nil {
+		return err
+	}
+
+	if err := store.SwapReadDB(dbPath); err != nil {
+		return err
+	}
+
+	logger.Debug("reader database refreshed from replica")
+	return nil
+}

--- a/internal/storage/readonly_test.go
+++ b/internal/storage/readonly_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/event"
+	"github.com/wiebe-xyz/bugbarn/internal/worker"
 )
 
 func TestOpenReadOnlyReadsExistingData(t *testing.T) {
@@ -45,5 +49,131 @@ func TestOpenReadOnlyReadsExistingData(t *testing.T) {
 	// Write connection must be nil.
 	if ro.db != nil {
 		t.Fatal("expected db (write connection) to be nil on read-only store")
+	}
+}
+
+func TestOpenReadOnly_PersistProcessedEventFails(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "bugbarn.db")
+
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw.Close()
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+
+	// Writes must fail cleanly.
+	_, _, _, _, err = ro.PersistProcessedEvent(context.Background(), dummyProcessedEvent("write-fail"))
+	if err == nil {
+		t.Fatal("expected error when writing to read-only store")
+	}
+}
+
+func TestSwapReadDB(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbPathV1 := filepath.Join(dir, "v1.db")
+	dbPathV2 := filepath.Join(dir, "v2.db")
+
+	// Create v1 database with project "alpha".
+	rwV1, err := Open(dbPathV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := rwV1.CreateProject(ctx, "Alpha", "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	rwV1.Close()
+
+	// Create v2 database with project "beta".
+	rwV2, err := Open(dbPathV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rwV2.CreateProject(ctx, "Beta", "beta"); err != nil {
+		t.Fatal(err)
+	}
+	rwV2.Close()
+
+	// Open read-only against v1.
+	ro, err := OpenReadOnly(dbPathV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+
+	// Verify we see alpha but not beta.
+	if _, err := ro.ProjectBySlug(ctx, "alpha"); err != nil {
+		t.Fatalf("expected alpha in v1: %v", err)
+	}
+	if _, err := ro.ProjectBySlug(ctx, "beta"); err == nil {
+		t.Fatal("did not expect beta in v1")
+	}
+
+	// Swap to v2.
+	if err := ro.SwapReadDB(dbPathV2); err != nil {
+		t.Fatalf("SwapReadDB: %v", err)
+	}
+
+	// Now we should see beta but not alpha (different database entirely).
+	if _, err := ro.ProjectBySlug(ctx, "beta"); err != nil {
+		t.Fatalf("expected beta after swap: %v", err)
+	}
+	if _, err := ro.ProjectBySlug(ctx, "alpha"); err == nil {
+		t.Fatal("did not expect alpha after swap to v2")
+	}
+}
+
+func TestSwapReadDB_InvalidPathFails(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "bugbarn.db")
+
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw.Close()
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+
+	// Swap to a non-existent path should fail.
+	if err := ro.SwapReadDB(filepath.Join(t.TempDir(), "does-not-exist.db")); err == nil {
+		t.Fatal("expected error swapping to non-existent path")
+	}
+
+	// Original connection should still work.
+	if _, err := ro.ProjectBySlug(context.Background(), "default"); err != nil {
+		t.Fatalf("original connection broken after failed swap: %v", err)
+	}
+}
+
+func dummyProcessedEvent(fp string) worker.ProcessedEvent {
+	now := time.Now()
+	return worker.ProcessedEvent{
+		Fingerprint: fp,
+		Event: event.Event{
+			ReceivedAt: now,
+			ObservedAt: now,
+			Severity:   "ERROR",
+			Message:    "test error",
+			Exception: event.Exception{
+				Type:    "Error",
+				Message: "test error",
+			},
+		},
 	}
 }

--- a/internal/storage/readonly_test.go
+++ b/internal/storage/readonly_test.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenReadOnlyReadsExistingData(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "bugbarn.db")
+
+	// Create a store with read-write access and insert a project.
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	created, err := rw.CreateProject(ctx, "Read Only Test", "ro-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw.Close()
+
+	// Re-open in read-only mode.
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ro.Close()
+
+	// Reads must work.
+	got, err := ro.ProjectBySlug(ctx, "ro-test")
+	if err != nil {
+		t.Fatalf("ProjectBySlug on read-only store: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("expected project ID %d, got %d", created.ID, got.ID)
+	}
+	if got.Name != "Read Only Test" {
+		t.Fatalf("expected project name %q, got %q", "Read Only Test", got.Name)
+	}
+
+	// Write connection must be nil.
+	if ro.db != nil {
+		t.Fatal("expected db (write connection) to be nil on read-only store")
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -35,6 +35,36 @@ var (
 )
 
 
+// OpenReadOnly opens a read-only connection to an existing SQLite database.
+// The returned Store has no write connection (db is nil) and skips schema
+// initialisation and migrations — the database must already be set up.
+// All read methods that go through readDB() work as normal; write methods
+// will fail because db is nil.
+func OpenReadOnly(path string) (*Store, error) {
+	if strings.TrimSpace(path) == "" {
+		path = defaultDBPath
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	roDB, err := sql.Open(driverName, sqliteReadOnlyDSN(absPath))
+	if err != nil {
+		return nil, err
+	}
+	roDB.SetMaxOpenConns(4)
+
+	// Verify the database is reachable.
+	if err := roDB.Ping(); err != nil {
+		roDB.Close()
+		return nil, err
+	}
+
+	return &Store{db: nil, roDB: roDB}, nil
+}
+
 func Open(path string) (*Store, error) {
 	if strings.TrimSpace(path) == "" {
 		path = defaultDBPath
@@ -110,6 +140,33 @@ func (s *Store) DefaultProjectID() int64 {
 // DB returns the underlying *sql.DB. Use sparingly — prefer Store methods.
 func (s *Store) DB() *sql.DB {
 	return s.db
+}
+
+// SwapReadDB closes the current read-only connection and opens a new one at path.
+// Used by the reader restore loop to pick up a freshly-restored database.
+func (s *Store) SwapReadDB(path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	newDB, err := sql.Open(driverName, sqliteReadOnlyDSN(absPath))
+	if err != nil {
+		return err
+	}
+	newDB.SetMaxOpenConns(4)
+
+	if err := newDB.Ping(); err != nil {
+		newDB.Close()
+		return err
+	}
+
+	old := s.roDB
+	s.roDB = newDB
+	if old != nil {
+		old.Close()
+	}
+	return nil
 }
 
 // PersistProcessedEvent stores a processed event and upserts the related issue.


### PR DESCRIPTION
## Summary

Fixes reader pod startup failures in the CQRS split:

- **Litestream restore path mismatch**: The litestream config references `/var/lib/bugbarn/bugbarn.db` (writer path), but reader pods use `/data/bugbarn.db`. Fixed by using `-o` flag to output to the reader's path.
- **Empty DB bootstrap**: If no Litestream replica exists yet, `OpenReadOnly` fails because the file doesn't exist. Now bootstraps an empty schema so the reader serves empty results until the restore loop succeeds.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Redeploy staging with fix — reader pods should start successfully