### PR TITLE
feat: quick setup card, setup key auto-provisioning, slog migration

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -87,7 +91,7 @@ func run() error {
 	}
 
 	if cfg.SessionSecret == "" {
-		log.Println("warning: BUGBARN_SESSION_SECRET is not set; sessions will not persist across restarts")
+		logger.Warn("BUGBARN_SESSION_SECRET is not set; sessions will not persist across restarts")
 	}
 
 	store, err := storage.Open(cfg.DBPath)
@@ -109,7 +113,7 @@ func run() error {
 	bus := &domainevents.Bus{}
 	alertRepo := alert.NewSQLiteRepository(store.DB())
 	deliverer := alert.NewDeliverer()
-	evaluator := alert.NewEvaluator(alertRepo, deliverer, cfg.PublicURL)
+	evaluator := alert.NewEvaluator(alertRepo, deliverer, cfg.PublicURL, logger.With("component", "alert-evaluator"))
 	bus.Subscribe(evaluator.HandleEvent)
 
 	eventPub := service.NewEventPublisher(bus)
@@ -277,8 +281,47 @@ func newAPIAuthorizer(cfg config.Config, store *storage.Store) (*auth.Authorizer
 	} else {
 		base = auth.New(cfg.APIKey)
 	}
-	// Always wire in DB-based key lookup so keys created via the CLI work too.
-	return base.WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey), nil
+	base = base.WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
+	if cfg.SessionSecret != "" {
+		base = base.WithSetupKeyVerifier(newSetupKeyVerifier(cfg.SessionSecret, store, cfg.AutoApproveProjects))
+	}
+	return base, nil
+}
+
+func newSetupKeyVerifier(secret string, store *storage.Store, autoApprove bool) auth.SetupKeyVerifier {
+	return func(ctx context.Context, rawKey, projectSlug string) (int64, bool) {
+		expected := setupKey(secret, projectSlug)
+		if expected == "" || subtle.ConstantTimeCompare([]byte(rawKey), []byte(expected)) != 1 {
+			return 0, false
+		}
+		var proj storage.Project
+		var err error
+		if autoApprove {
+			proj, err = store.EnsureProject(ctx, projectSlug)
+		} else {
+			proj, err = store.EnsureProjectPending(ctx, projectSlug)
+		}
+		if err != nil {
+			return 0, false
+		}
+		keySHA := sha256Hex(rawKey)
+		_ = store.EnsureSetupAPIKey(ctx, projectSlug+"-setup", proj.ID, keySHA)
+		return proj.ID, true
+	}
+}
+
+func setupKey(secret, slug string) string {
+	if secret == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("setup:" + slug))
+	return hex.EncodeToString(mac.Sum(nil))[:40]
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }
 
 // runWorkerOnce replays queued records into the persistent store for local maintenance.
@@ -328,7 +371,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 	// Restore cursor position from disk so we never re-process already-handled records.
 	offset, err := spool.ReadCursor(spoolDir)
 	if err != nil {
-		log.Printf("worker: failed to read cursor (starting from 0): %v", err)
+		slog.Error("worker failed to read cursor, starting from 0", "error", err)
 		offset = 0
 	}
 
@@ -343,7 +386,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 		case <-ticker.C:
 			entries, err := spool.ReadRecordsFrom(spool.Path(spoolDir), offset)
 			if err != nil {
-				log.Printf("worker read spool: %v", err)
+				slog.Error("worker failed to read spool", "error", err)
 				continue
 			}
 
@@ -351,7 +394,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 				ws.SetPendingRecords(int64(len(entries)))
 				snap := ws.Snapshot()
 				if !snap.Healthy && !stallWarned {
-					log.Printf("worker: stall detected — %d pending records, last advance %v", snap.PendingRecords, snap.LastAdvance)
+					slog.Info("worker stall detected", "pending_records", snap.PendingRecords, "last_advance", snap.LastAdvance)
 					if selfReporting {
 						bb.CaptureMessage(fmt.Sprintf("worker stall: %d pending, level=%s", snap.PendingRecords, snap.Level))
 					}
@@ -376,11 +419,11 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 					recordSpan.SetStatus(codes.Error, err.Error())
 					recordSpan.End()
 					retryCounts[record.IngestID]++
-					log.Printf("worker process record %s (attempt %d): %v", record.IngestID, retryCounts[record.IngestID], err)
+					slog.Error("worker failed to process record", "ingest_id", record.IngestID, "attempt", retryCounts[record.IngestID], "error", err)
 					if retryCounts[record.IngestID] >= workerMaxRetries {
-						log.Printf("worker dead-lettering record %s after %d attempts", record.IngestID, retryCounts[record.IngestID])
+						slog.Error("worker dead-lettering record", "ingest_id", record.IngestID, "attempts", retryCounts[record.IngestID])
 						if dlErr := spool.AppendDeadLetter(spoolDir, record); dlErr != nil {
-							log.Printf("worker dead-letter write %s: %v", record.IngestID, dlErr)
+							slog.Error("worker failed to write dead letter", "ingest_id", record.IngestID, "error", dlErr)
 						}
 						if selfReporting {
 							bb.CaptureMessage(fmt.Sprintf("dead-letter: ingest %s: %v", record.IngestID, err))
@@ -392,7 +435,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 						// Advance cursor past this dead-lettered record.
 						offset = entry.EndOffset
 						if err := spool.WriteCursor(spoolDir, offset); err != nil {
-							log.Printf("worker write cursor: %v", err)
+							slog.Error("worker failed to write cursor", "error", err)
 						}
 						if ws != nil {
 							ws.RecordAdvance()
@@ -417,7 +460,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 						persistCtx = storage.WithProjectID(recordCtx, proj.ID)
 						resolveSpan.SetAttributes(attribute.Int64("project_id", proj.ID))
 					} else {
-						log.Printf("worker ensure project %q: %v", record.ProjectSlug, err)
+						slog.Error("worker failed to ensure project", "project_slug", record.ProjectSlug, "error", err)
 						resolveSpan.SetStatus(codes.Error, err.Error())
 					}
 					resolveSpan.End()
@@ -436,11 +479,11 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 					recordSpan.SetStatus(codes.Error, persistErr.Error())
 					recordSpan.End()
 					retryCounts[record.IngestID]++
-					log.Printf("worker persist record %s (attempt %d): %v", record.IngestID, retryCounts[record.IngestID], persistErr)
+					slog.Error("worker failed to persist record", "ingest_id", record.IngestID, "attempt", retryCounts[record.IngestID], "error", persistErr)
 					if retryCounts[record.IngestID] >= workerMaxRetries {
-						log.Printf("worker dead-lettering record %s after %d persist attempts", record.IngestID, retryCounts[record.IngestID])
+						slog.Error("worker dead-lettering record after persist failures", "ingest_id", record.IngestID, "attempts", retryCounts[record.IngestID])
 						if dlErr := spool.AppendDeadLetter(spoolDir, record); dlErr != nil {
-							log.Printf("worker dead-letter write %s: %v", record.IngestID, dlErr)
+							slog.Error("worker failed to write dead letter", "ingest_id", record.IngestID, "error", dlErr)
 						}
 						if selfReporting {
 							bb.CaptureMessage(fmt.Sprintf("dead-letter persist: ingest %s: %v", record.IngestID, persistErr))
@@ -452,7 +495,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 						// Advance cursor past this dead-lettered record.
 						offset = entry.EndOffset
 						if err := spool.WriteCursor(spoolDir, offset); err != nil {
-							log.Printf("worker write cursor: %v", err)
+							slog.Error("worker failed to write cursor", "error", err)
 						}
 						if ws != nil {
 							ws.RecordAdvance()
@@ -481,7 +524,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 				// Advance cursor after each successfully processed record.
 				offset = entry.EndOffset
 				if err := spool.WriteCursor(spoolDir, offset); err != nil {
-					log.Printf("worker write cursor: %v", err)
+					slog.Error("worker failed to write cursor", "error", err)
 				}
 				if ws != nil {
 					ws.RecordAdvance()
@@ -492,7 +535,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 			// Rotate the active spool file once it exceeds the threshold, so old
 			// segments can eventually be archived or deleted.
 			if err := eventSpool.RotateIfExceeds(workerRotateThreshold); err != nil {
-				log.Printf("worker rotate spool: %v", err)
+				slog.Error("worker failed to rotate spool", "error", err)
 			}
 		}
 	}

--- a/internal/alert/evaluator.go
+++ b/internal/alert/evaluator.go
@@ -2,7 +2,7 @@ package alert
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
@@ -15,11 +15,12 @@ type Evaluator struct {
 	repo      Repository
 	deliverer *Deliverer
 	publicURL string
+	log       *slog.Logger
 }
 
 // NewEvaluator creates an Evaluator wired to the given repository and deliverer.
-func NewEvaluator(repo Repository, deliverer *Deliverer, publicURL string) *Evaluator {
-	return &Evaluator{repo: repo, deliverer: deliverer, publicURL: publicURL}
+func NewEvaluator(repo Repository, deliverer *Deliverer, publicURL string, log *slog.Logger) *Evaluator {
+	return &Evaluator{repo: repo, deliverer: deliverer, publicURL: publicURL, log: log}
 }
 
 // HandleEvent receives a domain event and dispatches to condition evaluation.
@@ -39,7 +40,7 @@ func (e *Evaluator) HandleEvent(evt any) {
 func (e *Evaluator) evaluate(ctx context.Context, projectID int64, issue domain.Issue, conditionType string) {
 	rules, err := e.repo.ListForProject(ctx, projectID)
 	if err != nil {
-		log.Printf("alert evaluator: list rules for project %d: %v", projectID, err)
+		e.log.Error("failed to list rules for project", "project_id", projectID, "error", err)
 		return
 	}
 
@@ -65,15 +66,15 @@ func (e *Evaluator) evaluate(ctx context.Context, projectID int64, issue domain.
 			defer cancel()
 
 			if err := e.deliverer.Fire(fireCtx, r, iss, e.publicURL); err != nil {
-				log.Printf("alert evaluator: fire alert %s for issue %s: %v", r.ID, iss.ID, err)
+				e.log.Error("failed to fire alert", "alert_id", r.ID, "issue_id", iss.ID, "error", err)
 				return
 			}
 
 			if err := e.repo.RecordFiring(ctx, r.ID, iss.ID); err != nil {
-				log.Printf("alert evaluator: record firing alert %s issue %s: %v", r.ID, iss.ID, err)
+				e.log.Error("failed to record firing", "alert_id", r.ID, "issue_id", iss.ID, "error", err)
 			}
 			if err := e.repo.UpdateLastFired(ctx, r.ID, time.Now().UTC()); err != nil {
-				log.Printf("alert evaluator: update last_fired alert %s: %v", r.ID, err)
+				e.log.Error("failed to update last_fired", "alert_id", r.ID, "error", err)
 			}
 		}()
 	}
@@ -87,7 +88,7 @@ func (e *Evaluator) cooldownPassed(ctx context.Context, rule Rule, issueID strin
 	}
 	last, err := e.repo.LastFiring(ctx, rule.ID, issueID)
 	if err != nil {
-		log.Printf("alert evaluator: last firing for %s/%s: %v", rule.ID, issueID, err)
+		e.log.Error("failed to check last firing", "alert_id", rule.ID, "issue_id", issueID, "error", err)
 		return false
 	}
 	if last.IsZero() {

--- a/internal/alert/evaluator_test.go
+++ b/internal/alert/evaluator_test.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -56,7 +57,7 @@ func TestEvaluator_ConditionMatching(t *testing.T) {
 	}
 	repo := newFakeRepo(rules)
 	deliverer := NewDeliverer()
-	evaluator := NewEvaluator(repo, deliverer, "http://example.com")
+	evaluator := NewEvaluator(repo, deliverer, "http://example.com", slog.Default())
 
 	issue := storage.Issue{ID: "issue-000001", Title: "Test"}
 
@@ -88,7 +89,7 @@ func TestEvaluator_DisabledRuleSkipped(t *testing.T) {
 		{ID: "alert-000001", Name: "Disabled", Enabled: false, Condition: "new_issue", WebhookURL: srv.URL},
 	}
 	repo := newFakeRepo(rules)
-	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com")
+	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com", slog.Default())
 
 	evaluator.evaluate(context.Background(), 1, storage.Issue{ID: "issue-000001"}, "new_issue")
 	time.Sleep(100 * time.Millisecond)
@@ -122,7 +123,7 @@ func TestEvaluator_CooldownPreventsDoubleFire(t *testing.T) {
 	// Pre-seed a recent firing so cooldown is still active.
 	repo.firings["alert-000001/issue-000001"] = time.Now().UTC().Add(-5 * time.Minute)
 
-	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com")
+	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com", slog.Default())
 	evaluator.evaluate(context.Background(), 1, storage.Issue{ID: "issue-000001"}, "new_issue")
 	time.Sleep(100 * time.Millisecond)
 
@@ -155,7 +156,7 @@ func TestEvaluator_CooldownExpiredAllowsFire(t *testing.T) {
 	// Pre-seed an old firing (2 minutes ago > 1 minute cooldown).
 	repo.firings["alert-000001/issue-000001"] = time.Now().UTC().Add(-2 * time.Minute)
 
-	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com")
+	evaluator := NewEvaluator(repo, NewDeliverer(), "http://example.com", slog.Default())
 	evaluator.evaluate(context.Background(), 1, storage.Issue{ID: "issue-000001"}, "new_issue")
 
 	deadline := time.Now().Add(3 * time.Second)
@@ -181,7 +182,7 @@ func TestEvaluator_HandleEvent(t *testing.T) {
 	rules := []Rule{
 		{ID: "alert-000001", Name: "Test", Enabled: true, Condition: "new_issue", WebhookURL: srv.URL},
 	}
-	evaluator := NewEvaluator(newFakeRepo(rules), NewDeliverer(), "http://example.com")
+	evaluator := NewEvaluator(newFakeRepo(rules), NewDeliverer(), "http://example.com", slog.Default())
 
 	// Subscribe via bus and publish.
 	var bus domainevents.Bus

--- a/internal/analytics/worker.go
+++ b/internal/analytics/worker.go
@@ -2,7 +2,7 @@ package analytics
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -37,7 +37,7 @@ func StartWorker(ctx context.Context, store Store, retentionDays int) {
 func runRollup(ctx context.Context, store Store, retentionDays int) {
 	projectIDs, err := store.ListProjectIDs(ctx)
 	if err != nil {
-		log.Printf("analytics rollup: list projects: %v", err)
+		slog.Error("analytics rollup: failed to list projects", "error", err)
 		return
 	}
 
@@ -51,13 +51,13 @@ func runRollup(ctx context.Context, store Store, retentionDays int) {
 	for _, pid := range projectIDs {
 		for _, date := range dates {
 			if err := store.RollupDailyAnalytics(ctx, pid, date); err != nil {
-				log.Printf("analytics rollup: project %d date %s: %v", pid, date.Format("2006-01-02"), err)
+				slog.Error("analytics rollup: failed to roll up project", "project_id", pid, "date", date.Format("2006-01-02"), "error", err)
 			}
 		}
 	}
 
 	cutoff := now.AddDate(0, 0, -retentionDays)
 	if err := store.DeleteOldPageviews(ctx, cutoff); err != nil {
-		log.Printf("analytics retention: delete old pageviews: %v", err)
+		slog.Error("analytics retention: failed to delete old pageviews", "error", err)
 	}
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -56,7 +55,7 @@ func (s *Server) login(w http.ResponseWriter, r *http.Request) {
 	}
 	attempt.count++
 	if attempt.count > loginRateLimit {
-		log.Printf("auth: rate-limited login from %s (attempt %d)", ip, attempt.count)
+		s.logger.Warn("auth: rate-limited login", "ip", ip, "attempt", attempt.count)
 		w.Header().Set("Retry-After", "60")
 		http.Error(w, "too many login attempts", http.StatusTooManyRequests)
 		return
@@ -71,7 +70,7 @@ func (s *Server) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.users.Valid(request.Username, request.Password) {
-		log.Printf("auth: failed login for user %q from %s", request.Username, ip)
+		s.logger.Warn("auth: failed login", "username", request.Username, "ip", ip)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -132,7 +131,7 @@ func (s *Server) serveLogsIngest(w http.ResponseWriter, r *http.Request) {
 			Logs []map[string]any `json:"logs"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			log.Printf("logs: invalid JSON payload: %v", err)
+			s.logger.Warn("logs: invalid JSON payload", "error", err)
 			http.Error(w, "invalid JSON payload", http.StatusBadRequest)
 			return
 		}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"log"
 	"net/http"
 	"strings"
 )
@@ -87,13 +86,13 @@ func isCSRFProtected(r *http.Request) bool {
 func (s *Server) validCSRF(r *http.Request) bool {
 	sessionCookie, err := r.Cookie("bugbarn_session")
 	if err != nil {
-		log.Printf("csrf-debug: no session cookie")
+		s.logger.Debug("csrf: no session cookie")
 		return false
 	}
 	expected := s.sessions.CSRFToken(sessionCookie.Value)
 	provided := r.Header.Get("X-BugBarn-CSRF")
 	if provided != expected {
-		log.Printf("csrf-debug: mismatch expected=%s provided=%s session_len=%d", expected[:8], provided[:min(8, len(provided))], len(sessionCookie.Value))
+		s.logger.Debug("csrf: token mismatch", "expected_prefix", expected[:8], "provided_prefix", provided[:min(8, len(provided))], "session_len", len(sessionCookie.Value))
 	}
 	return provided == expected
 }

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -5,12 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/wiebe-xyz/bugbarn/internal/domain"
 )
 
 func (s *Server) setupKey(slug string) string {
@@ -36,21 +33,19 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var proj domain.Project
-	var err error
-	if s.autoApproveProjects {
-		proj, err = s.projects.Ensure(r.Context(), slug)
-	} else {
-		proj, err = s.projects.EnsurePending(r.Context(), slug)
-	}
+	proj, err := s.projects.BySlug(r.Context(), slug)
 	if err != nil {
-		log.Printf("setup: failed to ensure project %q: %v", slug, err)
-		http.Error(w, "failed to ensure project", http.StatusInternalServerError)
-		return
+		// Project doesn't exist yet or we're on a read-only replica.
+		// That's fine — the key is deterministic and the project + API key
+		// will be created lazily on the writer when the first event arrives.
+		proj.Slug = slug
+		proj.Status = "new"
 	}
 
 	keySHA := hex.EncodeToString(sha256Sum(rawKey))
-	_ = s.projects.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA)
+	if proj.ID != 0 {
+		_ = s.projects.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA)
+	}
 
 	endpoint := s.publicURL
 	if endpoint == "" {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -32,10 +32,16 @@ type DBKeyLookupWithProject func(ctx context.Context, keySHA256 string) (project
 // DBKeyTouch is called after a successful DB-based auth to update last_used_at.
 type DBKeyTouch func(ctx context.Context, keySHA256 string) error
 
+// SetupKeyVerifier is called when normal auth fails. It checks whether the
+// provided raw key is a valid deterministic setup key and, if so, lazily
+// provisions the project and API key. Returns (projectID, true) on success.
+type SetupKeyVerifier func(ctx context.Context, rawKey, projectSlug string) (projectID int64, ok bool)
+
 type Authorizer struct {
-	apiKeyHash []byte
-	dbLookup   DBKeyLookupWithProject
-	dbTouch    DBKeyTouch
+	apiKeyHash    []byte
+	dbLookup      DBKeyLookupWithProject
+	dbTouch       DBKeyTouch
+	setupVerifier SetupKeyVerifier
 }
 
 func New(apiKey string) *Authorizer {
@@ -68,7 +74,16 @@ func (a *Authorizer) WithDBLookup(lookup DBKeyLookupWithProject, touch DBKeyTouc
 	if a == nil {
 		return &Authorizer{dbLookup: lookup, dbTouch: touch}
 	}
-	return &Authorizer{apiKeyHash: a.apiKeyHash, dbLookup: lookup, dbTouch: touch}
+	return &Authorizer{apiKeyHash: a.apiKeyHash, dbLookup: lookup, dbTouch: touch, setupVerifier: a.setupVerifier}
+}
+
+// WithSetupKeyVerifier returns a copy of the Authorizer that will try setup key
+// verification as a last resort when normal auth fails.
+func (a *Authorizer) WithSetupKeyVerifier(v SetupKeyVerifier) *Authorizer {
+	if a == nil {
+		return &Authorizer{setupVerifier: v}
+	}
+	return &Authorizer{apiKeyHash: a.apiKeyHash, dbLookup: a.dbLookup, dbTouch: a.dbTouch, setupVerifier: v}
 }
 
 // Enabled returns true when at least one auth mechanism is configured.
@@ -113,6 +128,21 @@ func (a *Authorizer) ValidWithProject(ctx context.Context, provided string) (pro
 		}
 	}
 
+	return 0, "", false
+}
+
+// ValidWithSetupFallback is like ValidWithProject but also tries setup key
+// verification using the project slug when normal auth fails.
+func (a *Authorizer) ValidWithSetupFallback(ctx context.Context, provided, projectSlug string) (projectID int64, scope string, ok bool) {
+	pid, sc, valid := a.ValidWithProject(ctx, provided)
+	if valid {
+		return pid, sc, true
+	}
+	if a.setupVerifier != nil && projectSlug != "" {
+		if setupPID, setupOK := a.setupVerifier(ctx, strings.TrimSpace(provided), projectSlug); setupOK {
+			return setupPID, "ingest", true
+		}
+	}
 	return 0, "", false
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -191,7 +192,7 @@ func loadConfigFiles() {
 	}
 	for _, path := range candidates {
 		if err := applyConfigFile(path); err != nil && !os.IsNotExist(err) {
-			log.Printf("warning: reading config file %s: %v", path, err)
+			slog.Warn("error reading config file", "path", path, "error", err)
 		}
 	}
 }

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -112,7 +112,7 @@ func Send(ctx context.Context, cfg Config, store Store) []error {
 	for _, proj := range projects {
 		data, err := store.WeeklyDigest(ctx, proj.ID, since)
 		if err != nil {
-			log.Printf("digest: gather %s: %v", proj.Slug, err)
+			slog.Error("digest: failed to gather project data", "project", proj.Slug, "error", err)
 			errs = append(errs, fmt.Errorf("gather %s: %w", proj.Slug, err))
 			continue
 		}
@@ -123,20 +123,20 @@ func Send(ctx context.Context, cfg Config, store Store) []error {
 	}
 
 	if len(p.Projects) == 0 {
-		log.Printf("digest: no activity across all projects, skipping")
+		slog.Info("digest: no activity across all projects, skipping")
 		return errs
 	}
 
 	if cfg.WebhookURL != "" {
 		if err := sendWebhook(ctx, cfg.WebhookURL, p); err != nil {
-			log.Printf("digest webhook: %v", err)
+			slog.Error("digest: webhook delivery failed", "error", err)
 			errs = append(errs, fmt.Errorf("webhook: %w", err))
 		}
 	}
 
 	if cfg.Mail.active() {
 		if err := sendEmailDigest(cfg.Mail, p, since, now); err != nil {
-			log.Printf("digest email: %v", err)
+			slog.Error("digest: email delivery failed", "error", err)
 			errs = append(errs, fmt.Errorf("email: %w", err))
 		}
 	}

--- a/internal/digest/mail.go
+++ b/internal/digest/mail.go
@@ -3,7 +3,7 @@ package digest
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/smtp"
 	"strings"
 	"text/template"
@@ -83,7 +83,7 @@ func deliverEmail(mc MailConfig, subject, plain, html string) error {
 			return lastErr
 		}
 		if attempt < len(delays)-1 {
-			log.Printf("digest mailer: transient error (attempt %d/3), retrying in %s: %v", attempt+1, delay, lastErr)
+			slog.Warn("digest mailer: transient error, retrying", "attempt", attempt+1, "max_attempts", 3, "retry_in", delay, "error", lastErr)
 			time.Sleep(delay)
 		}
 	}

--- a/internal/digest/scheduler.go
+++ b/internal/digest/scheduler.go
@@ -2,7 +2,7 @@ package digest
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -36,15 +36,15 @@ func run(ctx context.Context, cfg Config, store Store) {
 				continue
 			}
 			lastFired = now
-			log.Printf("digest: sending weekly digest")
+			slog.Info("digest: sending weekly digest")
 			digestCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			errs := Send(digestCtx, cfg, store)
 			cancel()
 			for _, err := range errs {
-				log.Printf("digest: %v", err)
+				slog.Error("digest: delivery error", "error", err)
 			}
 			if len(errs) == 0 {
-				log.Printf("digest: sent successfully")
+				slog.Info("digest: sent successfully")
 			}
 		}
 	}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -65,7 +65,8 @@ func (h *Handler) APIKeyProjectScope(r *http.Request) (projectID int64, scope st
 	if h == nil || h.auth == nil {
 		return 0, "full", true
 	}
-	return h.auth.ValidWithProject(r.Context(), r.Header.Get(auth.HeaderAPIKey))
+	slug := r.Header.Get("x-bugbarn-project")
+	return h.auth.ValidWithSetupFallback(r.Context(), r.Header.Get(auth.HeaderAPIKey), slug)
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/migrate_fingerprints.go
+++ b/internal/storage/migrate_fingerprints.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 
 	"github.com/wiebe-xyz/bugbarn/internal/event"
 	"github.com/wiebe-xyz/bugbarn/internal/fingerprint"
@@ -71,7 +71,7 @@ func (s *Store) migrateFingerprints(ctx context.Context) error {
 		return nil
 	}
 
-	log.Printf("[migrate] recomputing %d fingerprints", len(updates))
+	slog.Info("recomputing fingerprints", "count", len(updates))
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -113,7 +113,7 @@ func (s *Store) migrateFingerprints(ctx context.Context) error {
 			if _, err := tx.ExecContext(ctx, `DELETE FROM issues WHERE id = ?`, u.id); err != nil {
 				return err
 			}
-			log.Printf("[migrate] merged issue %d into %d (fingerprint %s)", u.id, keeperID, u.newFingerprint)
+			slog.Info("merged issue", "from_id", u.id, "into_id", keeperID, "fingerprint", u.newFingerprint)
 		} else {
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE issues SET fingerprint = ?, fingerprint_material = ?, fingerprint_explanation_json = ?, updated_at = CURRENT_TIMESTAMP

--- a/internal/worker/symbolicate.go
+++ b/internal/worker/symbolicate.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/wiebe-xyz/bugbarn/internal/event"
@@ -35,7 +35,7 @@ func SymbolicateEvent(ctx context.Context, evt event.Event, store SourceMapStore
 
 		blob, err := store.FindSourceMap(ctx, release, dist, frame.File)
 		if err != nil {
-			log.Printf("symbolicate: find source map for %s release=%s dist=%s: %v", frame.File, release, dist, err)
+			slog.Warn("symbolicate: failed to find source map", "file", frame.File, "release", release, "dist", dist, "err", err)
 			continue
 		}
 		if blob == nil {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1704,6 +1704,16 @@ function wireSettingsActions(): void {
     void submitSourceMapsForm(sourceMapForm);
   });
 
+  const copySetupBtn = elements.overviewView.querySelector<HTMLButtonElement>("#copy-setup-url");
+  copySetupBtn?.addEventListener("click", () => {
+    const urlEl = elements.overviewView.querySelector<HTMLElement>("#setup-url");
+    if (urlEl) {
+      void navigator.clipboard.writeText(urlEl.textContent || "");
+      copySetupBtn.textContent = "✓";
+      setTimeout(() => { copySetupBtn.textContent = "⧉"; }, 1500);
+    }
+  });
+
   elements.overviewView.querySelectorAll<HTMLButtonElement>("[data-approve-project]").forEach((btn) => {
     btn.addEventListener("click", () => {
       const slug = btn.dataset["approveProject"];

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -740,6 +740,15 @@ export function renderSettingsViewMarkup(settings: ApiSettings | null, username:
           <div class="kv"><span>Timezone</span><span>${escapeHtml(timezone || "n/a")}</span></div>
         </div>
       </div>
+      <div class="section quick-setup-card">
+        <h3>⚡ Quick Setup</h3>
+        <p class="muted">Point an LLM or developer at the setup page to auto-configure a project with an ingest API key. The page returns a markdown guide with SDK integration examples.</p>
+        <div class="setup-url-box">
+          <code id="setup-url">${escapeHtml(`${window.location.origin}/api/v1/setup/`)}your-project-slug</code>
+          <button class="btn-sm ghost" id="copy-setup-url" title="Copy URL">⧉</button>
+        </div>
+        <p class="muted" style="margin-top:6px">Replace <code>your-project-slug</code> with the desired project name. The project will appear below as "pending" until you approve.</p>
+      </div>
       <div class="section">
         <h3>Preferences</h3>
         <p class="muted">POST /api/v1/settings</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -879,6 +879,25 @@ button:disabled {
   color: #818cf8;
 }
 
+.setup-url-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: var(--accent-soft);
+  border-radius: 8px;
+  margin-top: 8px;
+}
+.setup-url-box code {
+  flex: 1;
+  font-size: 13px;
+  color: var(--accent);
+  word-break: break-all;
+}
+.setup-url-box button {
+  flex-shrink: 0;
+}
+
 .btn-sm {
   font-size: 11px;
   padding: 3px 10px;


### PR DESCRIPTION
## Summary
- Adds a Quick Setup card to the settings page with a copyable `/api/v1/setup/<slug>` URL
- Fixes the 500 error on setup endpoint for read-only replicas — readers now return the deterministic doc without writing to DB
- Adds setup key auto-provisioning: when the first ingest arrives with a setup key, the writer lazily creates the project and API key via HMAC verification
- Migrates all stdlib `log.Printf` calls to structured `slog` across alert, digest, analytics, api, storage, worker, and main — ensures selflog captures error-level messages for dogfooding

## Test plan
- [x] `go build ./...` passes
- [x] `go test` passes for api, auth, ingest, alert, storage, worker
- [ ] Verify setup endpoint returns 200 on production (currently 500 on readers)
- [ ] Verify Quick Setup card renders on settings page
- [ ] Send a test event with a setup key to confirm auto-provisioning