### PR TITLE
fix: reset spool cursor after file rotation

### DIFF
--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -172,7 +172,7 @@ func (s *Spool) Close() error {
 }
 
 // Rotate renames the current active segment to ingest-TIMESTAMP.ndjson and
-// opens a fresh ingest.ndjson. The cursor is reset to 0 on rotation.
+// opens a fresh ingest.ndjson. ReadRecordsFrom detects the stale cursor.
 func (s *Spool) Rotate() error {
 	if s == nil {
 		return errors.New("spool is nil")
@@ -312,8 +312,17 @@ func ReadRecordsFrom(path string, offset int64) ([]RecordAtOffset, error) {
 	defer file.Close()
 
 	if offset > 0 {
-		if _, err := file.Seek(offset, 0); err != nil {
+		info, err := file.Stat()
+		if err != nil {
 			return nil, err
+		}
+		if offset > info.Size() {
+			offset = 0
+		}
+		if offset > 0 {
+			if _, err := file.Seek(offset, 0); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/spool/spool_test.go
+++ b/internal/spool/spool_test.go
@@ -273,6 +273,49 @@ func TestReadRecordsFromOffsets(t *testing.T) {
 // TestRotateIfExceedsConcurrentAppend verifies that every record appended
 // concurrently with RotateIfExceeds ends up in exactly one segment and is
 // not silently discarded.
+func TestReadRecordsFromResetsCursorAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(dir)
+	if err != nil {
+		t.Fatalf("new spool: %v", err)
+	}
+
+	// Write some records and note the cursor position.
+	for i := 0; i < 10; i++ {
+		if err := s.Append(Record{IngestID: fmt.Sprintf("pre-%d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	preRecords, err := ReadRecordsFrom(Path(dir), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleCursor := preRecords[len(preRecords)-1].EndOffset
+
+	// Rotate the spool — active file is now empty.
+	if err := s.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write new data to the fresh spool file.
+	if err := s.Append(Record{IngestID: "after-rotation"}); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// Read with the stale cursor — should auto-reset and return the new data.
+	got, err := ReadRecordsFrom(Path(dir), staleCursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("ReadRecordsFrom with stale cursor returned 0 records, expected auto-reset")
+	}
+	if got[0].Record.IngestID != "after-rotation" {
+		t.Errorf("expected 'after-rotation', got %q", got[0].Record.IngestID)
+	}
+}
+
 func TestRotateIfExceedsConcurrentAppend(t *testing.T) {
 	dir := t.TempDir()
 	s, err := New(dir)


### PR DESCRIPTION
## Summary

- Same bug as wiebe-xyz/spanbarn#43 — after spool rotation, the persisted cursor points past EOF of the new file, silently dropping all new events
- `ReadRecordsFrom` now detects cursor > file size and resets to 0
- Fixed misleading comment on `Rotate` that claimed the cursor was reset

## Test plan

- [x] `TestReadRecordsFromResetsCursorAfterRotation` — new regression test
- [x] Full test suite passes