### PR TITLE
fix: auto-recover reader when Litestream WAL chain is broken

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -152,6 +152,7 @@ func run() error {
 	if len(cfg.TrustedProxies) > 0 {
 		apiServer.SetTrustedProxies(cfg.TrustedProxies)
 	}
+	apiServer.SetDBPath(cfg.DBPath)
 	apiServer.SetWorkerStatus(workerStatus)
 	apiServer.SetAutoApproveProjects(cfg.AutoApproveProjects)
 	apiServer.SetFunnelBarnConfig(cfg.FunnelBarnEndpoint, cfg.FunnelBarnAPIKey)
@@ -256,7 +257,7 @@ func runReader(cfg config.Config, logger *slog.Logger) error {
 		Handler: tracing.Middleware(apiServer),
 	}
 
-	go reader.StartRestoreLoop(ctx, store, cfg.DBPath, logger)
+	go reader.StartRestoreLoop(ctx, store, cfg.DBPath, cfg.WriterURL, logger)
 
 	logger.Info("starting in reader mode", "addr", cfg.Addr, "writer_url", cfg.WriterURL)
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// serveDBBackup streams the SQLite database file to the client.
+// Used by reader pods as a fallback when Litestream restore fails.
+func (s *Server) serveDBBackup(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	dbPath := s.dbPath
+	if dbPath == "" {
+		http.Error(w, "backup not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	f, err := os.Open(dbPath)
+	if err != nil {
+		s.logger.Error("db backup: open failed", "error", err)
+		http.Error(w, "backup not available", http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		s.logger.Error("db backup: stat failed", "error", err)
+		http.Error(w, "backup not available", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-sqlite3")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", stat.Size()))
+	http.ServeContent(w, r, "bugbarn.db", stat.ModTime(), f)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -51,6 +51,7 @@ type Server struct {
 
 	loginLimiter    sync.Map // map[string]*loginAttempt
 	writeForwarder  *WriteForwarder
+	dbPath          string
 }
 
 // SetTrustedProxies sets the CIDRs from which X-Forwarded-For is trusted.
@@ -106,6 +107,11 @@ func (s *Server) SetAutoApproveProjects(auto bool) {
 // an upstream writer instance. Used in reader mode (CQRS split).
 func (s *Server) SetWriteForwarder(f *WriteForwarder) {
 	s.writeForwarder = f
+}
+
+// SetDBPath sets the path to the SQLite database file for the backup endpoint.
+func (s *Server) SetDBPath(path string) {
+	s.dbPath = path
 }
 
 func NewServer(ingestHandler *ingest.Handler, store *storage.Store, logger *slog.Logger) *Server {
@@ -253,6 +259,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if r.URL.Path == "/api/docs" && r.Method == http.MethodGet {
 		s.serveAPIDocs(w, r)
+		return
+	}
+
+	// Internal endpoint — used by reader pods for DB backup fallback.
+	if r.URL.Path == "/internal/v1/db-backup" && r.Method == http.MethodGet {
+		s.serveDBBackup(w, r)
 		return
 	}
 

--- a/internal/reader/restore.go
+++ b/internal/reader/restore.go
@@ -2,7 +2,10 @@ package reader
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,13 +18,18 @@ const (
 	restoreInterval      = 30 * time.Second
 	litestreamConfig     = "/etc/litestream.yml"
 	litestreamDBPath     = "/var/lib/bugbarn/bugbarn.db"
+	maxLitestreamFailures = 3
 )
 
 // StartRestoreLoop periodically restores a fresh SQLite copy from Litestream
 // and swaps the Store's read-only connection to the new file.
-func StartRestoreLoop(ctx context.Context, store *storage.Store, dbPath string, logger *slog.Logger) {
+// After maxLitestreamFailures consecutive failures, it falls back to
+// downloading the database directly from the writer pod.
+func StartRestoreLoop(ctx context.Context, store *storage.Store, dbPath, writerURL string, logger *slog.Logger) {
 	ticker := time.NewTicker(restoreInterval)
 	defer ticker.Stop()
+
+	var consecutiveFailures int
 
 	for {
 		select {
@@ -29,7 +37,19 @@ func StartRestoreLoop(ctx context.Context, store *storage.Store, dbPath string, 
 			return
 		case <-ticker.C:
 			if err := restoreAndSwap(ctx, store, dbPath, logger); err != nil {
-				logger.Warn("reader restore failed", "error", err)
+				consecutiveFailures++
+				logger.Warn("reader restore failed", "error", err, "consecutive_failures", consecutiveFailures)
+
+				if consecutiveFailures >= maxLitestreamFailures && writerURL != "" {
+					logger.Info("litestream restore failed repeatedly, falling back to writer backup")
+					if fbErr := fallbackRestoreFromWriter(ctx, store, dbPath, writerURL, logger); fbErr != nil {
+						logger.Error("fallback restore from writer failed", "error", fbErr)
+					} else {
+						consecutiveFailures = 0
+					}
+				}
+			} else {
+				consecutiveFailures = 0
 			}
 		}
 	}
@@ -65,5 +85,55 @@ func restoreAndSwap(ctx context.Context, store *storage.Store, dbPath string, lo
 	}
 
 	logger.Debug("reader database refreshed from replica")
+	return nil
+}
+
+func fallbackRestoreFromWriter(ctx context.Context, store *storage.Store, dbPath, writerURL string, logger *slog.Logger) error {
+	tmpPath := filepath.Join(filepath.Dir(dbPath), ".bugbarn-writer-backup.db")
+	defer os.Remove(tmpPath)
+
+	url := writerURL + "/internal/v1/db-backup"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download from writer: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("writer returned %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	n, err := io.Copy(f, resp.Body)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("write backup: %w", err)
+	}
+
+	if n == 0 {
+		return fmt.Errorf("empty backup received")
+	}
+
+	if err := os.Rename(tmpPath, dbPath); err != nil {
+		return fmt.Errorf("rename backup: %w", err)
+	}
+
+	if err := store.SwapReadDB(dbPath); err != nil {
+		return fmt.Errorf("swap db: %w", err)
+	}
+
+	logger.Info("reader database restored from writer backup", "bytes", n)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Reader pods were stuck in a restore loop when the Litestream S3 replica had a broken WAL chain (missing segments after snapshot), serving empty/stale data indefinitely
- After 3 consecutive Litestream restore failures, the reader now falls back to downloading the database directly from the writer pod via `/internal/v1/db-backup`, bypassing S3
- Adds a new internal endpoint on the writer that streams the raw SQLite file to reader pods

## Test plan

- [ ] Deploy to testing, verify reader starts normally via Litestream
- [ ] Simulate broken WAL chain (delete S3 WAL segments), confirm reader auto-recovers via writer fallback after ~90s
- [ ] Verify `/internal/v1/db-backup` is not exposed externally (internal K8s service only)