### PR TITLE
feat: reader HPA and production CQRS split

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -115,11 +115,18 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             set -euo pipefail
             kubectl apply -k /tmp/bugbarn-deploy/deploy/k8s/production
-            kubectl -n ${NAMESPACE} set image deployment/bugbarn \
+
+            # Delete the old single deployment if it still exists (migration to CQRS split).
+            kubectl -n ${NAMESPACE} delete deployment/bugbarn --ignore-not-found=true
+
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-writer \
+              bugbarn=${SERVICE_IMAGE}:${VERSION}
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-reader \
               bugbarn=${SERVICE_IMAGE}:${VERSION}
             kubectl -n ${NAMESPACE} set image deployment/bugbarn-web \
               bugbarn-web=${WEB_IMAGE}:${VERSION}
-            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-reader --timeout=180s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-web --timeout=180s
           "
 
@@ -127,7 +134,8 @@ jobs:
         if: failure()
         run: |
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
-            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn || true
+            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-writer || true
+            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-reader || true
             kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-web || true
             echo 'Rollback triggered'
           " || true

--- a/deploy/k8s/production/kustomization.yaml
+++ b/deploy/k8s/production/kustomization.yaml
@@ -4,8 +4,11 @@ namespace: bugbarn-production
 resources:
   - namespace.yaml
   - pvc.yaml
-  - deployment.yaml
-  - service.yaml
+  - writer-deployment.yaml
+  - writer-service.yaml
+  - reader-deployment.yaml
+  - reader-service.yaml
+  - reader-hpa.yaml
   - web-deployment.yaml
   - web-service.yaml
   - ingress.yaml

--- a/deploy/k8s/production/reader-hpa.yaml
+++ b/deploy/k8s/production/reader-hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bugbarn-reader
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bugbarn-reader
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 120
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60

--- a/deploy/k8s/staging/kustomization.yaml
+++ b/deploy/k8s/staging/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - writer-service.yaml
   - reader-deployment.yaml
   - reader-service.yaml
+  - reader-hpa.yaml
   - web-deployment.yaml
   - web-service.yaml
   - ingress.yaml

--- a/deploy/k8s/staging/reader-hpa.yaml
+++ b/deploy/k8s/staging/reader-hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bugbarn-reader
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: bugbarn-reader
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 120
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60


### PR DESCRIPTION
## Summary
- Add CPU-based HPA for reader pods (60% CPU target, scales 2→5 staging, 2→6 production)
- Switch production kustomization and deploy workflow to CQRS writer/reader split
- Fast scale-up (30s stabilization, +2 pods/min), slow scale-down (120s, -1 pod/min)

## Test plan
- [x] HPA manifests validate with `kubectl apply --dry-run`
- [x] Staging CQRS verified: ingestion, querying, forwarding, flood test
- [ ] Deploy to production and verify scaling under load