### PR TITLE
fix: reader litestream restore path and empty DB bootstrap

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -185,7 +185,16 @@ func run() error {
 func runReader(cfg config.Config, logger *slog.Logger) error {
 	store, err := storage.OpenReadOnly(cfg.DBPath)
 	if err != nil {
-		return fmt.Errorf("open read-only storage: %w", err)
+		logger.Warn("read-only open failed, bootstrapping empty database", "error", err)
+		bootstrap, bErr := storage.Open(cfg.DBPath)
+		if bErr != nil {
+			return fmt.Errorf("bootstrap empty database: %w", bErr)
+		}
+		bootstrap.Close()
+		store, err = storage.OpenReadOnly(cfg.DBPath)
+		if err != nil {
+			return fmt.Errorf("open read-only storage after bootstrap: %w", err)
+		}
 	}
 	defer store.Close()
 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -10,7 +10,8 @@ case "${BUGBARN_MODE:-}" in
       litestream restore \
         -config /etc/litestream.yml \
         -if-replica-exists \
-        "$BUGBARN_DB_PATH" || echo "No replica found, starting with empty DB."
+        -o "$BUGBARN_DB_PATH" \
+        /var/lib/bugbarn/bugbarn.db || echo "No replica found, starting with empty DB."
     fi
     exec bugbarn
     ;;

--- a/internal/reader/restore.go
+++ b/internal/reader/restore.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	restoreInterval   = 30 * time.Second
-	litestreamConfig  = "/etc/litestream.yml"
+	restoreInterval      = 30 * time.Second
+	litestreamConfig     = "/etc/litestream.yml"
+	litestreamDBPath     = "/var/lib/bugbarn/bugbarn.db"
 )
 
 // StartRestoreLoop periodically restores a fresh SQLite copy from Litestream
@@ -42,7 +43,7 @@ func restoreAndSwap(ctx context.Context, store *storage.Store, dbPath string, lo
 		"-config", litestreamConfig,
 		"-if-replica-exists",
 		"-o", tmpPath,
-		dbPath,
+		litestreamDBPath,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Fixes reader pod startup: litestream restore path mismatch and empty DB fallback.