### PR TITLE
chore: commit untracked docs, infra files, and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 
 # Local runtime data
 .cache/
+.data/
 tmp/
 var/
 /data/
@@ -57,9 +58,17 @@ var/
 *.sqlite
 *.sqlite3
 *.db
+*.yaml.tmp
 
 # bb CLI local project config
 .bugbarn.json
+
+# Go compiled binaries at repo root
+/bb
+/bugbarn
+
+# Claude Code worktrees
+.claude/worktrees/
 
 # Docker and compose state
 docker-compose.override.yml

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,3 +5,5 @@ creation_rules:
     age: age1gm0rxsqsmasjf36jzs96rmkw6qwadt3mcts8zpql22tsff6uf56s62vemy
   - path_regex: deploy/k8s/production/.*secret.*\.yaml$
     age: age135zcsd472vweudg2g5f7h7253tlgmq35yfy4rew332ujadm32uaq5fquy9
+  - path_regex: deploy/ci-secrets\.yaml$
+    age: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295

--- a/deploy/ci-secrets.yaml
+++ b/deploy/ci-secrets.yaml
@@ -1,0 +1,21 @@
+#ENC[AES256_GCM,data:66NCmpN6m0LUpe3GUctMNbPdOmO8XKpgx6a4uYEUvJHE3VS1bTq1pj2N0ri++UnOY0Oev0SVaVu1YVVBew==,iv:FTeo4JcqMI0U1UTZgjBoFGjJLWGdgaerjxVPlhEx5xI=,tag:uDMw8sxShXCatb/AVlSAbQ==,type:comment]
+minio:
+    access_key: ENC[AES256_GCM,data:kRGFKKWK3Ic3LZPV,iv:gN6p9PKd7FSFba1FAjAm8piJoFpcWL+SAqSaqdXqqTY=,tag:ggZShF1POysYPTMfd3GgEw==,type:str]
+    secret_key: ENC[AES256_GCM,data:AzRqvclgqkC4dm0v/oxdPUFxvqvlS5kz,iv:zpzf5dwzFfFU9y809mS3Sp0ChqfIcIo0Shc1fD2W4Hc=,tag:iyu5Ns91DbZtT0cC5LrIIw==,type:str]
+    endpoint: ENC[AES256_GCM,data:2FjYAvO2MFnl/pTspHlQZeAtYag=,iv:5tamEupOJfdaixeXwrE4OLecfeVIROZA5sT+7lDMRPw=,tag:Z8TODDyrDVItzm74jdXljg==,type:str]
+    bucket: ENC[AES256_GCM,data:POpIMJ8eCSVkCIHw57YwVGg8gJ6Yyy0=,iv:ilrYMFlKUJcXi0Rzghv8bRyZz+Yawi+/6S8VihzZv1c=,tag:6BYBhyU7A0iByJdyRNZnfQ==,type:str]
+sops:
+    age:
+        - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUSEY0eWdsajhFWkttLzUw
+            VDVQeVEzVVhWVVRpWnlVZzlWRTl2S3VMM1NBCjcrYTRwTVM3OHJnUzNpei9BMStP
+            Tjk3TVZ0RFB3N0hGZmF3amxGb1U1NTQKLS0tIE1WOENJZGhBU0RxRUVDU05SNzZI
+            bUxVK01xR3VCNEEwYzBqMnVvZmE2NjQKLL9MbTRwWyp/auRXeWytQR29W/Exbi9Y
+            fDXC0Ob8zoMLpzMmCdHfP4filAWuMY/COXQj1PH6MPJolw+/dliuog==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-08T09:22:49Z"
+    mac: ENC[AES256_GCM,data:SI9AskmvAaO56MWjOzfVg8g/7qShaMtbibQ5hIdM0CIG2J9OS5udtMGlyCnuma8DUudFmT5S07tTAQ3vOy8m7yuCDKPLAfDNsOeT+qMTA8fCT1ErgubqranqepzXGTMR5ToJcY+zXaS8FxPa7QnmZ4OOFq91mppJnYgqplhjpr0=,iv:ESkttEJD9RBa+TN7ilGifrddkYUUvsVqoMjVLbuRCkE=,tag:QA5MQtdxyGbCOf7HFMxLIA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/deploy/docker/site.Dockerfile
+++ b/deploy/docker/site.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY site/package*.json ./
+RUN npm ci
+COPY site/ ./
+RUN npm run build
+
+FROM caddy:2.8-alpine
+COPY --from=build /app/dist /srv
+EXPOSE 8080
+CMD ["caddy", "file-server", "--root", "/srv", "--listen", ":8080"]

--- a/site/src/content/docs/README.md
+++ b/site/src/content/docs/README.md
@@ -1,0 +1,50 @@
+# BugBarn Documentation
+
+BugBarn is a lightweight, self-hosted error tracking system built in Go with SQLite.
+
+---
+
+## Start here
+
+**New user — try BugBarn locally**
+- [Getting started](getting-started.md) — run BugBarn and send your first error in under five minutes.
+
+**Business owner — evaluate BugBarn**
+- [Overview](overview.md) — what BugBarn does, who it is for, and where it fits (and does not fit).
+
+**Developer — integrate or deploy**
+- [SDK overview](sdks/overview.md) — choose an SDK or use the HTTP API directly, understand API keys and event shape.
+- [REST API reference](api.md) — full endpoint reference including authentication and payloads.
+- [Deployment configuration](deployment/configuration.md) — all environment variables for production deployments.
+
+---
+
+## All documents
+
+| File | Audience | Purpose |
+|---|---|---|
+| [overview.md](overview.md) | Everyone | What BugBarn is, key capabilities, and what it is not |
+| [getting-started.md](getting-started.md) | New users | Run BugBarn locally and send your first error |
+| [architecture/overview.md](architecture/overview.md) | Developers | System architecture, data flow, and component responsibilities |
+| [architecture/storage.md](architecture/storage.md) | Developers | Database schema, spool format, and WAL replication |
+| [architecture/authentication.md](architecture/authentication.md) | Developers | Session cookies, API keys, CSRF, and auth internals |
+| [features/issues.md](features/issues.md) | Everyone | Issue grouping, statuses, and lifecycle |
+| [features/alerts.md](features/alerts.md) | Everyone | Alert rules, conditions, delivery channels, and cooldowns |
+| [features/digest.md](features/digest.md) | Everyone | Weekly digest email and JSON webhook |
+| [features/logs.md](features/logs.md) | Everyone | Log ingestion, streaming, and filtering |
+| [deployment/configuration.md](deployment/configuration.md) | Operators | All environment variables and their defaults |
+| [deployment/kubernetes.md](deployment/kubernetes.md) | Operators | Kubernetes manifests, Litestream, and production deployment |
+| [deployment/performance.md](deployment/performance.md) | Operators | Throughput, hardware recommendations, and system limits |
+| [api.md](api.md) | Developers | Full REST API reference with request/response examples |
+| [sdks/overview.md](sdks/overview.md) | Developers | Integration options, API key scopes, event shape, and privacy scrubbing |
+| [sdks/go.md](sdks/go.md) | Developers | Go SDK installation, initialisation, and usage |
+| [sdks/http.md](sdks/http.md) | Developers | Sending events directly over HTTP from any language |
+
+---
+
+## Quick links
+
+- [Send your first error](getting-started.md)
+- [All environment variables](deployment/configuration.md)
+- [REST API reference](api.md)
+- [Go SDK](sdks/go.md)

--- a/site/src/content/docs/api.md
+++ b/site/src/content/docs/api.md
@@ -1,0 +1,852 @@
+# BugBarn REST API Reference
+
+## Base URL
+
+All endpoints are prefixed with `/api/v1`.
+
+---
+
+## Authentication
+
+BugBarn supports two authentication mechanisms. Which one is required depends on the endpoint group.
+
+### API Key (X-BugBarn-Api-Key header)
+
+Pass the API key in the `X-BugBarn-Api-Key` request header:
+
+```
+X-BugBarn-Api-Key: <your-api-key>
+```
+
+API keys have one of two scopes:
+
+| Scope | Access |
+|---|---|
+| `ingest` | May only call `POST /api/v1/events` and `POST /api/v1/logs`. |
+| `full` | May call all protected endpoints. |
+
+Keys are created with `bugbarn apikey create` or via `POST /api/v1/apikeys`. The plaintext key is shown only once at creation time.
+
+### Session Cookie
+
+Browser clients authenticate by calling `POST /api/v1/login` with a JSON body containing `username` and `password`. On success, BugBarn sets two cookies:
+
+- `bugbarn_session` — HttpOnly session token.
+- `bugbarn_csrf` — readable CSRF token derived from the session.
+
+### CSRF Token
+
+State-changing requests made with a session cookie (POST, PUT, DELETE — excluding `/api/v1/login`, `/api/v1/logout`, and `/api/v1/events`) must include the CSRF token in the `X-BugBarn-CSRF` header:
+
+```
+X-BugBarn-CSRF: <value of the bugbarn_csrf cookie>
+```
+
+Requests authenticated via API key are exempt from CSRF checks.
+
+---
+
+## Project Scoping
+
+Most endpoints operate in the context of a project.
+
+### X-BugBarn-Project Header
+
+Send the project slug in this header to scope the request to that project:
+
+```
+X-BugBarn-Project: my-project
+```
+
+If the slug does not exist, BugBarn creates the project automatically.
+
+### All-Projects Mode
+
+Session-authenticated `GET` requests that omit the `X-BugBarn-Project` header return results from all projects in this BugBarn instance. Each result carries a `project_slug` field identifying which project it belongs to. This is how the web UI shows a global issue list.
+
+### API Key Scoping
+
+When using an API key that was created for a specific project, that project is the implicit scope. The `X-BugBarn-Project` header takes precedence and overrides the key's project binding.
+
+---
+
+## Error Responses
+
+All error responses use plain text bodies with standard HTTP status codes. Successful responses are JSON.
+
+| Status | Meaning |
+|---|---|
+| `400` | Bad request — malformed or missing payload. |
+| `401` | Unauthorized — no valid session or API key. |
+| `403` | Forbidden — ingest-only key on a protected endpoint, or missing/invalid CSRF token. |
+| `404` | Not found. |
+| `405` | Method not allowed. |
+| `413` | Payload too large — body exceeds `BUGBARN_MAX_BODY_BYTES`. |
+| `429` | Too many requests — spool full (ingest) or login rate limit exceeded. Includes `Retry-After` header. |
+| `500` | Internal server error. |
+
+Error body (plain text):
+
+```
+unauthorized
+```
+
+---
+
+## Rate Limiting
+
+- **Ingest (`POST /api/v1/events`, `POST /api/v1/logs`):** Returns `429` when the spool exceeds `BUGBARN_MAX_SPOOL_BYTES`. Includes `Retry-After: 60`. No other ingest rate limiting applies.
+- **Login (`POST /api/v1/login`):** Rate-limited to 10 attempts per IP per minute. Returns `429` with `Retry-After: 60`.
+- No rate limiting applies to any other endpoint.
+
+---
+
+## Endpoint Reference
+
+### Public Endpoints (no auth required)
+
+#### GET /api/v1/health
+
+Health check. Always returns `200` when the server is running.
+
+**Response:**
+```json
+{"status": "ok"}
+```
+
+---
+
+#### POST /api/v1/login
+
+Authenticate and obtain a session cookie.
+
+**Request body:**
+```json
+{"username": "admin", "password": "hunter2"}
+```
+
+**Response (success):**
+```json
+{"authenticated": true, "authEnabled": true, "username": "admin"}
+```
+
+Sets `bugbarn_session` and `bugbarn_csrf` cookies on success.
+
+---
+
+#### POST /api/v1/logout
+
+Clear the session cookie.
+
+**Response:**
+```json
+{"authenticated": false}
+```
+
+---
+
+#### GET /api/v1/me
+
+Return the current authentication state.
+
+**Response (authenticated):**
+```json
+{"authenticated": true, "authEnabled": true, "username": "admin"}
+```
+
+**Response (unauthenticated):**
+```json
+{"authenticated": false, "authEnabled": true}
+```
+
+If authentication is not configured, `authEnabled` is `false` and `authenticated` is always `true`.
+
+---
+
+### Ingest Endpoints
+
+Ingest endpoints accept wildcard CORS (`Access-Control-Allow-Origin: *`) so browser SDKs can call them from any origin. Authentication requires an API key with `ingest` or `full` scope.
+
+#### POST /api/v1/events
+
+Ingest an error event.
+
+**Auth:** API key (`ingest` or `full` scope).
+
+**Request body:** Event JSON object (see [Event Payload](#event-payload)).
+
+**Response `202`:**
+```json
+{"accepted": true, "ingestId": "01HX..."}
+```
+
+The event is written to the spool and processed asynchronously. The `ingestId` can be used to correlate spool entries during debugging.
+
+---
+
+#### POST /api/v1/logs
+
+Ingest one or more log entries.
+
+**Auth:** API key (`ingest` or `full` scope).
+
+**Content-Type options:**
+
+- `application/json` — body: `{"logs": [<entry>, ...]}`
+- `application/x-ndjson` — one JSON object per line (newline-delimited JSON)
+
+**Request body (JSON):**
+```json
+{
+  "logs": [
+    {
+      "timestamp": "2026-04-26T10:30:00Z",
+      "level": "error",
+      "level_num": 50,
+      "message": "Database connection failed",
+      "data": {
+        "host": "db.internal",
+        "retries": 3
+      }
+    }
+  ]
+}
+```
+
+**Response:** `204 No Content` on success.
+
+A project must be determinable from either the API key or the `X-BugBarn-Project` header. Requests without a resolvable project are rejected with `400`.
+
+---
+
+### Issues
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/issues
+
+List issues with optional filtering.
+
+**Query parameters:**
+
+| Parameter | Description |
+|---|---|
+| `sort` | Sort order: `last_seen` (default), `first_seen`, or `event_count`. |
+| `status` | Filter by status: `open`, `muted`, `resolved`, or `all`. |
+| `q` | Full-text search query. |
+| `<facet_key>=<value>` | Filter by any facet key. Example: `environment=production`. Multiple facets can be combined. |
+
+**Response:**
+```json
+{
+  "issues": [
+    {
+      "id": "issue-000001",
+      "title": "TypeError: Cannot read property 'x' of undefined",
+      "status": "open",
+      "event_count": 42,
+      "first_seen": "2026-04-01T08:00:00Z",
+      "last_seen": "2026-04-26T10:30:00Z",
+      "hourly_counts": [0, 0, 1, 3, 0, ...]
+    }
+  ]
+}
+```
+
+`hourly_counts` is an array of 24 integers representing event counts for each of the last 24 hours (oldest first), used to render a sparkline.
+
+---
+
+#### GET /api/v1/issues/{id}
+
+Fetch a single issue.
+
+**Response:**
+```json
+{"issue": { ...issue object... }}
+```
+
+---
+
+#### GET /api/v1/issues/{id}/events
+
+List events grouped under an issue.
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `limit` | 25 | Maximum number of events to return. |
+| `beforeId` | — | Return events with ID less than this value (pagination cursor). |
+
+**Response:**
+```json
+{"events": [ ...event objects... ]}
+```
+
+---
+
+#### POST /api/v1/issues/{id}/resolve
+
+Mark the issue as resolved. No request body.
+
+**Response:**
+```json
+{"issue": { ...updated issue object... }}
+```
+
+---
+
+#### POST /api/v1/issues/{id}/reopen
+
+Reopen the issue to `unresolved`. No request body.
+
+**Response:**
+```json
+{"issue": { ...updated issue object... }}
+```
+
+---
+
+#### PATCH /api/v1/issues/{id}/mute
+
+Mute the issue.
+
+**Request body:**
+```json
+{"mute_mode": "until_regression"}
+```
+
+| Field | Values | Description |
+|---|---|---|
+| `mute_mode` | `until_regression`, `forever` | How to mute the issue. |
+
+**Response:**
+```json
+{"issue": { ...updated issue object... }}
+```
+
+---
+
+#### PATCH /api/v1/issues/{id}/unmute
+
+Remove the mute and return the issue to `unresolved`. No request body.
+
+**Response:**
+```json
+{"issue": { ...updated issue object... }}
+```
+
+---
+
+### Events
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/events/{id}
+
+Fetch a single event by ID.
+
+**Response:**
+```json
+{"event": { ...event object... }}
+```
+
+---
+
+#### GET /api/v1/events/stream
+
+Server-Sent Events (SSE) stream of live events as they are processed from the spool.
+
+See [SSE Endpoints](#sse-endpoints) for the stream format.
+
+---
+
+#### GET /api/v1/live/events
+
+List recent events (polling alternative to SSE).
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `limit` | 50 | Maximum number of events to return. |
+| `since` | — | RFC 3339 timestamp. Return only events received after this time. |
+
+**Response:**
+```json
+{"events": [ ...event objects... ]}
+```
+
+---
+
+### Releases
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/releases
+
+List all releases.
+
+**Response:**
+```json
+{"releases": [ ...release objects... ]}
+```
+
+---
+
+#### POST /api/v1/releases
+
+Create a release.
+
+**Request body:**
+```json
+{
+  "name": "v1.2.3",
+  "environment": "production",
+  "version": "1.2.3",
+  "commit_sha": "abc123",
+  "url": "https://github.com/org/repo/releases/tag/v1.2.3",
+  "notes": "Bug fixes and performance improvements."
+}
+```
+
+**Response:**
+```json
+{"release": { ...release object... }}
+```
+
+---
+
+#### GET /api/v1/releases/{id}
+
+Fetch a single release.
+
+---
+
+#### PATCH /api/v1/releases/{id}
+
+Update a release. Accepts the same fields as the create request (all optional).
+
+---
+
+#### DELETE /api/v1/releases/{id}
+
+Delete a release.
+
+**Response:**
+```json
+{"deleted": true}
+```
+
+---
+
+### Alerts
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/alerts
+
+List all alerts.
+
+**Response:**
+```json
+{"alerts": [ ...alert objects... ]}
+```
+
+---
+
+#### POST /api/v1/alerts
+
+Create an alert.
+
+**Request body:**
+```json
+{
+  "name": "High error rate",
+  "enabled": true,
+  "severity": "error",
+  "condition": "event_count_exceeds",
+  "threshold": 10,
+  "cooldown_minutes": 60,
+  "webhook_url": "https://hooks.example.com/notify"
+}
+```
+
+**Response:**
+```json
+{"alert": { ...alert object... }}
+```
+
+---
+
+#### GET /api/v1/alerts/{id}
+
+Fetch a single alert.
+
+---
+
+#### PATCH /api/v1/alerts/{id}
+
+Update an alert. Accepts the same fields as the create request (all optional).
+
+---
+
+#### DELETE /api/v1/alerts/{id}
+
+Delete an alert.
+
+**Response:**
+```json
+{"deleted": true}
+```
+
+---
+
+### Logs
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/logs
+
+Query stored log entries.
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `level` | — | Minimum log level name to return: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `q` | — | Full-text search query against log messages. |
+| `limit` | 200 | Maximum entries to return (capped at 500). |
+| `before` | — | Return entries with ID less than this value (pagination cursor). |
+
+**Response:**
+```json
+{
+  "logs": [ ...log entry objects... ],
+  "next_cursor": 12345
+}
+```
+
+Pass `next_cursor` as `before` in the next request to page backwards through older entries.
+
+---
+
+#### GET /api/v1/logs/stream
+
+Server-Sent Events (SSE) stream of live log entries as they are ingested.
+
+See [SSE Endpoints](#sse-endpoints) for the stream format.
+
+---
+
+### Facets
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/facets
+
+List all known facet keys.
+
+**Response:**
+```json
+{"keys": ["environment", "severity", "release", "http.route"]}
+```
+
+---
+
+#### GET /api/v1/facets/{key}
+
+List all observed values for a given facet key.
+
+**Response:**
+```json
+{"key": "environment", "values": ["production", "staging", "development"]}
+```
+
+---
+
+### Projects
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/projects
+
+List all projects.
+
+**Response:**
+```json
+{"projects": [{"id": 1, "name": "My App", "slug": "my-app"}]}
+```
+
+---
+
+#### POST /api/v1/projects
+
+Create a project.
+
+**Request body:**
+```json
+{"name": "My App", "slug": "my-app"}
+```
+
+**Response:**
+```json
+{"project": {"id": 1, "name": "My App", "slug": "my-app"}}
+```
+
+---
+
+### API Keys
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/apikeys
+
+List all API keys. The plaintext key value is never returned; only metadata is shown.
+
+**Response:**
+```json
+{
+  "apiKeys": [
+    {
+      "id": 1,
+      "name": "production-sdk",
+      "projectId": 1,
+      "scope": "ingest",
+      "createdAt": "2026-01-01T00:00:00Z",
+      "lastUsedAt": "2026-04-26T10:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+#### POST /api/v1/apikeys
+
+Create a new API key.
+
+**Request body:**
+```json
+{"name": "my-key", "scope": "ingest", "project": "my-app"}
+```
+
+**Response:**
+```json
+{
+  "apiKey": {
+    "id": 2,
+    "name": "my-key",
+    "scope": "ingest",
+    "projectId": 1,
+    "key": "a3f1..."
+  }
+}
+```
+
+> The `key` field is only present in the creation response. Store it securely — it cannot be retrieved again.
+
+---
+
+#### DELETE /api/v1/apikeys/{id}
+
+Delete an API key by its numeric ID.
+
+**Response:**
+```json
+{"deleted": true}
+```
+
+---
+
+### Settings
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/settings
+
+Return current instance settings as a key-value map.
+
+**Response:**
+```json
+{"settings": {"some_key": "some_value"}}
+```
+
+---
+
+#### PUT /api/v1/settings
+
+Update one or more settings.
+
+**Request body:**
+```json
+{"some_key": "new_value"}
+```
+
+**Response:**
+```json
+{"settings": {"some_key": "new_value"}}
+```
+
+---
+
+### Source Maps
+
+**Auth:** Session cookie or full-scope API key.
+
+#### GET /api/v1/source-maps
+
+List uploaded source maps.
+
+**Response:**
+```json
+{"sourceMaps": [ ...source map objects... ]}
+```
+
+---
+
+#### POST /api/v1/source-maps
+
+Upload a source map file. Uses `multipart/form-data`.
+
+**Form fields:**
+
+| Field | Description |
+|---|---|
+| `bundle_url` | URL of the JavaScript bundle this map corresponds to. |
+| `release` | Release name or version string. |
+| `dist` | Optional distribution identifier. |
+| `source_map` | The source map file (`.map`). |
+
+---
+
+#### DELETE /api/v1/source-maps/{id}
+
+Delete a source map by ID.
+
+**Response:**
+```json
+{"deleted": true}
+```
+
+---
+
+## SSE Endpoints
+
+Two endpoints stream data using [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events):
+
+- `GET /api/v1/events/stream` — live error events
+- `GET /api/v1/logs/stream` — live log entries
+
+### Stream Format
+
+Each message is a standard SSE frame with a `data` field containing a JSON-encoded object:
+
+```
+data: {"id":1,"message":"Database connection failed","level":"error",...}
+
+data: {"id":2,"message":"Order placed","level":"info",...}
+
+```
+
+Keep-alive comments are sent every 15 seconds to prevent proxy timeouts:
+
+```
+:
+
+```
+
+### Reconnection
+
+The browser's `EventSource` API reconnects automatically on disconnect. To avoid re-displaying events already seen, track the last received event ID and use the `since` parameter on `GET /api/v1/live/events` (the polling alternative) when reconnecting.
+
+### Project Filtering
+
+SSE streams respect the `X-BugBarn-Project` header. Omitting the header streams events from all projects (session auth only).
+
+---
+
+## Event Payload
+
+The full shape of the JSON body for `POST /api/v1/events`:
+
+```json
+{
+  "timestamp": "2026-04-26T10:30:00.000Z",
+  "severityText": "error",
+  "body": "Something went wrong",
+  "exception": {
+    "type": "TypeError",
+    "message": "Cannot read property 'x' of undefined",
+    "stacktrace": [
+      {
+        "function": "processOrder",
+        "module": "orders",
+        "filename": "orders.js",
+        "lineno": 42
+      }
+    ]
+  },
+  "attributes": {
+    "http.route": "/api/orders",
+    "http.method": "POST",
+    "http.status_code": "500",
+    "environment": "production",
+    "release": "v1.2.3"
+  },
+  "resource": {
+    "service.name": "api",
+    "host.name": "web-01"
+  },
+  "user": {
+    "id": "usr_123",
+    "email": "user@example.com",
+    "username": "johndoe"
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | RFC 3339 string | When the event occurred. |
+| `severityText` | string | Severity level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `body` | string | Human-readable event message. |
+| `exception` | object | Optional. Exception details. |
+| `exception.type` | string | Exception class name. |
+| `exception.message` | string | Exception message. |
+| `exception.stacktrace` | array | Stack frames. Each frame may include `function`, `module`, `filename`, `lineno`, `colno`. |
+| `attributes` | object | Arbitrary key-value metadata. Values used for faceting and filtering. |
+| `resource` | object | Resource attributes describing the originating service or host. |
+| `user` | object | Optional. User context: `id`, `email`, `username`. |
+
+All top-level fields except `body` are optional. Ingest accepts any JSON object — unrecognised fields are stored and surfaced in the UI.
+
+---
+
+## Log Entry Payload
+
+The shape of each entry in `POST /api/v1/logs`:
+
+```json
+{
+  "timestamp": "2026-04-26T10:30:00Z",
+  "level": "error",
+  "level_num": 50,
+  "message": "Database connection failed",
+  "data": {
+    "host": "db.internal",
+    "retries": 3
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | RFC 3339 string | When the log entry was produced. |
+| `level` | string | Level name: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+| `level_num` | integer | Pino-style numeric level (10, 20, 30, 40, 50, 60). Used when `level` is absent or for numeric-only loggers. |
+| `message` | string | Log message text. Also accepted under the key `msg` (Pino convention). |
+| `data` | object | Arbitrary additional structured fields. |
+
+The log ingest endpoint also accepts raw [Pino](https://getpino.io) JSON output (where `msg` is the message key and `time` is epoch milliseconds) — both via `application/json` with a `{"logs":[...]}` wrapper and via `application/x-ndjson` line-by-line.

--- a/site/src/content/docs/architecture.md
+++ b/site/src/content/docs/architecture.md
@@ -1,0 +1,52 @@
+# BugBarn Architecture
+
+This document describes the repository layout and the current runtime flow for the personal error tracker foundation.
+
+## Runtime Flow
+
+SDK/client -> ingest API -> durable spool -> background worker -> normalization/privacy/fingerprinting -> SQLite storage -> query API/web
+
+1. A client or SDK posts an event to `POST /api/v1/events` with the BugBarn API key header.
+2. The ingest handler authenticates the request, enforces body limits, and appends the raw payload plus request metadata to the durable local spool.
+3. `cmd/bugbarn` keeps the service running and starts the background worker loop alongside the HTTP server.
+4. The worker reads spool records, decodes the payload, normalizes it into the canonical event shape, scrubs sensitive values, and derives a fingerprint.
+5. The service layer applies issue lifecycle and live-window rules, then calls repository interfaces for persistence.
+6. Storage repositories persist the processed issue, event, and facet rows in SQLite.
+7. The API server serves read endpoints for the UI, accepts source map artifact uploads, and the browser client renders issue lists, issue detail, event detail, and recent live events from those read APIs.
+
+## Repository Layout
+
+- `cmd/bugbarn`: process entrypoint. It loads config, opens storage, opens the spool, starts the HTTP server, and runs the background worker. `worker-once` is the maintenance path for processing the current spool one time.
+- `internal/ingest`: request-path ingest handler. It owns API key validation, size checks, and durable enqueue into the spool.
+- `internal/api`: HTTP server and route dispatch. It owns request/response handling and delegates use cases to `internal/service`.
+- `internal/service`: business use cases and error boundary between HTTP handlers and repositories.
+- `internal/worker`: spool record processing. It owns decoding, normalization, privacy scrubbing, and fingerprint generation before persistence.
+- `internal/storage`: SQLite repository implementation, schema setup, migrations, inserts, issue grouping, event persistence, facet storage, and read queries.
+- `internal/normalize`, `internal/privacy`, `internal/fingerprint`: transformation helpers used by the worker before data reaches storage.
+- `web`: browser UI for issue and event inspection.
+- `sdks/typescript`, `sdks/python`: client SDKs.
+- `examples`: local validation programs and the load generator.
+- `specs/001-personal-error-tracker`: the source-of-truth product spec, plan, tasks, fixtures, and ingest contract.
+
+## Ownership Boundaries
+
+- `cmd/bugbarn` wires the process together; it does not own route semantics or storage policy.
+- `internal/api` owns the HTTP server surface, including `GET /api/v1/issues`, `GET /api/v1/issues/{id}`, `GET /api/v1/issues/{id}/events`, `GET /api/v1/events/{id}`, and `GET /api/v1/events/stream` (SSE). Handlers should stay limited to parsing, authentication/session handling, response formatting, and calling service methods.
+- `internal/service` owns business behavior such as issue resolution/reopen, regression semantics, live-event recency windows, releases, alerts, settings, and source-map upload use cases.
+- `internal/storage` implements repository interfaces. SQL and migration details stay behind this boundary and should not leak to API handlers or frontend responses.
+- `internal/ingest` owns `POST /api/v1/events`.
+- `internal/worker` owns the transformation pipeline from raw spool record to processed event.
+- `internal/storage` owns the SQLite representation and query behavior.
+
+## Endpoint Definitions
+
+- The public ingest contract lives in [`specs/001-personal-error-tracker/contracts/ingest-api.yaml`](../specs/001-personal-error-tracker/contracts/ingest-api.yaml).
+- The source map upload contract lives in [`specs/001-personal-error-tracker/contracts/source-maps-api.yaml`](../specs/001-personal-error-tracker/contracts/source-maps-api.yaml).
+- The HTTP route map is implemented in [`internal/api/server.go`](../internal/api/server.go).
+- The browser UI expects the read/live endpoints documented in [`web/README.md`](../web/README.md).
+
+## Source Language Notes
+
+- Browser-side scripting source should be authored in TypeScript.
+- Any JavaScript committed for the browser should be treated as build output or temporary legacy source, not the preferred authoring format.
+- The foundation SDKs are TypeScript and Python. PHP is reserved for a later SDK iteration.

--- a/site/src/content/docs/architecture/authentication.md
+++ b/site/src/content/docs/architecture/authentication.md
@@ -1,0 +1,198 @@
+# BugBarn — Authentication
+
+## Two Auth Modes
+
+BugBarn supports two mutually exclusive authentication paths on any given request.
+
+| Mode | Credential | Use case |
+|---|---|---|
+| **Session** | `bugbarn_session` cookie | Interactive browser sessions; the Web UI uses this after login |
+| **API key** | `X-BugBarn-Api-Key` header | SDKs, CI scripts, automated clients, browser-side error reporting |
+
+The two modes are evaluated in order: session first, then API key. For the ingest endpoint and the log ingest endpoint, only the API key path is checked (sessions are not accepted there).
+
+---
+
+## Session Authentication
+
+### Login and Logout
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `POST /api/v1/login` | `POST` | Submit `{"username":"…","password":"…"}`. On success sets two cookies and returns `200`. On failure returns `401`. |
+| `POST /api/v1/logout` | `POST` | Clears both session cookies. No auth required. |
+| `GET /api/v1/me` | `GET` | Returns `{"username":"…","authenticated":true}` for a valid session, or `{"authenticated":false}`. |
+
+### Cookie Format
+
+A successful login sets two cookies:
+
+#### `bugbarn_session`
+
+The session token is a two-part string: `<payload>.<signature>`, where both parts are base64url-encoded (no padding).
+
+- **Payload**: base64url-encoded JSON:
+  ```json
+  {"u": "admin", "e": 1745826000, "n": "<random-nonce>"}
+  ```
+  - `u` — username
+  - `e` — Unix timestamp of expiry
+  - `n` — 32-byte random nonce (prevents signature re-use)
+
+- **Signature**: base64url-encoded HMAC-SHA256 over the raw payload bytes, keyed with `BUGBARN_SESSION_SECRET`
+
+Cookie attributes:
+- `HttpOnly: true` — not accessible from JavaScript
+- `SameSite: Strict`
+- `Secure` — set when the request arrives over HTTPS
+- `Path: /`
+- `Expires` — set to the session expiry time
+
+#### `bugbarn_csrf`
+
+A companion cookie whose value is a CSRF token derived from the session token (see [CSRF Protection](#csrf-protection) below).
+
+Cookie attributes:
+- `HttpOnly: false` — **must** be readable by JavaScript so the UI can attach it as a request header
+- `SameSite: Lax`
+- `Secure` — set when the request arrives over HTTPS
+- `Path: /`
+
+### Session TTL
+
+The default session lifetime is **12 hours**. This can be changed by setting `BUGBARN_SESSION_TTL_SECONDS` to a positive integer number of seconds.
+
+Sessions are **stateless**: there is no server-side session store. Validity is determined entirely by the HMAC signature and the expiry timestamp embedded in the cookie. If `BUGBARN_SESSION_SECRET` is not set, a random secret is generated at startup and sessions will not survive a process restart.
+
+### Password Storage
+
+Passwords are stored as bcrypt hashes in the `users` table (`password_bcrypt` column). BugBarn supports two ways to configure the admin password at startup:
+
+- `BUGBARN_ADMIN_PASSWORD_BCRYPT` — a pre-computed bcrypt hash (preferred for production)
+- `BUGBARN_ADMIN_PASSWORD` — a plaintext password; BugBarn hashes it with `bcrypt.DefaultCost` on startup
+
+Verification uses `bcrypt.CompareHashAndPassword` which is timing-safe by design. Username comparison uses `crypto/subtle.ConstantTimeCompare`.
+
+---
+
+## API Key Authentication
+
+### Header
+
+All API key requests must include:
+
+```
+X-BugBarn-Api-Key: <plaintext-key>
+```
+
+### Scopes
+
+| Scope | Permitted endpoints |
+|---|---|
+| `full` | All authenticated endpoints |
+| `ingest` | `POST /api/v1/events` and `POST /api/v1/logs` only |
+
+An `ingest`-scoped key presented to any other protected endpoint receives `403 Forbidden`.
+
+### Key Storage
+
+The plaintext key is never stored. BugBarn stores only `SHA-256(plaintext_key)` as a hex string in `api_keys.key_sha256`. On each request, the server computes `SHA-256(provided_key)` and performs a constant-time comparison against the stored hash (for the static env-var key) or a database lookup by hash.
+
+The `last_used_at` column in `api_keys` is updated on every successful database-key authentication.
+
+### Static Environment Variable Key
+
+A single global key can be configured without a database record:
+
+- `BUGBARN_API_KEY` — plaintext key; BugBarn hashes it at startup
+- `BUGBARN_API_KEY_SHA256` — pre-computed SHA-256 hex digest (preferred)
+
+A static env-var key is always `full`-scoped and is not bound to any project (`project_id = 0`), meaning it has access to all projects.
+
+### Database Keys
+
+Keys created with `bugbarn apikey create` are stored in the `api_keys` table. They are bound to a specific project and can have either scope. The `bugbarn apikey create` CLI command generates a 32-byte random key, prints the plaintext once, and stores only the SHA-256 hash.
+
+When both a static env-var key and database keys are configured, the static key is checked first.
+
+---
+
+## CSRF Protection
+
+### When It Applies
+
+CSRF protection applies to **session-authenticated, state-changing requests** (any method other than `GET`, `HEAD`, or `OPTIONS`) against all protected API endpoints. It does **not** apply to:
+
+- Requests authenticated by API key (API keys are out-of-band credentials that a cross-site attacker cannot access)
+- `GET` / `OPTIONS` requests
+- The ingest endpoint (`/api/v1/events`) — that endpoint accepts wildcard CORS by design
+
+### Token Format
+
+The CSRF token is derived from the session token:
+
+```
+csrf_token = hex( HMAC-SHA256(key="csrf", message=session_token) )[:16 bytes] = 32 hex characters
+```
+
+This token is stored in the `bugbarn_csrf` cookie (readable by JavaScript because `HttpOnly=false`) and must be included as the `X-BugBarn-CSRF` request header on every protected state-changing request.
+
+### How to Include in Requests
+
+1. After login, read the `bugbarn_csrf` cookie value from JavaScript.
+2. Attach it as a request header: `X-BugBarn-CSRF: <token>`.
+
+The Web UI does this automatically. If the header is absent or the token does not match the one derived from the current session cookie, the server responds with `403 Forbidden`.
+
+---
+
+## Project Resolution
+
+Every authenticated request is resolved to a project (or to "all projects" for GET requests with session auth). The resolution logic is:
+
+```
+If X-BugBarn-Project header is present:
+  → EnsureProject(slug)   [auto-creates the project if not found]
+  → use that project ID
+
+Else if request is authenticated by API key AND the key is bound to a project:
+  → use the key's project_id
+
+Else if request is authenticated by session AND method != GET:
+  → use the "default" project
+
+Else if request is authenticated by session AND method == GET:
+  → project ID = 0  (all-projects mode: queries span all projects)
+```
+
+The resolved project ID is stored in the request context so storage methods can distinguish "all projects" (`0`) from "specific project" (non-zero).
+
+---
+
+## CORS
+
+### Ingest and Log Ingest Endpoints
+
+`POST /api/v1/events` and `POST /api/v1/logs` respond with:
+
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Headers: content-type, x-bugbarn-api-key, x-bugbarn-project
+Access-Control-Allow-Methods: POST, OPTIONS
+```
+
+The wildcard origin is intentional: browser-side SDKs must be able to POST errors from any origin without requiring the BugBarn host to know every client origin in advance.
+
+### All Other Endpoints
+
+All other API endpoints use a configurable origin allowlist set via the `BUGBARN_ALLOWED_ORIGINS` environment variable (comma-separated list). Only origins present in that list receive a matching `Access-Control-Allow-Origin` response header.
+
+### Why Ingest-Scope Keys Are Safe for Browser Use
+
+Exposing an API key in browser JavaScript is acceptable for `ingest`-scoped keys because:
+
+1. An `ingest`-scoped key is only accepted at `POST /api/v1/events` and `POST /api/v1/logs`. It cannot read issues, events, settings, or any other data.
+2. The worst an attacker who intercepts the key can do is submit fabricated error events, which have no impact on application security or confidentiality.
+3. The key is bound to a specific project, so any noise is isolated to that project.
+
+`full`-scoped keys should never be used in browser-side code.

--- a/site/src/content/docs/architecture/overview.md
+++ b/site/src/content/docs/architecture/overview.md
@@ -1,0 +1,115 @@
+# BugBarn — Architecture Overview
+
+## Three-Layer Design
+
+BugBarn is structured as three distinct layers that decouple ingest throughput from database write latency and from API serving.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Layer 1: Ingest (async, durable)                   │
+│  POST /api/v1/events → spool file on disk           │
+│  Returns 202 immediately; never blocks on DB write  │
+└─────────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│  Layer 2: Processing (background worker goroutine)  │
+│  Reads spool → normalise → scrub → fingerprint      │
+│  → persist to SQLite → publish domain events        │
+└─────────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────┐
+│  Layer 3: Serve (API + UI)                          │
+│  REST endpoints + SSE streams over SQLite reads     │
+│  TypeScript SPA served as static files              │
+└─────────────────────────────────────────────────────┘
+```
+
+### Why This Architecture
+
+**SQLite-first.** The entire persistent state fits in a single WAL-mode SQLite file. There is no separate database server to operate, no connection pool to tune, and no network round-trip to storage. Operational complexity is minimal — backup is a file copy (or Litestream replication).
+
+**Spool for durability.** The ingest handler never writes directly to SQLite. Instead it appends records to an append-only NDJSON file on disk and returns `202 Accepted` to the caller. If the background worker is slow, the spool absorbs the backlog without blocking producers. If the process crashes, the cursor file records the last successfully processed offset so no record is silently dropped.
+
+---
+
+## Full Data Flow
+
+```mermaid
+flowchart TD
+    SDK["SDK / Client\nHTTP POST /api/v1/events"]
+    IH["Ingest Handler\ninternal/ingest/handler.go\n─\nAPI key validation\nbody size check (1 MiB default)\nwraps body as base64 spool.Record"]
+    IQ["In-Memory Queue\n32 768-record channel\nflushed every 5 ms or 64 records"]
+    SPOOL["Event Spool\ninternal/spool/\n─\n.data/spool/ingest.ndjson\nappend-only NDJSON\ncursor.json tracks offset\ndeadletter.ndjson on 3 failures"]
+    W["Background Worker\ncmd/bugbarn/main.go:runBackgroundWorker\nruns every ~1 s\n─\nReadRecordsFrom(offset)\nProcessRecord() — decode→normalise→scrub→fingerprint\nEnsureProject()\nSymbolicateEvent()\nPersistProcessedEvent()\nPublishIssueEvent()\nadvance cursor"]
+    DB["SQLite (WAL mode)\n.data/bugbarn.db\n─\nprojects, issues, events,\nevent_facets, alerts,\nalert_firings, log_entries, …"]
+    BUS["Domain Event Bus\ninternal/domainevents/Bus\nin-process pub/sub"]
+    AE["Alert Evaluator\ninternal/alert/evaluator.go\n─\nnew_issue / regression /\nevent_count_exceeds\ncooldown check\nwebhook HTTP POST (3 retries)"]
+    API["API Server\ninternal/api/\n─\nREST + SSE\nsession & API key auth\nCSRF middleware"]
+    UI["Web UI\nTypeScript SPA\nweb/src/"]
+
+    SDK -->|"HTTP POST 202 Accepted"| IH
+    IH -->|"enqueue spool.Record"| IQ
+    IQ -->|"flush batch"| SPOOL
+    W -->|"ReadRecordsFrom(offset)"| SPOOL
+    W -->|"INSERT issues, events, event_facets"| DB
+    W -->|"PublishIssueEvent"| BUS
+    BUS -->|"HandleEvent"| AE
+    AE -->|"RecordFiring"| DB
+    API -->|"SELECT"| DB
+    UI -->|"REST / SSE"| API
+```
+
+---
+
+## Component Summary
+
+| Component | File / Package | Responsibility |
+|---|---|---|
+| Ingest Handler | `internal/ingest/handler.go` | Validate API key, enforce body size limit, wrap event as `spool.Record`, enqueue to in-memory channel, return 202 |
+| Spool | `internal/spool/spool.go` | Append-only NDJSON durability layer; cursor tracking; dead-letter file; 64 MiB rotation |
+| Background Worker | `cmd/bugbarn/main.go` (`runBackgroundWorker`) | Tick every second, drain spool, process and persist records, advance cursor, rotate spool |
+| Privacy Scrubber | `internal/privacy/scrub.go` | Redact sensitive keys and PII string patterns before fingerprinting and storage |
+| Normaliser | `internal/normalize/normalize.go` | Canonical form of exception types and messages for consistent grouping |
+| Fingerprinter | `internal/fingerprint/fingerprint.go` | SHA-256 over stable JSON material derived from exception type, message, stacktrace, and allowlisted context keys |
+| Source Map Symbolication | `internal/sourcemap/symbolicate.go` | Translate minified JS stack frames to original positions using stored source maps |
+| Domain Event Bus | `internal/domainevents/bus.go` | Synchronous in-process pub/sub; delivers `IssueCreated`, `IssueRegressed`, `IssueEventRecorded` events |
+| Alert Evaluator | `internal/alert/evaluator.go` | Subscribes to bus, matches domain events to alert rules, enforces cooldown, fires webhook with retry |
+| Alert Deliverer | `internal/alert/deliverer.go` | HTTP POST to webhook URL; 3 retries with 1 s / 2 s / 4 s backoff; 5 s per-attempt timeout |
+| Storage | `internal/storage/` | SQLite persistence: upsert issues, insert events, persist facets, manage projects, API keys, alerts, log entries |
+| API Server | `internal/api/server.go` | HTTP router; session and API key authentication; CSRF middleware; REST endpoints; SSE streams |
+| Log Stream Hub | `internal/logstream/hub.go` | In-memory fan-out of log entries to SSE subscribers; buffer 64 entries; non-blocking sends |
+| Digest Scheduler | `internal/digest/scheduler.go` | Weekly summary delivery via SMTP and/or webhook |
+| Web UI | `web/src/` | TypeScript single-page application; consumes REST and SSE endpoints |
+
+---
+
+## Concurrency Model
+
+BugBarn runs as a single OS process. The table below lists every goroutine that is active during normal operation.
+
+| Goroutine | Started in | What it does |
+|---|---|---|
+| **HTTP server** | `main.go` | Accepts and handles all inbound HTTP connections; one goroutine per connection spawned by `net/http` |
+| **Ingest flusher** | `ingest.Handler.Start` | Drains the 32 768-record in-memory channel; flushes batches to the spool file every 5 ms or every 64 records |
+| **Background worker** | `main.go:runBackgroundWorker` | Ticks every second; reads new records from spool; processes, persists, and publishes domain events |
+| **Alert webhook** | `alert/evaluator.go` (per firing) | Short-lived goroutine per alert firing; HTTP POST with retry; bounded by 30 s context |
+| **Digest scheduler** | `digest.StartScheduler` | Sleeps until the next configured weekday + hour; delivers weekly digest |
+| **Login limiter cleanup** | `api.Server.cleanupLoginLimiter` | Periodically evicts stale login attempt records from the in-memory map |
+
+The domain event bus (`domainevents.Bus`) publishes **synchronously** from the background worker goroutine. Alert evaluation is initiated in that same goroutine; the actual HTTP webhook delivery is offloaded to a new goroutine per firing so a slow webhook does not stall the worker.
+
+SQLite access is serialised through a single `*sql.DB` connection (`db.SetMaxOpenConns(1)`). WAL mode allows concurrent reads from the API server while the worker holds a write transaction.
+
+---
+
+## Trade-offs
+
+**Single-node only.** There is no sharding, no replication of the application tier, and no distributed coordination. A single BugBarn binary owns the spool directory and the SQLite file. Horizontal scaling is not supported.
+
+**SQLite WAL mode.** WAL (Write-Ahead Logging) allows readers to proceed concurrently with a single writer without blocking. `synchronous=NORMAL` means SQLite syncs at checkpoints rather than after every write, which improves throughput at the cost of a small durability window (data written since the last checkpoint could be lost in a hard crash). For most self-hosted error-tracking workloads this is an acceptable trade-off.
+
+**No message broker.** The spool is a simple append-only file. It is not a distributed queue. It provides durability across process restarts but not across machine failures unless the `.data/` directory is on durable storage (network volume, Litestream-replicated block device, etc.).
+
+**Litestream for replication.** Continuous off-site replication of the SQLite database is delegated to [Litestream](https://litestream.io/), which runs as a separate process alongside BugBarn. BugBarn itself has no knowledge of Litestream; it simply writes a standard WAL-mode SQLite file. See [storage.md](storage.md) for the relevant environment variables.

--- a/site/src/content/docs/architecture/storage.md
+++ b/site/src/content/docs/architecture/storage.md
@@ -1,0 +1,407 @@
+# BugBarn — Storage
+
+## SQLite Setup
+
+BugBarn opens a single SQLite file (default `.data/bugbarn.db`) using the `modernc.org/sqlite` pure-Go driver. Three PRAGMAs are applied on every connection:
+
+```sql
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+```
+
+| PRAGMA | Value | Reason |
+|---|---|---|
+| `foreign_keys` | `ON` | Enforces referential integrity declared in the schema (cascade deletes, key constraints). SQLite disables foreign keys by default. |
+| `journal_mode` | `WAL` | Write-Ahead Logging allows API-server reads to proceed concurrently with background-worker writes without blocking. Essential because BugBarn has a continuous write path (background worker) and a continuous read path (API server). |
+| `synchronous` | `NORMAL` | SQLite syncs at WAL checkpoints rather than after every individual write. This improves write throughput at the cost of a small durability window: data written since the last checkpoint could be lost in an OS crash (not a power failure, which WAL already protects against). Acceptable for a self-hosted error tracker where a few seconds of data loss during a crash is tolerable. |
+
+The connection pool is capped at one open connection (`db.SetMaxOpenConns(1)`) to serialise all writes through a single SQLite file handle.
+
+---
+
+## Schema
+
+### `projects`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `slug` | `TEXT UNIQUE` | URL-safe identifier used as routing key during ingest (`x-bugbarn-project` header) |
+| `name` | `TEXT` | Human-readable display name |
+| `created_at` | `TEXT` | ISO 8601 timestamp |
+
+A `default` project is always created on first startup.
+
+---
+
+### `issues`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `fingerprint` | `TEXT` | SHA-256 hex digest that identifies this logical issue; unique per project |
+| `fingerprint_material` | `TEXT` | The JSON string that was hashed (for debugging) |
+| `fingerprint_explanation_json` | `TEXT` | JSON array of human-readable strings explaining which fields contributed to the fingerprint |
+| `title` | `TEXT` | Issue title derived from the first event |
+| `normalized_title` | `TEXT` | Lower-cased, whitespace-collapsed title used for deduplication display |
+| `exception_type` | `TEXT` | Normalised exception type from the first event |
+| `status` | `TEXT` | `unresolved`, `resolved`, or `ignored` |
+| `mute_mode` | `TEXT` | Optional mute behaviour (empty = not muted) |
+| `resolved_at` | `TEXT` | ISO 8601 timestamp when last resolved (empty if never) |
+| `reopened_at` | `TEXT` | ISO 8601 timestamp when last reopened |
+| `last_regressed_at` | `TEXT` | ISO 8601 timestamp of the most recent regression |
+| `regression_count` | `INTEGER` | Total number of regressions |
+| `first_seen` | `TEXT` | ISO 8601 timestamp of the first event |
+| `last_seen` | `TEXT` | ISO 8601 timestamp of the most recent event |
+| `event_count` | `INTEGER` | Total number of events grouped under this issue |
+| `representative_event_json` | `TEXT` | Full JSON of the most recent event, stored for quick display without a join |
+| `created_at` | `TEXT` | Row creation timestamp |
+| `updated_at` | `TEXT` | Row last-update timestamp |
+
+**Unique constraint:** `(project_id, fingerprint)` — one issue per fingerprint per project.
+
+---
+
+### `events`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `issue_id` | `INTEGER` | Foreign key → `issues(id)` ON DELETE CASCADE |
+| `fingerprint` | `TEXT` | Fingerprint of this event (matches parent issue) |
+| `fingerprint_material` | `TEXT` | JSON material that produced the fingerprint |
+| `fingerprint_explanation_json` | `TEXT` | Human-readable explanation of the fingerprint |
+| `received_at` | `TEXT` | When the ingest handler accepted the HTTP request |
+| `observed_at` | `TEXT` | Timestamp from the event payload itself |
+| `severity` | `TEXT` | Severity string from the event |
+| `message` | `TEXT` | Human-readable message |
+| `regressed` | `INTEGER` | `1` if this event caused a regression (issue re-opened after resolve); `0` otherwise |
+| `event_json` | `TEXT` | Full normalised event payload as JSON |
+| `user_json` | `TEXT` | User context extracted from the event |
+| `breadcrumbs_json` | `TEXT` | Breadcrumbs extracted from the event |
+| `created_at` | `TEXT` | Row creation timestamp |
+
+---
+
+### `event_facets`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `event_id` | `INTEGER` | Foreign key → `events(id)` ON DELETE CASCADE |
+| `issue_id` | `INTEGER` | Foreign key → `issues(id)` ON DELETE CASCADE |
+| `section` | `TEXT` | Grouping label derived from the key prefix (e.g. `http`, `service`) |
+| `facet_key` | `TEXT` | Attribute name (e.g. `http.route`, `severity`) |
+| `facet_value` | `TEXT` | Attribute value |
+
+See [Event Facets](#event-facets) below for cardinality caps and the list of extracted keys.
+
+---
+
+### `releases`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `name` | `TEXT` | Release name |
+| `environment` | `TEXT` | Environment label |
+| `observed_at` | `TEXT` | When the release was first observed |
+| `version` | `TEXT` | Version string |
+| `commit_sha` | `TEXT` | Git commit SHA |
+| `url` | `TEXT` | URL to release (e.g. GitHub tag) |
+| `notes` | `TEXT` | Release notes |
+| `created_by` | `TEXT` | Who triggered the release |
+| `created_at` | `TEXT` | Row creation timestamp |
+
+---
+
+### `alerts`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `name` | `TEXT` | Human-readable alert name |
+| `enabled` | `INTEGER` | `1` = active; `0` = disabled |
+| `severity` | `TEXT` | Severity filter (may be empty = any severity) |
+| `rule_json` | `TEXT` | Reserved structured rule JSON |
+| `webhook_url` | `TEXT` | HTTP endpoint to POST when the alert fires |
+| `condition` | `TEXT` | `new_issue`, `regression`, or `event_count_exceeds` |
+| `threshold` | `INTEGER` | For `event_count_exceeds`: fires when `event_count > threshold` |
+| `cooldown_minutes` | `INTEGER` | Minimum minutes between firings for the same alert/issue pair |
+| `last_fired_at` | `TEXT` | ISO 8601 timestamp of the most recent firing (any issue) |
+| `created_at` | `TEXT` | Row creation timestamp |
+| `updated_at` | `TEXT` | Row last-update timestamp |
+
+---
+
+### `alert_firings`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `alert_id` | `INTEGER` | References `alerts(id)` |
+| `issue_id` | `INTEGER` | References `issues(id)` |
+| `fired_at` | `TEXT` | ISO 8601 timestamp of the firing |
+
+Used to enforce per-alert, per-issue cooldowns.
+
+---
+
+### `settings`
+
+| Column | Type | Description |
+|---|---|---|
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `key` | `TEXT` | Setting name |
+| `value` | `TEXT` | Setting value |
+| `updated_at` | `TEXT` | Last-update timestamp |
+
+**Primary key:** `(project_id, key)`.
+
+---
+
+### `source_maps`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)` ON DELETE CASCADE |
+| `release` | `TEXT` | Release string the source map applies to |
+| `dist` | `TEXT` | Distribution identifier (may be empty) |
+| `bundle_url` | `TEXT` | URL of the minified bundle this map corresponds to |
+| `name` | `TEXT` | File name |
+| `content_type` | `TEXT` | MIME type |
+| `source_map_blob` | `BLOB` | Raw source map bytes |
+| `size_bytes` | `INTEGER` | Size of the blob |
+| `created_at` | `TEXT` | Upload timestamp |
+
+---
+
+### `users`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `username` | `TEXT UNIQUE` | Login username |
+| `password_bcrypt` | `TEXT` | bcrypt hash of the password |
+| `created_at` | `TEXT` | Row creation timestamp |
+| `updated_at` | `TEXT` | Row last-update timestamp |
+
+---
+
+### `api_keys`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `name` | `TEXT` | Human-readable label |
+| `project_id` | `INTEGER` | Foreign key → `projects(id)`. Requests authenticated with this key are scoped to this project |
+| `key_sha256` | `TEXT UNIQUE` | SHA-256 hex digest of the plaintext key. The plaintext is never stored |
+| `scope` | `TEXT` | `full` (all endpoints) or `ingest` (`POST /api/v1/events` and `POST /api/v1/logs` only) |
+| `created_at` | `TEXT` | Row creation timestamp |
+| `last_used_at` | `TEXT` | Updated on every successful authentication |
+
+---
+
+### `log_entries`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `INTEGER PK` | Auto-increment primary key |
+| `project_id` | `INTEGER` | Project that owns this log entry |
+| `received_at` | `TEXT` | ISO 8601 timestamp when BugBarn received the entry |
+| `level_num` | `INTEGER` | Numeric log level (default 30 = info) |
+| `level` | `TEXT` | Level string (e.g. `info`, `warn`, `error`) |
+| `message` | `TEXT` | Log message |
+| `data_json` | `TEXT` | Arbitrary structured data as JSON |
+
+---
+
+## Fingerprinting Algorithm
+
+Fingerprinting groups distinct events into the same logical issue. Two events share a fingerprint if and only if their normalised exception type, message, stacktrace, and stable context produce the same SHA-256 digest.
+
+### Input Material
+
+The fingerprinter builds a `material` struct:
+
+```go
+type material struct {
+    ExceptionType string            `json:"exceptionType,omitempty"`
+    Message       string            `json:"message,omitempty"`
+    Stacktrace    []string          `json:"stacktrace,omitempty"`
+    Context       map[string]string `json:"context,omitempty"`
+}
+```
+
+- **`ExceptionType`** — `normalize(event.Exception.Type)`
+- **`Message`** — `normalize(event.Exception.Message)`, falling back to `normalize(event.Message)` when the exception message is empty
+- **`Stacktrace`** — for each frame: `normalize(frame.Module) + ":" + normalize(frame.Function) + ":" + normalizePath(frame.File)`; empty parts are omitted; frames that produce an empty string are skipped
+- **`Context`** — the subset of fields from `event.Resource` and `event.Attributes` whose keys appear in the stable-context allowlist (see below)
+
+### Stable Context Allowlist
+
+Only these keys are included in the context map, preventing high-cardinality values (e.g. request IDs) from causing fingerprint drift:
+
+```
+environment, host, http.method, http.route, http.status_code,
+region, release, route, service.name, service.namespace,
+status_code, user_agent.family, version
+```
+
+Key matching is done after normalisation and also accepts suffix matches (e.g. `foo.environment` matches `environment`).
+
+### Normalisation Steps
+
+Normalisation is applied to every string before it contributes to the fingerprint material:
+
+1. Lowercase and trim whitespace
+2. UUIDs → `<id>`
+3. IPv4 addresses → `<ip>`
+4. Hex addresses (`0x` followed by 6+ hex digits) → `<hex>`
+5. Long numbers (4+ consecutive digits as a word) → `<num>`
+6. Privacy-scrubber placeholders (`[redacted-id]`, `[redacted-ip]`, `[redacted-email]`, `[redacted-secret]`) → `<redacted>`
+7. Collapse runs of whitespace to a single space
+
+Path normalisation additionally:
+- Replaces backslashes with forward slashes
+- Replaces numeric path segments (`/123`) with `/:num`
+
+### Digest
+
+```
+fingerprint = hex( SHA-256( JSON.Marshal(material) ) )
+```
+
+The JSON serialisation is deterministic because map keys are iterated in sorted order by the Go JSON encoder and by the fingerprinter's explicit key sorting.
+
+The raw JSON material string and a human-readable explanation array are also stored alongside the fingerprint in `issues.fingerprint_material` and `issues.fingerprint_explanation_json` for debugging.
+
+---
+
+## Event Facets
+
+Facets are a flat set of key/value pairs extracted from each event and stored in the `event_facets` table. They enable the API and UI to offer filtered views of issues (e.g. "show all issues where `http.route = /api/v1/users`") without requiring a full-text scan of the `event_json` column.
+
+### Extracted Keys
+
+The following fields are extracted from each event:
+
+**From `event.Resource`:**
+- `host.name`
+- `service.name`
+- `telemetry.sdk.language`
+- `deployment.environment`
+
+**From `event.Attributes`:**
+- `http.route`
+- `http.status_code`
+- `http.method`
+- `user_agent.original`
+
+**Derived:**
+- `severity` — from the event severity field
+- `environment` — attributes value preferred over resource value
+- `release` — from attributes
+
+### Cardinality Caps
+
+To prevent unbounded table growth, two hard limits are enforced per project within a transaction on every ingest:
+
+| Cap | Limit |
+|---|---|
+| Distinct facet keys per project | **50** |
+| Distinct values per facet key per project | **10 000** |
+
+If either limit is reached, the facet entry is silently skipped. The event itself is still persisted in full; only the facet index entry is omitted.
+
+---
+
+## The Event Spool
+
+### Purpose
+
+The spool decouples HTTP ingest from SQLite writes. The ingest handler never touches the database; it simply appends a record to a file and returns `202 Accepted`. The background worker reads from the spool independently.
+
+### File Format
+
+Records are stored as append-only newline-delimited JSON (NDJSON) in `.data/spool/ingest.ndjson`. Each line is one serialised `spool.Record`:
+
+```json
+{"ingestId":"a1b2c3d4e5f6","receivedAt":"2026-04-26T10:00:00Z","contentType":"application/json","remoteAddr":"10.0.0.1:54321","contentLength":512,"bodyBase64":"eyJ...","projectSlug":"my-app"}
+```
+
+| Field | Description |
+|---|---|
+| `ingestId` | 24-hex-character random ID generated at ingest time |
+| `receivedAt` | UTC timestamp when the HTTP request was accepted |
+| `contentType` | `Content-Type` header from the request |
+| `remoteAddr` | Client IP and port |
+| `contentLength` | Body size in bytes |
+| `bodyBase64` | Base64-encoded raw request body |
+| `projectSlug` | Value of the `X-BugBarn-Project` header, if present |
+
+### Cursor
+
+`.data/spool/cursor.json` stores a single byte offset:
+
+```json
+{"offset": 1048576}
+```
+
+On startup the background worker reads this file to resume from where it left off. After each successfully processed record the worker writes the new offset to `cursor.json`. This ensures that a crash between processing and writing the cursor causes at-most-once re-processing of the last record rather than silent loss.
+
+### Rotation
+
+When the active spool file exceeds **64 MiB**, the worker renames `ingest.ndjson` to `ingest-YYYYMMDDTHHMMSSZ.ndjson` (UTC timestamp) and opens a fresh `ingest.ndjson`. The cursor is not reset on rotation; old rotated segments are left in the spool directory for manual archival or deletion.
+
+### Dead-Letter File
+
+If a record fails processing (decode, normalise, or persist) **3 times**, it is written to `.data/spool/deadletter.ndjson` and the cursor advances past it. The dead-letter file preserves the original `spool.Record` in full so that the record can be inspected and replayed manually.
+
+### Back-Pressure (429)
+
+The ingest handler maintains a 32 768-record in-memory channel between the HTTP goroutines and the spool-flusher goroutine. If that channel is full when a new request arrives, the handler responds with:
+
+```
+HTTP 429 Too Many Requests
+Retry-After: 1
+```
+
+The `BUGBARN_MAX_SPOOL_BYTES` environment variable sets an additional byte limit on the spool file itself. If adding a batch would exceed this limit, `spool.AppendBatch` returns `spool.ErrFull`.
+
+---
+
+## Litestream Replication
+
+BugBarn does not bundle any replication logic. Continuous off-site replication is handled by [Litestream](https://litestream.io/), a separate binary that streams SQLite WAL frames to an object store (S3, GCS, Azure Blob, SFTP, etc.) in near-real time.
+
+Litestream is configured entirely via its own configuration file or environment variables. BugBarn has no knowledge of it; BugBarn simply operates on the SQLite file as normal. Common Litestream environment variables used alongside BugBarn deployments:
+
+| Variable | Purpose |
+|---|---|
+| `LITESTREAM_ACCESS_KEY_ID` | S3-compatible access key |
+| `LITESTREAM_SECRET_ACCESS_KEY` | S3-compatible secret key |
+| `LITESTREAM_REPLICA_URL` | Replica destination (e.g. `s3://bucket/bugbarn.db`) |
+
+See the [Litestream documentation](https://litestream.io/reference/config/) for the full reference.
+
+---
+
+## Index Strategy
+
+| Index | Table | Columns | Purpose |
+|---|---|---|---|
+| `idx_issues_project_last_seen` | `issues` | `(project_id, last_seen DESC, id DESC)` | Powers the default issues list, ordered by most recently active within a project |
+| `idx_events_issue_id` | `events` | `(project_id, issue_id, id ASC)` | Fetches the event history for a single issue in chronological order |
+| `idx_events_project_received_at` | `events` | `(project_id, received_at DESC, id DESC)` | Powers the recent-events feed ordered by ingest time within a project |
+| `idx_releases_project_observed_at` | `releases` | `(project_id, observed_at DESC, id DESC)` | Lists releases for a project ordered by most recent |
+| `idx_event_facets_lookup` | `event_facets` | `(project_id, section, facet_key, facet_value)` | Supports facet key/value queries and cardinality cap checks |
+| `idx_alert_firings_lookup` | `alert_firings` | `(alert_id, issue_id, fired_at DESC)` | Cooldown check: most recent firing for a given alert/issue pair |
+| `idx_log_entries_project_id` | `log_entries` | `(project_id, id DESC)` | Paginates log entries for a project in reverse-insertion order |

--- a/site/src/content/docs/ci-integration.md
+++ b/site/src/content/docs/ci-integration.md
@@ -1,0 +1,315 @@
+# CI/CD Integration
+
+## Prerequisites
+
+Every pipeline that talks to BugBarn needs an API key. Create one with the CLI (run inside the BugBarn pod or via `kubectl exec`):
+
+```sh
+bugbarn apikey create --project <project-slug> --name "my-app-staging"
+# Key (shown once, store securely): <64-hex-char string>
+```
+
+Store that value as a **repository secret** (e.g. `BUGBARN_API_KEY`) and the BugBarn base URL as a **repository variable** (e.g. `BUGBARN_ENDPOINT`).
+
+---
+
+## Multi-Project Setup
+
+BugBarn isolates data by **project**. Every API key is bound to exactly one project at creation time — all events, releases, and source maps ingested with that key are stored under the corresponding project.
+
+This model maps naturally onto monorepos with multiple sites or services: create one BugBarn project per component and one API key per component per environment.
+
+### Create projects
+
+```sh
+# Create projects via the CLI (run inside the BugBarn pod)
+kubectl -n bugbarn exec deploy/bugbarn -- bugbarn project create --slug frontend --name "Frontend"
+kubectl -n bugbarn exec deploy/bugbarn -- bugbarn project create --slug backend  --name "Backend"
+kubectl -n bugbarn exec deploy/bugbarn -- bugbarn project create --slug marketing --name "Marketing site"
+```
+
+### Create API keys per project per environment
+
+```sh
+# testing environment
+kubectl -n bugbarn-testing exec deploy/bugbarn -- \
+  bugbarn apikey create --project frontend  --name "frontend-testing"
+kubectl -n bugbarn-testing exec deploy/bugbarn -- \
+  bugbarn apikey create --project backend   --name "backend-testing"
+
+# staging environment
+kubectl -n bugbarn-staging exec deploy/bugbarn -- \
+  bugbarn apikey create --project frontend  --name "frontend-staging"
+kubectl -n bugbarn-staging exec deploy/bugbarn -- \
+  bugbarn apikey create --project backend   --name "backend-staging"
+```
+
+Store each key as a separate repository secret, e.g. `BUGBARN_FRONTEND_API_KEY`, `BUGBARN_BACKEND_API_KEY`.
+
+### Monorepo workflow pattern
+
+In a monorepo that deploys multiple sites, use a matrix or parallel jobs — one per component — each with its own API key secret:
+
+```yaml
+jobs:
+  deploy:
+    strategy:
+      matrix:
+        include:
+          - component: frontend
+            secret_name: BUGBARN_FRONTEND_API_KEY
+          - component: backend
+            secret_name: BUGBARN_BACKEND_API_KEY
+    steps:
+      # ... build and deploy steps ...
+
+      - name: Post release marker to BugBarn
+        env:
+          BUGBARN_ENDPOINT: ${{ vars.BUGBARN_ENDPOINT }}
+          BUGBARN_API_KEY: ${{ secrets[matrix.secret_name] }}
+        run: |
+          curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
+            -H "Content-Type: application/json" \
+            -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+            -d "{
+              \"name\": \"${GITHUB_SHA:0:7}\",
+              \"environment\": \"staging\",
+              \"version\": \"${GITHUB_SHA}\",
+              \"commitSha\": \"${GITHUB_SHA}\",
+              \"url\": \"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}\",
+              \"notes\": \"Deployed ${{ matrix.component }}\"
+            }" || true
+```
+
+The key determines the project — no extra header is needed.
+
+---
+
+## Marking Releases
+
+A release marker ties a commit SHA to a deploy event. BugBarn displays these on the issues timeline so you can immediately see which deploy introduced or fixed an error.
+
+### curl
+
+```sh
+curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
+  -H "Content-Type: application/json" \
+  -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+  -d "{
+    \"name\": \"${GITHUB_SHA:0:7}\",
+    \"environment\": \"${DEPLOY_ENV}\",
+    \"version\": \"${GITHUB_SHA}\",
+    \"commitSha\": \"${GITHUB_SHA}\",
+    \"url\": \"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}\",
+    \"notes\": \"Deployed by GitHub Actions run #${GITHUB_RUN_NUMBER}\"
+  }"
+```
+
+### GitHub Actions step
+
+```yaml
+- name: Post release marker to BugBarn
+  if: vars.BUGBARN_ENDPOINT != ''
+  env:
+    BUGBARN_ENDPOINT: ${{ vars.BUGBARN_ENDPOINT }}
+    BUGBARN_API_KEY: ${{ secrets.BUGBARN_API_KEY }}
+    DEPLOY_ENV: staging   # or testing, production
+  run: |
+    curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
+      -H "Content-Type: application/json" \
+      -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+      -d "{
+        \"name\": \"${GITHUB_SHA:0:7}\",
+        \"environment\": \"${DEPLOY_ENV}\",
+        \"version\": \"${GITHUB_SHA}\",
+        \"commitSha\": \"${GITHUB_SHA}\",
+        \"url\": \"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}\",
+        \"notes\": \"Deployed by GitHub Actions run #${GITHUB_RUN_NUMBER}\"
+      }" || echo "BugBarn release marker skipped"
+```
+
+The `|| echo` keeps a BugBarn outage from failing a successful deploy.
+
+---
+
+## Uploading Source Maps
+
+Source maps let BugBarn display original file names, line numbers, and source snippets in stack traces instead of minified noise.
+
+### API contract
+
+```
+POST /api/v1/source-maps
+Content-Type: multipart/form-data
+X-BugBarn-Api-Key: <key>
+
+Fields:
+  release          string (required)  — must match the name used in the release marker
+  bundle_url       string (required)  — public URL of the corresponding minified JS bundle
+  source_map       file   (required)  — .map file contents
+  source_map_name  string (optional)  — filename hint stored alongside the map
+  dist             string (optional)  — variant/distribution, e.g. "web"
+```
+
+One request per source map file. The `bundle_url` is used at symbolication time to match a stack frame's file URL against the right source map.
+
+### curl — single file
+
+```sh
+curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/source-maps" \
+  -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+  -F "release=${GITHUB_SHA}" \
+  -F "bundle_url=https://example.com/_next/static/chunks/main.js" \
+  -F "source_map_name=main.js.map" \
+  -F "source_map=@.next/static/chunks/main.js.map"
+```
+
+### TypeScript SDK (Node.js build scripts)
+
+```ts
+import { createSourceMapUploader } from "@bugbarn/typescript";
+
+const upload = createSourceMapUploader({
+  endpoint: process.env.BUGBARN_ENDPOINT,
+  apiKey: process.env.BUGBARN_API_KEY!,
+  release: process.env.GITHUB_SHA!,
+});
+
+// Pass sourceMapPath (file path) — not sourceMap (content string)
+await upload({
+  bundleUrl: "https://example.com/_next/static/chunks/main.js",
+  sourceMapPath: ".next/static/chunks/main.js.map",
+  sourceMapName: "main.js.map",
+});
+```
+
+### Batch upload — all Next.js source maps
+
+Next.js emits source maps under `.next/static/` when `productionBrowserSourceMaps: true` is set in `next.config.js`. To upload all of them:
+
+```sh
+#!/bin/sh
+# upload-sourcemaps.sh — run after `next build`, before containerizing
+set -e
+RELEASE="${GITHUB_SHA}"
+PUBLIC_BASE_URL="https://example.com"   # public origin serving /_next/...
+
+find .next/static -name "*.js.map" | while read -r map_file; do
+  # .next/static/chunks/foo.js.map → https://example.com/_next/static/chunks/foo.js
+  bundle_path="${map_file#.next/}"
+  bundle_url="${PUBLIC_BASE_URL}/_next/${bundle_path%.map}"
+
+  curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/source-maps" \
+    -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+    -F "release=${RELEASE}" \
+    -F "bundle_url=${bundle_url}" \
+    -F "source_map_name=$(basename "${map_file}")" \
+    -F "source_map=@${map_file}" || echo "  warning: upload failed for ${bundle_url}"
+done
+```
+
+### Extracting source maps from a Docker image
+
+If source maps are only available inside the built image (e.g. they were stripped from the repo before the CI run), extract them with `docker create` / `docker cp` before uploading:
+
+```sh
+container=$(docker create "${IMAGE}:${TAG}")
+docker cp "${container}:/app/.next/static" ./extracted-static
+docker rm "${container}"
+
+find extracted-static -name "*.js.map" | while read -r map_file; do
+  bundle_path="${map_file#extracted-static/}"
+  bundle_url="${PUBLIC_BASE_URL}/_next/${bundle_path%.map}"
+  curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/source-maps" \
+    -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+    -F "release=${GITHUB_SHA}" \
+    -F "bundle_url=${bundle_url}" \
+    -F "source_map_name=$(basename "${map_file}")" \
+    -F "source_map=@${map_file}" || true
+done
+```
+
+### When to upload
+
+Upload source maps **after the build, before or alongside the release marker**. They do not need to be uploaded inside the Docker build. The recommended order in a workflow step:
+
+1. Build the application (Next.js, webpack, etc.)
+2. Upload source maps → BugBarn
+3. Package / push the Docker image (strip source maps from the image if desired)
+4. Deploy to the target environment
+5. Post release marker → BugBarn
+
+---
+
+## Full GitHub Actions example
+
+```yaml
+jobs:
+  build-and-deploy:
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_APP_ENV: staging
+
+      - name: Upload source maps to BugBarn
+        if: vars.BUGBARN_ENDPOINT != ''
+        env:
+          BUGBARN_ENDPOINT: ${{ vars.BUGBARN_ENDPOINT }}
+          BUGBARN_API_KEY: ${{ secrets.BUGBARN_API_KEY }}
+          PUBLIC_BASE_URL: https://example.com
+        run: |
+          find .next/static -name "*.js.map" | while read -r map_file; do
+            bundle_path="${map_file#.next/}"
+            bundle_url="${PUBLIC_BASE_URL}/_next/${bundle_path%.map}"
+            curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/source-maps" \
+              -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+              -F "release=${GITHUB_SHA}" \
+              -F "bundle_url=${bundle_url}" \
+              -F "source_map_name=$(basename "${map_file}")" \
+              -F "source_map=@${map_file}" || true
+          done
+
+      - name: Build and push Docker image
+        run: docker buildx build ...
+
+      - name: Deploy
+        run: kubectl apply ...
+
+      - name: Post release marker to BugBarn
+        if: vars.BUGBARN_ENDPOINT != ''
+        env:
+          BUGBARN_ENDPOINT: ${{ vars.BUGBARN_ENDPOINT }}
+          BUGBARN_API_KEY: ${{ secrets.BUGBARN_API_KEY }}
+          DEPLOY_ENV: staging
+        run: |
+          curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
+            -H "Content-Type: application/json" \
+            -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+            -d "{
+              \"name\": \"${GITHUB_SHA:0:7}\",
+              \"environment\": \"${DEPLOY_ENV}\",
+              \"version\": \"${GITHUB_SHA}\",
+              \"commitSha\": \"${GITHUB_SHA}\",
+              \"url\": \"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}\",
+              \"notes\": \"Deployed by GitHub Actions run #${GITHUB_RUN_NUMBER}\"
+            }" || true
+```
+
+---
+
+## Environment Variables Reference
+
+| Name | Where to set | Description |
+|------|-------------|-------------|
+| `BUGBARN_ENDPOINT` | Repository or environment variable | Base URL of the BugBarn instance, e.g. `https://bugbarn.example.com`. Omit trailing slash. |
+| `BUGBARN_API_KEY` | Repository or environment secret | API key created via `bugbarn apikey create --project <slug>`. Never commit this value. |
+
+For pipelines that deploy to multiple environments (testing, staging), use GitHub's **environment-scoped** secrets and variables. Set `BUGBARN_ENDPOINT` and `BUGBARN_API_KEY` at the environment level so each deploy automatically uses the right instance and key.
+
+For monorepos with multiple components, use **per-component secrets** (e.g. `BUGBARN_FRONTEND_API_KEY`, `BUGBARN_BACKEND_API_KEY`). Each key was created against a specific project so BugBarn routes ingested data accordingly — no extra configuration needed at call time.

--- a/site/src/content/docs/deployment/configuration.md
+++ b/site/src/content/docs/deployment/configuration.md
@@ -1,0 +1,164 @@
+# BugBarn Configuration Reference
+
+## Config File Locations
+
+BugBarn reads configuration from files before applying environment variables. Files are processed in order; values already present in the process environment always take precedence over file values.
+
+| Location | Purpose |
+|---|---|
+| `/etc/bugbarn/bugbarn.conf` | System-wide (e.g., set by `systemd EnvironmentFile`) |
+| `~/.config/bugbarn/bugbarn.conf` | Per-user (XDG config dir, Linux and macOS) |
+
+Environment variables have the highest precedence and override both config files.
+
+### File Format
+
+Plain `KEY=VALUE` pairs, one per line. Blank lines and lines starting with `#` are ignored. Values may be wrapped in single or double quotes.
+
+```
+# BugBarn configuration
+BUGBARN_ADMIN_USERNAME=admin
+BUGBARN_ADMIN_PASSWORD_BCRYPT=$2y$10$...
+BUGBARN_SESSION_SECRET=somelong32bytesecret
+BUGBARN_PUBLIC_URL=https://bugbarn.example.com
+BUGBARN_ALLOWED_ORIGINS=https://app.example.com,https://staging.example.com
+```
+
+---
+
+## Environment Variable Reference
+
+### Core
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BUGBARN_ADDR` | `:8080` | No | TCP address the HTTP server listens on. |
+| `BUGBARN_DB_PATH` | `.data/bugbarn.db` | No | Path to the SQLite database file. |
+| `BUGBARN_SPOOL_DIR` | `.data/spool` | No | Directory used for the event spool (write-ahead buffer). |
+| `BUGBARN_MAX_BODY_BYTES` | `1048576` (1 MiB) | No | Maximum size of an ingest request body in bytes. Requests larger than this value are rejected with `413`. |
+| `BUGBARN_MAX_SPOOL_BYTES` | `0` (unlimited) | No | Maximum total size of the spool directory in bytes. When set and exceeded, ingest requests return `429 Too Many Requests` with a `Retry-After` header. Set this to protect disk space on constrained nodes. |
+| `BUGBARN_PUBLIC_URL` | — | No | Base URL of the BugBarn instance (e.g., `https://bugbarn.example.com`). Used to build links in alert notifications and digest emails. |
+
+#### BUGBARN_MAX_SPOOL_BYTES
+
+Set this variable when you want a hard ceiling on disk usage by the event spool. Useful in production where disk is shared with other workloads or where you prefer to drop events over crashing. When the limit is exceeded, the ingest endpoint returns `429` with `Retry-After: 60`. SDKs and clients that respect `Retry-After` will back off and retry automatically.
+
+---
+
+### Authentication
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BUGBARN_API_KEY` | — | No | Static ingest API key in plaintext. BugBarn hashes it with SHA-256 at startup. Mutually exclusive with `BUGBARN_API_KEY_SHA256`. |
+| `BUGBARN_API_KEY_SHA256` | — | No | Static ingest API key pre-hashed as a hex-encoded SHA-256 digest. Use this instead of `BUGBARN_API_KEY` to avoid storing the plaintext value. |
+| `BUGBARN_ADMIN_USERNAME` | — | No | Username for the web UI admin account. |
+| `BUGBARN_ADMIN_PASSWORD` | — | No | Admin password in plaintext. BugBarn bcrypts it at startup. Mutually exclusive with `BUGBARN_ADMIN_PASSWORD_BCRYPT`. |
+| `BUGBARN_ADMIN_PASSWORD_BCRYPT` | — | No | Admin password pre-hashed as a bcrypt string. Use this to avoid storing the plaintext password. |
+| `BUGBARN_SESSION_SECRET` | — | No | HMAC key used to sign session tokens. Must be a long, random string (at minimum 32 bytes of entropy). **If unset, a random key is generated at startup — sessions will not survive process restarts.** In production, always set this to a stable value so users are not logged out on redeploy. |
+| `BUGBARN_SESSION_TTL_SECONDS` | `43200` (12 h) | No | Session lifetime in seconds. After expiry the user must log in again. |
+
+#### BUGBARN_SESSION_SECRET
+
+Without a stable `BUGBARN_SESSION_SECRET`, every restart of the BugBarn process invalidates all existing sessions. In a Kubernetes environment this means every pod restart logs every user out. Generate a value with:
+
+```sh
+openssl rand -hex 32
+```
+
+Store the result in your secrets manager and inject it as an environment variable.
+
+---
+
+### CORS
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BUGBARN_ALLOWED_ORIGINS` | — | No | Comma-separated list of origins permitted to make credentialed (session-cookie) requests. Example: `https://app.example.com,https://staging.example.com`. If unset, only same-origin requests are allowed with credentials. The ingest endpoints (`POST /api/v1/events`, `POST /api/v1/logs`) always allow all origins regardless of this setting. |
+
+---
+
+### Digest
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BUGBARN_DIGEST_ENABLED` | `false` | No | Set to `true` to enable weekly email digests. SMTP must also be configured. |
+| `BUGBARN_DIGEST_TO` | — | Yes (if digest enabled) | Recipient email address for digest emails. |
+| `BUGBARN_DIGEST_DAY` | `0` (Sunday) | No | Day of the week to send the digest (0 = Sunday, 1 = Monday, …, 6 = Saturday). |
+| `BUGBARN_DIGEST_HOUR` | `8` | No | Hour of the day (UTC, 0–23) to send the digest. |
+| `BUGBARN_DIGEST_WEBHOOK_URL` | — | No | Optional webhook URL. When set, the digest payload is also `POST`ed to this URL as JSON. |
+
+---
+
+### SMTP
+
+These variables do not use the `BUGBARN_` prefix, matching conventions used by other services (e.g., `rapid-root`).
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `SMTP_HOST` | — | Yes (if digest enabled) | SMTP server hostname. |
+| `SMTP_PORT` | `587` | No | SMTP server port. |
+| `SMTP_USER` | — | Yes (if digest enabled) | SMTP authentication username. |
+| `SMTP_PASS` | — | Yes (if digest enabled) | SMTP authentication password. |
+| `SMTP_FROM` | value of `SMTP_USER` | No | From address used in outgoing digest emails. Defaults to `SMTP_USER` if not set. |
+
+---
+
+### Self-Reporting
+
+BugBarn can report its own unhandled errors to a BugBarn instance (including itself).
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `BUGBARN_SELF_ENDPOINT` | — | No | URL of the BugBarn instance to report own errors to (e.g., `https://bugbarn.example.com`). |
+| `BUGBARN_SELF_API_KEY` | — | No | API key for the self-reporting instance. Both `BUGBARN_SELF_ENDPOINT` and `BUGBARN_SELF_API_KEY` must be set to enable self-reporting. |
+
+---
+
+### Litestream
+
+These variables are consumed by the Litestream process that runs alongside BugBarn (as a sidecar or wrapper). BugBarn itself does not read them.
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `LITESTREAM_REPLICA_PATH` | — | Yes (if Litestream enabled) | S3-compatible path for the database replica (e.g., `s3://bucket/production/bugbarn.db`). |
+| `LITESTREAM_ACCESS_KEY_ID` | — | Yes (if Litestream enabled) | Access key ID for the object-storage backend. |
+| `LITESTREAM_SECRET_ACCESS_KEY` | — | Yes (if Litestream enabled) | Secret access key for the object-storage backend. |
+
+---
+
+## CLI Commands
+
+```
+bugbarn [flags]                                          # Start the server
+bugbarn version                                          # Print version and build time
+bugbarn worker-once                                      # Process the spool once and exit (useful for debugging)
+bugbarn user create --username=X --password=Y            # Create or update an admin user in the database
+bugbarn apikey create --project=SLUG --name=NAME \
+        --scope=ingest|full                              # Create a new API key
+bugbarn project create --slug=SLUG --name=NAME           # Create a new project
+```
+
+`bugbarn worker-once` reads all pending spool records, processes them into the database, and exits. It is useful for replaying events after a spool backup restore or for debugging ingestion issues without running the full server.
+
+---
+
+## Resource Sizing Guidance
+
+The default resource requests (100m CPU / 128 Mi RAM) are appropriate for:
+
+- Low-to-medium traffic (up to a few hundred events per minute).
+- A single project with up to tens of thousands of issues in the database.
+- Running Litestream in the same pod without heavy replication load.
+
+**Consider increasing memory limits when:**
+
+- The issue list query is slow and you see SQLite page-cache pressure.
+- You are ingesting many events per second with large payloads close to the 1 MiB limit.
+- You are running source-map upload and lookup for many releases simultaneously.
+
+**Consider increasing CPU limits when:**
+
+- You see throttling (`cpu_cfs_throttled_seconds_total` rising) during peak ingest bursts.
+- bcrypt login operations are noticeably slow (bcrypt is CPU-intensive by design).
+
+A typical small production deployment fits comfortably within the defaults. Start there and adjust based on observed usage.

--- a/site/src/content/docs/deployment/kubernetes.md
+++ b/site/src/content/docs/deployment/kubernetes.md
@@ -1,0 +1,172 @@
+# Kubernetes Deployment
+
+## Overview
+
+A full BugBarn deployment consists of the following Kubernetes resources:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| Deployment | `bugbarn` | BugBarn service (API + background worker) |
+| Deployment | `bugbarn-web` | Web frontend (static asset server) |
+| PersistentVolumeClaim | `bugbarn-data` | Spool directory and SQLite database (1 Gi) |
+| Service | `bugbarn` | ClusterIP for the API pod |
+| Service | `bugbarn-web` | ClusterIP for the web pod |
+| Ingress | `bugbarn` | Routes `/api/*` to the service pod and `/` to the web pod |
+| Secret | `bugbarn-secrets` | Core auth and Litestream credentials |
+| Secret | `smtp-secret` | SMTP credentials and digest configuration |
+
+All resources live in a dedicated namespace (e.g., `bugbarn-production`).
+
+---
+
+## Deployment Strategy
+
+Both deployments use `strategy.type: Recreate`.
+
+**Why Recreate and not RollingUpdate?** BugBarn uses SQLite as its database. SQLite allows only one writer at a time, and the database file is stored on a `ReadWriteOnce` PVC. Running two pods simultaneously — even briefly during a rolling update — would cause the second pod to fail to acquire the write lock on the database and the PVC mount. `Recreate` terminates the existing pod before starting the new one, ensuring clean single-writer semantics.
+
+> Never change the strategy to `RollingUpdate` for the `bugbarn` deployment.
+
+---
+
+## Health Checks
+
+Both probes target `GET /api/v1/health`, which returns `{"status":"ok"}` when the server is ready.
+
+| Probe | Initial Delay | Period | Failure Threshold |
+|---|---|---|---|
+| Liveness | 30 s | 20 s | 3 |
+| Readiness | 10 s | 10 s | 3 (default) |
+
+The liveness probe has a longer initial delay to give Litestream time to restore the database from the replica before BugBarn starts serving traffic. The readiness probe uses a shorter delay so the pod is marked ready as soon as the server accepts requests.
+
+---
+
+## Volume Setup
+
+The `bugbarn-data` PVC is mounted at `/var/lib/bugbarn` inside the service container. It stores:
+
+- **SQLite database** — at `/var/lib/bugbarn/bugbarn.db` (set via `BUGBARN_DB_PATH`).
+- **Event spool** — at `/var/lib/bugbarn/spool` (set via `BUGBARN_SPOOL_DIR`).
+
+The PVC is provisioned with `storageClassName: local-path` and `accessModes: [ReadWriteOnce]`, which is appropriate for a single-replica SQLite workload.
+
+The web deployment mounts a separate `bugbarn-packages` PVC (256 Mi) at `/srv/packages` for serving source-map packages.
+
+---
+
+## Secrets Management
+
+Secrets are stored as SOPS-encrypted YAML files in the repository and decrypted during the CI/CD deployment workflow before being applied with `kubectl apply`.
+
+### bugbarn-secrets
+
+Contains core authentication and Litestream replication credentials:
+
+- `BUGBARN_API_KEY`
+- `BUGBARN_ADMIN_USERNAME`
+- `BUGBARN_ADMIN_PASSWORD_BCRYPT`
+- `BUGBARN_SESSION_SECRET`
+- `LITESTREAM_ACCESS_KEY_ID`
+- `LITESTREAM_SECRET_ACCESS_KEY`
+
+### smtp-secret
+
+Contains SMTP credentials and digest configuration:
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_FROM`
+- `BUGBARN_DIGEST_ENABLED`
+- `BUGBARN_DIGEST_TO`
+- `BUGBARN_DIGEST_WEBHOOK_URL`
+
+> After patching either secret, always run `kubectl rollout restart deployment/bugbarn` so the pod picks up the new values.
+
+---
+
+## Litestream
+
+[Litestream](https://litestream.io) provides continuous streaming replication of the SQLite database to an S3-compatible object store. It runs alongside BugBarn — either as a sidecar container or as a wrapper process — and is configured entirely through environment variables injected from `bugbarn-secrets`.
+
+Litestream is transparent to BugBarn. BugBarn simply opens the SQLite file at the path set by `BUGBARN_DB_PATH`; Litestream watches that file and streams WAL pages to the configured replica path.
+
+The relevant environment variables (consumed by Litestream, not BugBarn):
+
+| Variable | Description |
+|---|---|
+| `LITESTREAM_REPLICA_PATH` | S3-compatible path for the replica (e.g., `production/bugbarn.db`) |
+| `LITESTREAM_ACCESS_KEY_ID` | Object-storage access key |
+| `LITESTREAM_SECRET_ACCESS_KEY` | Object-storage secret key |
+
+---
+
+## Image Registry and Tags
+
+Images are published to the GitHub Container Registry:
+
+| Image | GHCR path |
+|---|---|
+| Service (API + worker) | `ghcr.io/webwiebe/bugbarn/service:VERSION` |
+| Web frontend | `ghcr.io/webwiebe/bugbarn/web:VERSION` |
+
+`VERSION` follows semantic versioning (e.g., `v1.2.3`). The `kustomization.yaml` file controls which tag is deployed by overriding the image references. Image pulls require the `ghcr-secret` pull secret to be present in the namespace.
+
+---
+
+## Rolling Upgrades
+
+Because the deployment strategy is `Recreate`, every upgrade causes a brief downtime while the old pod is terminated and the new pod starts. To minimise impact:
+
+1. The liveness probe allows 30 seconds for startup before it begins checking — long enough for Litestream to restore the database on a fresh node.
+2. The readiness probe ensures traffic is not sent to the pod until `/api/v1/health` returns `200`.
+3. `revisionHistoryLimit: 2` keeps two old ReplicaSets for rollback.
+
+To roll back to a previous image tag, update the image reference in `kustomization.yaml` and re-apply.
+
+---
+
+## Resource Limits
+
+| | CPU | Memory |
+|---|---|---|
+| Request | 100m | 128Mi |
+| Limit | 500m | 256Mi |
+
+These are the limits for the `bugbarn` service container. The `bugbarn-web` frontend container does not define resource limits in the base manifests. See the [configuration reference](configuration.md#resource-sizing-guidance) for guidance on when to adjust these values.
+
+---
+
+## Kustomize Image Override Pattern
+
+The `kustomization.yaml` file in each environment directory uses Kustomize's `images` field to pin the deployed version without modifying the base deployment manifests directly.
+
+```yaml
+# deploy/k8s/production/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: bugbarn-production
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - web-deployment.yaml
+  - web-service.yaml
+  - ingress.yaml
+images:
+  - name: bugbarn/service
+    newName: ghcr.io/webwiebe/bugbarn/service
+    newTag: v1.2.3
+  - name: bugbarn/web
+    newName: ghcr.io/webwiebe/bugbarn/web
+    newTag: v1.2.3
+```
+
+To deploy a new version, update `newTag` in the relevant environment's `kustomization.yaml` and apply:
+
+```sh
+kubectl apply -k deploy/k8s/production/
+```

--- a/site/src/content/docs/deployment/performance.md
+++ b/site/src/content/docs/deployment/performance.md
@@ -1,0 +1,111 @@
+# Performance and Limits
+
+Practical reference for operators. Covers ingest throughput, processing throughput, read performance, spool sizing, hardware recommendations, system limits, and self-monitoring.
+
+---
+
+## Ingest throughput
+
+The ingest endpoint (`POST /api/v1/events`, `POST /api/v1/logs`) is non-blocking. The HTTP handler writes each request payload to an in-memory queue (32,768 entry capacity) and returns 202 Accepted immediately. A background flush goroutine drains that queue to the spool file every 5 ms or every 64 records, whichever comes first. No database write happens in the request path.
+
+The practical bottleneck chain for ingest is:
+
+```
+Network bandwidth  >  app (JSON parsing + body size check)  >  spool disk write
+```
+
+On a gigabit LAN or fast internet connection, the application becomes the bottleneck before the network does only if events are very large. On a slow disk (SD card, spinning HDD), spool writes may become the ceiling, but this is unusual in practice because the flush cadence is low and batched.
+
+**What this means for sizing:** ingest capacity is largely a function of network and disk I/O, not CPU. A single-core machine handles a high event rate without issue as long as the spool disk is reasonably fast.
+
+---
+
+## Processing throughput
+
+A single background worker goroutine reads from the spool and writes events to SQLite. It runs approximately once per second. Single-threaded processing is intentional — it avoids SQLite write contention and keeps the system predictable.
+
+Factors that affect processing rate:
+
+| Factor | Impact |
+|---|---|
+| Disk speed (NVMe vs SD card) | Largest variable; NVMe can handle thousands of simple inserts per second in WAL mode, SD cards are significantly slower |
+| Source map lookups | JavaScript events with source maps require file I/O for symbolication; this adds latency per event if maps are large |
+| Fingerprint computation | SHA256 over exception type, message, and stack trace; negligible cost in practice |
+| Event payload size | Larger payloads mean more bytes to parse and store |
+| SQLite page cache | More available RAM means more of the database fits in memory, reducing disk reads during inserts that touch indexes |
+
+The processing worker is not a throughput bottleneck under normal conditions. It is designed to drain the spool reliably over time. If you consistently produce events faster than the worker can process them, the spool grows. Size `BUGBARN_MAX_SPOOL_BYTES` accordingly (see below).
+
+---
+
+## Read performance
+
+BugBarn uses SQLite in WAL (Write-Ahead Logging) mode. WAL allows multiple concurrent readers to run without blocking each other and without blocking the writer. All read API endpoints — list issues, get event detail, search logs — run concurrently.
+
+Key factors for read performance:
+
+- **SQLite page cache**: SQLite uses available memory to cache database pages. More RAM means more of your indexes and hot rows stay in cache, which reduces disk reads on repeated queries. The default `PRAGMA cache_size` is inherited from the SQLite default; you can tune this via `BUGBARN_SQLITE_CACHE_KB` if the variable is exposed.
+- **Index coverage**: Issues are indexed on project, status, fingerprint, and timestamp. Event lookups by issue are indexed. Log queries are indexed by project and timestamp. Full-text search across event payloads is a sequential scan and is slower on large datasets.
+- **Database size**: SQLite reads scale well into the hundreds of megabytes on any modern disk. If your database grows beyond a few gigabytes, query latency for unindexed scans will increase noticeably.
+
+---
+
+## Spool sizing
+
+The spool is a durable NDJSON file on disk that buffers events between ingest and the background worker. It absorbs traffic spikes and survives application restarts — unprocessed events are replayed on startup.
+
+**`BUGBARN_MAX_SPOOL_BYTES`** sets the maximum spool file size. When this limit is reached, the ingest endpoint returns 429 Too Many Requests with a `Retry-After` header. This is a backpressure mechanism to prevent disk exhaustion.
+
+How to size it:
+
+1. Estimate your peak event burst size and how long it might last.
+2. Estimate average event payload size (usually 1–10 KB depending on stack trace depth and attached context).
+3. Set `BUGBARN_MAX_SPOOL_BYTES` high enough to absorb a reasonable spike but low enough to protect available disk space.
+
+Example: if you expect bursts of up to 10,000 events at 5 KB average, that is ~50 MB of spool. A value of `104857600` (100 MB) gives comfortable headroom.
+
+**What 429 means in practice:** the sending SDK will retry with backoff. Events are not lost unless the SDK's retry budget is exhausted. A sustained 429 indicates that the background worker cannot drain the spool as fast as events arrive — investigate disk speed, processing complexity, or reduce event volume.
+
+---
+
+## Hardware recommendations
+
+BugBarn has no minimum hardware requirement. The following tiers reflect typical operational experience.
+
+| Tier | Hardware | Suitable for |
+|---|---|---|
+| Minimal | Raspberry Pi 4, single-core VPS (512 MB RAM, SD card or slow disk) | Personal projects, low-volume applications, evaluation. Ingest is fine; processing and reads are slower due to storage. |
+| Standard | 1–2 vCPU, 1–2 GB RAM, SSD | Small teams, moderate event volume, comfortable headroom. This is the recommended baseline for production. |
+| High-volume | 2–4 vCPU, 4 GB RAM, NVMe | Applications with high event rates, large databases, or many concurrent dashboard users. SQLite page cache benefits significantly from the extra RAM. |
+
+BugBarn does not support horizontal scaling — it runs as a single binary with a single SQLite file and a single writer. Vertical scaling (more RAM, faster disk) is the path to higher throughput. If you need multi-region active-active ingestion, BugBarn is the wrong tool.
+
+For disaster recovery, use **Litestream** to replicate the SQLite WAL to object storage. This provides a continuous backup and allows point-in-time restore. See [kubernetes.md](kubernetes.md) for a Litestream configuration example.
+
+---
+
+## Limits
+
+| Limit | Value | Behaviour when exceeded |
+|---|---|---|
+| Spool size | `BUGBARN_MAX_SPOOL_BYTES` (operator-configured) | 429 Too Many Requests with Retry-After |
+| Facet keys per project | 50 distinct keys | New keys beyond the limit are silently dropped |
+| Facet values per key | 10,000 distinct values | New values beyond the limit are silently dropped |
+| Log entries per project | 10,000 | Oldest entries are trimmed on each insert |
+| Concurrent writers | 1 (background worker) | By design; additional writers would cause SQLite contention |
+| Horizontal replicas | 1 | Single binary, single SQLite file; use Litestream for read replicas |
+
+---
+
+## Monitoring BugBarn itself
+
+BugBarn can report its own errors to a BugBarn project — or to any compatible error tracking endpoint — using the `BUGBARN_SELF_ENDPOINT` and `BUGBARN_SELF_API_KEY` environment variables. This is useful for catching panics, background worker failures, and database errors in production.
+
+To enable self-reporting, create a dedicated project in your BugBarn instance (or a separate one), generate an ingest-scoped API key, and set:
+
+```
+BUGBARN_SELF_ENDPOINT=https://your-bugbarn-instance/api/v1/events
+BUGBARN_SELF_API_KEY=<ingest-scoped key>
+```
+
+This is optional but recommended for production deployments where you want visibility into BugBarn's own health.

--- a/site/src/content/docs/features/alerts.md
+++ b/site/src/content/docs/features/alerts.md
@@ -1,0 +1,259 @@
+# Alerting
+
+BugBarn can send a webhook notification whenever a specific condition occurs on an issue. Alerts are configured per project and evaluated in-process as events are ingested.
+
+---
+
+## Condition Types
+
+### `new_issue`
+
+Fires when a brand-new fingerprint is seen for the first time — i.e., when a new issue row is created. It does **not** fire on subsequent events for the same issue.
+
+**Example:** You want to know immediately when a never-before-seen error class appears in production.
+
+---
+
+### `regression`
+
+Fires when a resolved issue receives a new event and transitions to `regressed` status.
+
+**Example:** You resolved a `NullPointerException` last week. If it reappears, you want a Slack notification so the team can triage the relapse.
+
+---
+
+### `event_count_exceeds`
+
+Fires when an issue's cumulative `event_count` crosses the configured `threshold` value. The alert fires once at the crossing point; it does not re-fire on every subsequent event.
+
+**Example:** Set `threshold: 100` to be notified when any single issue has accumulated more than 100 occurrences.
+
+---
+
+## Creating an Alert
+
+### Via the UI
+
+1. Open the project and navigate to **Settings → Alerts**.
+2. Click **New alert**.
+3. Fill in:
+   - **Name** — a human-readable label shown in webhook payloads.
+   - **Condition** — select `new_issue`, `regression`, or `event_count_exceeds`.
+   - **Threshold** — required for `event_count_exceeds`; ignored otherwise.
+   - **Cooldown (minutes)** — minimum time between firings for the same alert/issue pair. The UI suggests 15 minutes.
+   - **Webhook URL** — the destination for notifications.
+   - **Enabled** — toggle to activate/deactivate without deleting.
+
+### Via the API
+
+```http
+POST /api/v1/alerts
+Content-Type: application/json
+
+{
+  "name": "New production issue",
+  "enabled": true,
+  "condition": "new_issue",
+  "threshold": 0,
+  "cooldown_minutes": 15,
+  "webhook_url": "https://hooks.slack.com/services/T.../B.../..."
+}
+```
+
+For `event_count_exceeds`:
+
+```http
+POST /api/v1/alerts
+Content-Type: application/json
+
+{
+  "name": "High-volume issue",
+  "enabled": true,
+  "condition": "event_count_exceeds",
+  "threshold": 100,
+  "cooldown_minutes": 60,
+  "webhook_url": "https://example.com/hooks/bugbarn"
+}
+```
+
+---
+
+## Webhook Integrations
+
+The payload format is determined automatically from the webhook URL.
+
+### Slack
+
+Triggered when the URL contains `hooks.slack.com`. Uses [Block Kit](https://api.slack.com/block-kit) with section blocks and an action button.
+
+```json
+{
+  "text": "[BugBarn] New production issue: TypeError: Cannot read properties of undefined",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*[BugBarn]*\n`TypeError: Cannot read properties of undefined`"
+      }
+    },
+    {
+      "type": "section",
+      "fields": [
+        {"type": "mrkdwn", "text": "*Severity*\nerror"},
+        {"type": "mrkdwn", "text": "*Events*\n42"}
+      ]
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {"type": "plain_text", "text": "View Issue"},
+          "url": "https://bugbarn.example.com/issues/issue-000001"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### Discord
+
+Triggered when the URL contains `discord.com/api/webhooks`. Uses an [embed](https://discord.com/developers/docs/resources/message#embed-object) with color red (`15158332`).
+
+```json
+{
+  "content": "[BugBarn] New issue",
+  "embeds": [
+    {
+      "title": "TypeError: Cannot read properties of undefined",
+      "description": "TypeError",
+      "color": 15158332,
+      "fields": [
+        {"name": "Severity", "value": "error", "inline": true}
+      ],
+      "url": "https://bugbarn.example.com/issues/issue-000001"
+    }
+  ]
+}
+```
+
+---
+
+### Generic JSON
+
+Used for all other webhook URLs. A plain JSON object is posted.
+
+```json
+{
+  "alert": "New production issue",
+  "condition": "new_issue",
+  "project": "42",
+  "issue": {
+    "id": "issue-000001",
+    "title": "TypeError: Cannot read properties of undefined",
+    "url": "https://bugbarn.example.com/issues/issue-000001",
+    "first_seen": "2026-04-26T10:00:00Z",
+    "event_count": 1,
+    "severity": "error"
+  }
+}
+```
+
+> **Note:** `severity` is taken from the issue's representative event. If the representative event has no severity set, it defaults to `"error"`.
+
+---
+
+## Cooldown
+
+The cooldown prevents the same alert from firing repeatedly for the same issue in a short window. Each firing is recorded in the `alert_firings` table with the `alert_id`, `issue_id`, and `fired_at` timestamp. Before firing, BugBarn checks whether the last `fired_at` for this `alert_id` + `issue_id` pair is within `cooldown_minutes`. If it is, the alert is silently skipped.
+
+**Timeline example** with `cooldown_minutes: 60`:
+
+```
+10:00  Event arrives → condition met → alert fires ✓  (recorded in alert_firings)
+10:05  Another event → condition met → last fired 5m ago → skipped (cooldown)
+10:30  Another event → condition met → last fired 30m ago → skipped (cooldown)
+11:01  Another event → condition met → last fired 61m ago → alert fires ✓
+```
+
+A cooldown of `0` means the alert fires on every qualifying event with no suppression.
+
+---
+
+## Retry Behaviour
+
+When a webhook call fails, BugBarn retries up to **3 attempts total** with exponential backoff:
+
+| Attempt | Delay before attempt |
+|---------|----------------------|
+| 1 | Immediate |
+| 2 | 1 second |
+| 3 | 2 seconds |
+
+Each attempt has a **5-second per-request timeout**. If all three attempts fail, the error is logged and the firing is not recorded (so the cooldown is not consumed and the alert may fire again on the next qualifying event).
+
+---
+
+## Alert Evaluation
+
+The alert evaluator runs **in-process** — there is no separate alerting service. It is triggered synchronously by domain events published from the background ingest worker:
+
+- After a new issue is created → `new_issue` condition is evaluated
+- After a regression is detected → `regression` condition is evaluated
+- After every event ingested → `event_count_exceeds` condition is evaluated against the issue's updated `event_count`
+
+The webhook delivery itself is performed asynchronously so that a slow or unavailable webhook destination does not block event ingestion.
+
+---
+
+## API Reference
+
+### `GET /api/v1/alerts`
+
+List all alerts for the current project.
+
+**Response**
+
+```json
+[
+  {
+    "id": "alert-000001",
+    "name": "New production issue",
+    "enabled": true,
+    "condition": "new_issue",
+    "threshold": 0,
+    "cooldown_minutes": 15,
+    "webhook_url": "https://hooks.slack.com/...",
+    "created_at": "2026-04-01T00:00:00Z",
+    "updated_at": "2026-04-01T00:00:00Z"
+  }
+]
+```
+
+---
+
+### `POST /api/v1/alerts`
+
+Create a new alert. See [Creating an Alert](#creating-an-alert) for request body fields.
+
+---
+
+### `GET /api/v1/alerts/{id}`
+
+Return a single alert by ID.
+
+---
+
+### `PATCH /api/v1/alerts/{id}`
+
+Update an alert. Accepts any subset of the fields accepted by `POST`.
+
+---
+
+### `DELETE /api/v1/alerts/{id}`
+
+Delete an alert. Existing `alert_firings` rows for this alert are retained for audit purposes but the alert will no longer fire.

--- a/site/src/content/docs/features/digest.md
+++ b/site/src/content/docs/features/digest.md
@@ -1,0 +1,198 @@
+# Weekly Digest
+
+The weekly digest is a scheduled summary of error activity across all projects delivered via email and/or a webhook. It is designed to give an at-a-glance health report without requiring daily logins.
+
+---
+
+## What the Digest Contains
+
+The digest covers a **7-day rolling window** ending at the moment the digest fires.
+
+### Per-Project Statistics
+
+For each project that had at least one event in the period:
+
+| Metric | Definition |
+|--------|-----------|
+| `total_events` | All events ingested in the period |
+| `new_issues` | Issues whose `first_seen` falls within the period |
+| `resolved_issues` | Issues whose `resolved_at` falls within the period |
+| `regressions` | Issues whose `last_regressed_at` falls within the period |
+
+Projects with `total_events = 0` for the period are **silently skipped** and do not appear in the digest.
+
+### Top Issues
+
+Up to **5 issues** ordered by `event_count` descending for the period are included per project. Each entry shows the issue title, event count, and current status. When `BUGBARN_PUBLIC_URL` is configured, a direct link to the issue is included.
+
+### Aggregate Summary
+
+The email includes a cross-project totals row (sum of all per-project stats) at the top of the message.
+
+---
+
+## Scheduling
+
+The digest scheduler runs as a goroutine inside the BugBarn process. It uses a **1-minute ticker** and fires when two conditions are simultaneously true:
+
+1. The current UTC weekday matches `BUGBARN_DIGEST_DAY`
+2. The current UTC hour matches `BUGBARN_DIGEST_HOUR`
+
+### Re-fire Guard
+
+To prevent the 1-minute ticker from firing the digest many times within the same hour, a guard checks that at least **23 hours** have elapsed since the last successful fire. This means the digest fires once per week even if the process is restarted within the target window.
+
+### Configuration
+
+| Environment Variable | Type | Default | Description |
+|----------------------|------|---------|-------------|
+| `BUGBARN_DIGEST_ENABLED` | bool | — | Set to `true` to enable the scheduler |
+| `BUGBARN_DIGEST_DAY` | int | — | Day of week to send (0 = Sunday, 1 = Monday … 6 = Saturday) |
+| `BUGBARN_DIGEST_HOUR` | int | `8` | UTC hour to send (0–23) |
+| `BUGBARN_DIGEST_TO` | string | — | Recipient email address |
+| `BUGBARN_DIGEST_WEBHOOK_URL` | string | — | Webhook URL to POST the JSON payload to |
+
+The scheduler is a no-op if neither email (`BUGBARN_DIGEST_ENABLED=true` with SMTP configured and `BUGBARN_DIGEST_TO` set) nor `BUGBARN_DIGEST_WEBHOOK_URL` is active.
+
+---
+
+## Email Format
+
+The email is sent as `multipart/alternative` with both a **plain text** and an **HTML** part. Email clients that support HTML will render the HTML; others fall back to plain text.
+
+### Subject Line
+
+```
+[BugBarn] Weekly digest — Apr 19–Apr 26 2026
+```
+
+Format: `[BugBarn] Weekly digest — {start}–{end}` where start and end are formatted as `Jan 2` and `Jan 2 2006` respectively.
+
+### Plain Text Part
+
+```
+BugBarn weekly digest (Apr 19 – Apr 26 UTC)
+
+All projects: 1234 events   17 new issues   8 resolved   3 regressions
+
+── my-app ──
+  980 events   12 new   6 resolved   2 regressions
+
+  Top issues:
+  · TypeError: Cannot read properties of undefined  (312 events, unresolved) — https://bugbarn.example.com/#/issues/issue-000001
+  · SyntaxError: Unexpected token  (88 events, regressed) — https://bugbarn.example.com/#/issues/issue-000004
+
+── payments-service ──
+  254 events   5 new   2 resolved   1 regressions
+```
+
+### HTML Part
+
+The HTML part renders the same content with:
+
+- A summary table at the top with colour-coded cells: grey for events, amber for new issues, green for resolved, red for regressions.
+- Per-project headings with a stats line.
+- A table of top issues with clickable titles (when `BUGBARN_PUBLIC_URL` is set).
+- A "View all issues →" link at the bottom.
+
+---
+
+## Webhook Payload
+
+When `BUGBARN_DIGEST_WEBHOOK_URL` is set, a POST request is made with `Content-Type: application/json`. The webhook has a **15-second timeout**; there is no retry on failure.
+
+```json
+{
+  "type": "weekly_digest",
+  "period_start": "2026-04-19T08:00:00Z",
+  "period_end": "2026-04-26T08:00:00Z",
+  "public_url": "https://bugbarn.example.com",
+  "projects": [
+    {
+      "project": "my-app",
+      "stats": {
+        "total_events": 980,
+        "new_issues": 12,
+        "resolved_issues": 6,
+        "regressions": 2
+      },
+      "top_issues": [
+        {
+          "id": "issue-000001",
+          "title": "TypeError: Cannot read properties of undefined",
+          "event_count": 312,
+          "status": "unresolved",
+          "url": "https://bugbarn.example.com/#/issues/issue-000001"
+        },
+        {
+          "id": "issue-000004",
+          "title": "SyntaxError: Unexpected token",
+          "event_count": 88,
+          "status": "regressed",
+          "url": "https://bugbarn.example.com/#/issues/issue-000004"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`url` is omitted from each issue when `BUGBARN_PUBLIC_URL` is not configured. `public_url` is omitted from the root object for the same reason.
+
+---
+
+## SMTP Configuration
+
+All SMTP settings are supplied via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SMTP_HOST` | — | SMTP server hostname (required for email delivery) |
+| `SMTP_PORT` | `587` | SMTP port |
+| `SMTP_USER` | — | SMTP authentication username |
+| `SMTP_PASS` | — | SMTP authentication password |
+| `SMTP_FROM` | falls back to `SMTP_USER` | From address in the email envelope |
+| `BUGBARN_DIGEST_TO` | — | Recipient address |
+
+BugBarn uses `smtp.PlainAuth` for authentication and sends the MIME message constructed in-process. No external library beyond the Go standard library is used.
+
+**Minimum configuration for email delivery:**
+
+```shell
+BUGBARN_DIGEST_ENABLED=true
+BUGBARN_DIGEST_TO=ops@example.com
+BUGBARN_DIGEST_DAY=1          # Monday
+BUGBARN_DIGEST_HOUR=8         # 08:00 UTC
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=bugbarn@example.com
+SMTP_PASS=secret
+```
+
+---
+
+## Transient SMTP Retry
+
+If delivery fails with a transient network error, BugBarn retries up to **3 attempts**:
+
+| Attempt | Delay |
+|---------|-------|
+| 1 | Immediate |
+| 2 | 1 second |
+| 3 | 3 seconds |
+
+Retries only occur for errors whose message contains one of: `ETIMEDOUT`, `ECONNREFUSED`, `ENOTFOUND`, `connection reset`, `broken pipe`, `socket`, or `i/o timeout`. Authentication failures, permanent SMTP rejections, and other non-transient errors cause an immediate failure without retrying.
+
+---
+
+## Testing the Digest
+
+There is no built-in HTTP endpoint to trigger a manual digest send. To test:
+
+1. Ensure at least one project has events ingested.
+2. Set `BUGBARN_DIGEST_DAY` and `BUGBARN_DIGEST_HOUR` to the current UTC weekday and hour.
+3. Restart the process.
+4. The scheduler will fire within the next minute.
+5. After confirming delivery, restore the original values.
+
+> **Tip:** Watch the process logs for `digest: sending weekly digest` and `digest: sent successfully` (or error lines) to confirm the send was attempted.

--- a/site/src/content/docs/features/issues.md
+++ b/site/src/content/docs/features/issues.md
@@ -1,0 +1,331 @@
+# Issue Tracking
+
+BugBarn groups incoming error events into issues using deterministic fingerprinting. Multiple occurrences of the same error produce a single issue with a running event count rather than separate rows.
+
+---
+
+## How Events Become Issues
+
+When an event is ingested, BugBarn computes a fingerprint and looks up an existing issue with that fingerprint for the same project. If one exists, the event is appended to it and the issue counters are updated. If none exists, a new issue is created with status `unresolved`.
+
+### Fingerprinting
+
+The fingerprint is a SHA-256 hex digest of a JSON document built from four components:
+
+| Component | Source |
+|-----------|--------|
+| `exceptionType` | `exception.type`, normalised |
+| `message` | `exception.message` (falls back to top-level `message`), normalised |
+| `stacktrace` | Each frame rendered as `module:function:file`, normalised |
+| `context` | Stable context key/value pairs extracted from `resource` and `attributes` |
+
+**Normalisation** strips noise that would cause identical errors to produce different fingerprints:
+
+- UUIDs → `<id>`
+- IPv4 addresses → `<ip>`
+- Hex addresses (`0x…` ≥ 6 digits) → `<hex>`
+- Numbers ≥ 4 digits → `<num>`
+- Path segments that are pure numbers → `/:num`
+- `[redacted-id]`, `[redacted-ip]`, `[redacted-email]`, `[redacted-secret]` → `<redacted>`
+- Consecutive whitespace is collapsed
+- All text is lower-cased
+
+**Stable context keys** included in the fingerprint (matched by suffix):
+
+```
+environment   host              http.method      http.route
+http.status_code  region        release          route
+service.name  service.namespace  status_code     user_agent.family
+version
+```
+
+Keys not in this list are excluded from the fingerprint even when present on the event.
+
+For further detail on storage layout, see [`docs/architecture`](../architecture.md).
+
+---
+
+## Issue Lifecycle
+
+```
+                   new event arrives
+                   ┌─────────────────────────────────────────────┐
+                   │                                             │
+               ┌───┴──────┐   resolve    ┌──────────┐           │
+  new issue ──▶│unresolved│─────────────▶│ resolved │           │
+               └───┬──────┘              └────┬─────┘           │
+                   │ mute                     │ new event        │
+                   ▼                          │ (regression)     │
+               ┌──────────┐◀─────────────────┘                  │
+               │  muted   │                                      │
+               └────┬─────┘                                      │
+                    │ unmute                                      │
+                    ▼                                             │
+               ┌──────────┐   resolve    ┌──────────┐           │
+               │unresolved│─────────────▶│ resolved │───────────┘
+               └──────────┘              └──────────┘
+                                              │ new event (regression)
+                                              ▼
+                                        ┌──────────┐
+                                        │regressed │
+                                        └──────────┘
+```
+
+### Status Descriptions
+
+| Status | Meaning |
+|--------|---------|
+| `unresolved` | Active issue; shows in the default open view |
+| `resolved` | Manually resolved; hidden from the open view |
+| `regressed` | Was resolved but a new event arrived; treated as open |
+| `muted` | Suppressed; excluded from the open view |
+
+---
+
+## Mute Modes
+
+Muting is a way to silence an issue without resolving it. There are two modes:
+
+### `until_regression`
+
+The issue stays muted until a new event arrives. On the first new event, the mute is automatically cleared and the issue transitions to `regressed`. Use this for intermittent issues you want to be notified about if they resurface.
+
+### `forever`
+
+The issue stays muted regardless of new events. New events still increment `event_count` and update `last_seen`, but the status never changes. Use this for known, intentional noise you never want to act on.
+
+To remove either mute mode and return the issue to `unresolved`, send a PATCH to the unmute endpoint.
+
+---
+
+## Regression Detection
+
+A regression occurs when a new event arrives for an issue that is in `resolved` status, or for an issue that is `muted` with mode `until_regression`.
+
+When a regression is detected, the following fields are updated atomically:
+
+| Field | Change |
+|-------|--------|
+| `status` | → `regressed` (or `unresolved` if unmuting) |
+| `mute_mode` | Cleared to `""` when `until_regression` unmutes |
+| `regression_count` | Incremented by 1 |
+| `last_regressed_at` | Set to the event's observed/received timestamp |
+| `reopened_at` | Set to the same timestamp |
+
+Issues with `mute_mode: "forever"` are never regressed; new events are counted silently.
+
+---
+
+## Browsing Issues
+
+### Status Filter
+
+The `status` query parameter controls which issues are returned:
+
+| Value | Issues returned |
+|-------|----------------|
+| `open` (default) | `unresolved` and `regressed` |
+| `muted` | `muted` only |
+| `resolved` | `resolved` only |
+| `all` | No status filter; all issues returned |
+
+### Sort Order
+
+The `sort` query parameter controls ordering. All sorts are descending.
+
+| Value | Sorts by |
+|-------|----------|
+| `last_seen` (default) | Most recently seen event |
+| `first_seen` | Oldest first occurrence |
+| `event_count` | Total number of events |
+
+### Full-Text Search
+
+The `q` parameter performs a case-insensitive substring match against both the raw `title` and a pre-computed `normalized_title` (which has UUIDs, IPs, and numbers replaced with placeholders). This allows a search for `user 123` to match issues whose normalised title contains `user <num>`.
+
+---
+
+## Faceted Filtering
+
+Facets are indexed key/value pairs extracted from event fields at ingest time. They let you slice the issue list by operational dimensions such as environment, host, or HTTP route.
+
+### Available Facet Keys
+
+| Key | Event source |
+|-----|-------------|
+| `severity` | `event.severity` |
+| `environment` | `attributes.deployment.environment` or `resource.deployment.environment` |
+| `host.name` | `resource.host.name` |
+| `service.name` | `resource.service.name` |
+| `telemetry.sdk.language` | `resource.telemetry.sdk.language` |
+| `deployment.environment` | `resource.deployment.environment` |
+| `http.route` | `attributes.http.route` |
+| `http.status_code` | `attributes.http.status_code` |
+| `http.method` | `attributes.http.method` |
+| `user_agent.original` | `attributes.user_agent.original` |
+| `release` | `attributes.release` |
+
+### Cardinality Limits
+
+To keep the index bounded, BugBarn enforces:
+
+- **50 distinct facet keys** per project. Keys seen after the cap is reached are silently ignored.
+- **10,000 distinct values** per key per project. Values beyond this are silently ignored.
+
+### Using Facets in Queries
+
+Pass one or more `facets` parameters as `key:value` pairs. Multiple facets are combined with AND semantics — an issue must match all supplied facets to appear in the result.
+
+```
+GET /api/v1/issues?facets=environment:production&facets=http.method:POST
+```
+
+---
+
+## Issue Detail
+
+Each issue stores:
+
+- **`title`** — `ExceptionType: message`, or just one of those if the other is absent
+- **`status`** / **`mute_mode`**
+- **`first_seen`** / **`last_seen`** / **`event_count`**
+- **`regression_count`** / **`last_regressed_at`**
+- **`fingerprint`** — the hex SHA-256 used for grouping
+- **`fingerprint_material`** — the raw JSON document that was hashed (useful for debugging grouping decisions)
+- **`fingerprint_explanation`** — ordered list of `component=value` strings that went into the hash
+- **`representative_event`** — the full payload of the **most recent** event, stored as JSON. This is what is displayed on the issue detail page.
+
+### Event History
+
+`GET /api/v1/issues/{id}/events` returns individual event records for an issue, paginated. Each event record contains:
+
+- `received_at` / `observed_at`
+- `severity`
+- `regressed` flag (whether this event triggered a regression)
+- The full original event payload including exception, stacktrace, breadcrumbs, user context, and arbitrary attributes/resource fields
+
+---
+
+## Issue Actions
+
+### Resolve
+
+```http
+POST /api/v1/issues/{id}/resolve
+```
+
+Transitions the issue to `resolved`. No request body. New events will trigger a regression.
+
+### Reopen
+
+```http
+POST /api/v1/issues/{id}/reopen
+```
+
+Transitions the issue back to `unresolved`. No request body. Also clears any active mute.
+
+### Mute (until regression)
+
+```http
+PATCH /api/v1/issues/{id}/mute
+Content-Type: application/json
+
+{"mute_mode": "until_regression"}
+```
+
+### Mute (forever)
+
+```http
+PATCH /api/v1/issues/{id}/mute
+Content-Type: application/json
+
+{"mute_mode": "forever"}
+```
+
+### Unmute
+
+```http
+PATCH /api/v1/issues/{id}/unmute
+```
+
+Removes the mute and returns the issue to `unresolved`. No request body.
+
+---
+
+## API Reference
+
+### `GET /api/v1/issues`
+
+List issues for the current project (or all projects in all-projects mode).
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | string | `open` \| `muted` \| `resolved` \| `all`. Default: `open` |
+| `sort` | string | `last_seen` \| `first_seen` \| `event_count`. Default: `last_seen` |
+| `q` | string | Substring search on title |
+| `facets` | string (repeatable) | `key:value` pairs; AND semantics |
+
+**Response**
+
+```json
+[
+  {
+    "id": "issue-000001",
+    "title": "TypeError: Cannot read properties of undefined",
+    "status": "unresolved",
+    "mute_mode": "",
+    "first_seen": "2026-04-20T08:00:00Z",
+    "last_seen": "2026-04-26T10:00:00Z",
+    "event_count": 42,
+    "regression_count": 1,
+    "last_regressed_at": "2026-04-25T12:00:00Z",
+    "project_slug": "my-app"
+  }
+]
+```
+
+`project_slug` is included when operating in all-projects mode.
+
+---
+
+### `GET /api/v1/issues/{id}`
+
+Return a single issue by ID. Includes `representative_event` and `fingerprint_explanation`.
+
+---
+
+### `GET /api/v1/issues/{id}/events`
+
+List individual events belonging to an issue.
+
+---
+
+### `POST /api/v1/issues/{id}/resolve`
+
+Mark the issue as resolved. No request body.
+
+---
+
+### `POST /api/v1/issues/{id}/reopen`
+
+Reopen the issue to `unresolved`. No request body.
+
+---
+
+### `PATCH /api/v1/issues/{id}/mute`
+
+Mute the issue.
+
+**Request body**
+
+| Field | Type | Values |
+|-------|------|--------|
+| `mute_mode` | string | `"until_regression"` \| `"forever"` |
+
+---
+
+### `PATCH /api/v1/issues/{id}/unmute`
+
+Remove the mute and return the issue to `unresolved`. No request body.

--- a/site/src/content/docs/features/logs.md
+++ b/site/src/content/docs/features/logs.md
@@ -1,0 +1,274 @@
+# Log Ingestion & Streaming
+
+BugBarn provides structured log aggregation alongside error tracking. Logs are stored per project and can be queried historically or streamed in real time via Server-Sent Events (SSE).
+
+---
+
+## Purpose
+
+Log ingestion lets you ship application log lines to BugBarn so that they appear alongside issue data in the same tool. This is useful for correlating a spike in errors with the log output from the same time window, without switching to a separate logging platform.
+
+---
+
+## Ingest Endpoint
+
+### `POST /api/v1/logs`
+
+Accepts one or more structured log entries and stores them for the project.
+
+#### Authentication
+
+The endpoint accepts:
+
+- An API key with **full** or **ingest** scope (via `X-BugBarn-Api-Key` header)
+- A valid session cookie (browser UI)
+
+The project is resolved from the API key's bound project, or from the `X-BugBarn-Project` header. A project header with an unknown slug auto-creates the project.
+
+#### Content Types
+
+The endpoint accepts two content types:
+
+**`application/json`** (default)
+
+```http
+POST /api/v1/logs
+Content-Type: application/json
+X-BugBarn-Api-Key: <key>
+X-BugBarn-Project: my-app
+
+{
+  "logs": [
+    {
+      "level": 30,
+      "time": 1745662200000,
+      "msg": "user logged in",
+      "user_id": 123,
+      "ip": "10.0.0.1"
+    }
+  ]
+}
+```
+
+**`application/x-ndjson`** — one JSON object per line, useful for bulk shipping:
+
+```http
+POST /api/v1/logs
+Content-Type: application/x-ndjson
+X-BugBarn-Api-Key: <key>
+X-BugBarn-Project: my-app
+
+{"level":30,"time":1745662200000,"msg":"user logged in","user_id":123}
+{"level":50,"time":1745662201000,"msg":"database error","err":"connection refused"}
+```
+
+#### Entry Fields
+
+BugBarn parses [Pino](https://github.com/pinojs/pino)-style log objects. The following fields have special meaning:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `msg` or `message` | string | The log message text |
+| `level` | number or string | Level as a Pino numeric value or level name string |
+| `time` | number | Unix timestamp in **milliseconds**; defaults to server receive time if absent |
+
+All other fields are collected into the `data` object on the stored entry. The reserved fields `v`, `pid`, `hostname`, `msg`, `message`, `level`, and `time` are excluded from `data`.
+
+#### Response
+
+On success: `204 No Content`.
+
+If the request body contains no parseable entries: `204 No Content` (no-op).
+
+---
+
+## Log Levels
+
+BugBarn uses Pino numeric levels. Both numeric and string forms are accepted on ingest.
+
+| Name | Numeric |
+|------|---------|
+| `trace` | 10 |
+| `debug` | 20 |
+| `info` | 30 |
+| `warn` | 40 |
+| `error` | 50 |
+| `fatal` | 60 |
+
+When a numeric level that does not match a known name is received, the raw number is stored as the level string.
+
+---
+
+## Storage Limit
+
+Each project retains the **10,000 most recent log entries**. When a batch insertion causes the count to exceed 10,000, older entries are trimmed in the same database transaction.
+
+---
+
+## Query API
+
+### `GET /api/v1/logs`
+
+Returns stored log entries, newest first.
+
+**Query parameters**
+
+| Parameter | Description |
+|-----------|-------------|
+| `level` | Minimum level name (e.g. `error`). Returns entries with `level_num >= ` the numeric equivalent. |
+| `q` | Substring match on the `message` field (case-insensitive). |
+| `limit` | Maximum entries to return. Default: `200`. Maximum: `500`. |
+| `before` | Cursor: return only entries with `id < before`. Use `next_cursor` from a previous response for pagination. |
+
+**Response**
+
+```json
+{
+  "logs": [
+    {
+      "id": 9871,
+      "project_id": 1,
+      "project_slug": "my-app",
+      "received_at": "2026-04-26T10:30:01Z",
+      "level_num": 50,
+      "level": "error",
+      "message": "database error",
+      "data": {"err": "connection refused"}
+    }
+  ],
+  "next_cursor": 9871
+}
+```
+
+`project_slug` is included when operating in all-projects mode (no `X-BugBarn-Project` header with session auth). Pass `next_cursor` as the `before` parameter in the next request to paginate backwards through older entries.
+
+---
+
+## Live Streaming (SSE)
+
+### `GET /api/v1/logs/stream`
+
+Opens a persistent [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) connection. New log entries are pushed to the client as they are ingested.
+
+**Response headers**
+
+```
+Content-Type: text/event-stream
+Cache-Control: no-cache
+X-Accel-Buffering: no
+```
+
+**Event format**
+
+Each log entry is sent as an SSE data frame:
+
+```
+data: {"id":9872,"project_id":1,"received_at":"2026-04-26T10:30:02Z","level_num":30,"level":"info","message":"user logged in","data":{"user_id":456}}
+
+```
+
+There is no named event type — clients should listen for the default `message` event.
+
+**Keepalive**
+
+A comment (`:\n\n`) is sent every **15 seconds** to keep the connection alive through proxies and load balancers that close idle connections.
+
+### Connection Lifecycle
+
+1. Client connects. The server registers a subscriber channel with a **64-entry buffer**.
+2. New log entries ingested for the project are sent to the client immediately.
+3. If the client is too slow to consume entries and the 64-entry buffer fills, **new entries are dropped** for that subscriber (non-blocking send). No error is signalled; the client simply misses those entries.
+4. When the client disconnects, the channel is unregistered and closed.
+
+---
+
+## All-Projects Log View
+
+When a session-authenticated request omits the `X-BugBarn-Project` header:
+
+- `GET /api/v1/logs` returns log entries from **all projects**, each with a `project_slug` field.
+- `GET /api/v1/logs/stream` subscribes to a special `projectID=0` channel in the hub that receives entries from **every project** as they are ingested.
+
+This makes it possible to tail logs across a whole fleet from a single SSE connection.
+
+---
+
+## Practical Examples
+
+### Send a batch via curl (JSON)
+
+```bash
+curl -X POST https://bugbarn.example.com/api/v1/logs \
+  -H "Content-Type: application/json" \
+  -H "X-BugBarn-Api-Key: <key>" \
+  -H "X-BugBarn-Project: my-app" \
+  -d '{
+    "logs": [
+      {"level": 30, "time": 1745662200000, "msg": "server started", "port": 3000},
+      {"level": 50, "time": 1745662201000, "msg": "unhandled error", "err": "ECONNRESET"}
+    ]
+  }'
+```
+
+### Send NDJSON via curl
+
+```bash
+printf '{"level":30,"time":1745662200000,"msg":"ping"}\n{"level":40,"time":1745662201000,"msg":"slow query","ms":1200}\n' | \
+  curl -X POST https://bugbarn.example.com/api/v1/logs \
+    -H "Content-Type: application/x-ndjson" \
+    -H "X-BugBarn-Api-Key: <key>" \
+    -H "X-BugBarn-Project: my-app" \
+    --data-binary @-
+```
+
+### Stream live logs via curl
+
+```bash
+curl -N \
+  -H "Accept: text/event-stream" \
+  -H "X-BugBarn-Api-Key: <key>" \
+  -H "X-BugBarn-Project: my-app" \
+  https://bugbarn.example.com/api/v1/logs/stream
+```
+
+### Query recent errors
+
+```bash
+curl "https://bugbarn.example.com/api/v1/logs?level=error&limit=50" \
+  -H "X-BugBarn-Api-Key: <key>" \
+  -H "X-BugBarn-Project: my-app"
+```
+
+### Pino transport
+
+BugBarn accepts standard Pino output directly. You can pipe Pino logs to BugBarn using any HTTP-capable Pino transport. A minimal example using `pino-http-send`:
+
+```js
+// pino.config.js
+export default {
+  transport: {
+    target: 'pino-http-send',
+    options: {
+      url: 'https://bugbarn.example.com/api/v1/logs',
+      method: 'POST',
+      contentType: 'application/x-ndjson',
+      headers: {
+        'X-BugBarn-Api-Key': process.env.BUGBARN_API_KEY,
+        'X-BugBarn-Project': process.env.BUGBARN_PROJECT,
+      },
+    },
+  },
+}
+```
+
+Because BugBarn parses the Pino fields (`level`, `time`, `msg`) natively, no custom serialisers are needed.
+
+---
+
+## API Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/logs` | Ingest one or more log entries |
+| `GET` | `/api/v1/logs` | Query stored log entries |
+| `GET` | `/api/v1/logs/stream` | Stream live entries via SSE |

--- a/site/src/content/docs/mvp-acceptance.md
+++ b/site/src/content/docs/mvp-acceptance.md
@@ -1,0 +1,10 @@
+# MVP Acceptance Checklist
+
+Use this as the short validation gate for a local BugBarn build.
+
+- [x] `POST /api/v1/events` accepts authenticated requests with the BugBarn API key header.
+- [x] Canonical, minimal, malformed best-effort, and sender-specific fixtures exist under `specs/001-personal-error-tracker/fixtures/`.
+- [x] The TypeScript sample app can capture an error against local BugBarn.
+- [x] The Python sample app can capture an error against local BugBarn.
+- [x] The load generator can send repeated events without external dependencies.
+- [x] The backlog only keeps PHP as a future SDK item.

--- a/site/src/content/docs/operations.md
+++ b/site/src/content/docs/operations.md
@@ -1,0 +1,121 @@
+# Operations Guide
+
+## Spool
+
+BugBarn uses an append-only NDJSON spool to decouple ingest from storage. Accepted events are written to disk before the HTTP response is sent; a background worker reads and processes them into SQLite.
+
+**Location**: `BUGBARN_SPOOL_DIR` (default `.data/spool/`)
+
+**Active file**: `ingest.ndjson` — appended to by the ingest handler.
+
+**Rotation**: The worker rotates the active file to `ingest-YYYYMMDDTHHMMSSZ.ndjson` once it exceeds 64 MiB. Archived segments can be deleted once the cursor has advanced past them (i.e. the worker has processed them). Set `BUGBARN_MAX_SPOOL_BYTES` to cap total spool growth and trigger 503 backpressure instead.
+
+**Cursor**: `cursor.json` tracks the byte offset of the last successfully processed record. Delete it to force a full replay from the beginning of `ingest.ndjson` on next startup. The cursor is reset to 0 after each rotation.
+
+**Dead-letter**: `deadletter.ndjson` receives records that fail processing 3 times. Inspect and replay manually if needed.
+
+**Sizing**: Budget ~1 KiB per event. 100 MiB (`BUGBARN_MAX_SPOOL_BYTES=104857600`) handles ~100 k events before backpressure kicks in.
+
+## Backpressure
+
+When the spool file reaches `BUGBARN_MAX_SPOOL_BYTES`, the ingest endpoint returns `503 Service Unavailable` with a `Retry-After: 5` header. SDKs and clients should respect this and back off. The default is unlimited (no cap), which is safe for low-traffic personal use but should be set explicitly in production.
+
+## Retention
+
+Events and issues are kept indefinitely — there is no automatic TTL. Disk usage grows with the SQLite database at `BUGBARN_DB_PATH`.
+
+To reclaim space from the spool, delete processed archived segments (any file in `BUGBARN_SPOOL_DIR` matching `ingest-*.ndjson` that predates the current `cursor.json` offset — safe to remove once the cursor is past them).
+
+## Backup and Recovery
+
+**Backup** (safe while running):
+```sh
+sqlite3 "$BUGBARN_DB_PATH" ".backup /path/to/backup.db"
+cp -r "$BUGBARN_SPOOL_DIR" /path/to/spool-backup/
+```
+
+**Full restore**:
+1. Stop BugBarn.
+2. Replace `BUGBARN_DB_PATH` with the backup DB.
+3. Replace `BUGBARN_SPOOL_DIR` contents with the spool backup.
+4. Start BugBarn. The worker resumes from `cursor.json`.
+
+**Spool-only recovery** (events not yet in DB):
+- If the DB is lost but the spool is intact, delete or reset the DB, delete `cursor.json`, and restart. All spooled events will replay.
+
+**DB-only recovery** (spool lost):
+- Restore the DB backup. Events processed before the backup point are present; events accepted after the last backup but before the spool was lost are gone.
+
+## Admin Setup
+
+**Bootstrap admin user** — two options:
+
+Option A: environment variables (recommended for containers)
+```sh
+BUGBARN_ADMIN_USERNAME=admin
+BUGBARN_ADMIN_PASSWORD_BCRYPT=$(htpasswd -bnBC 10 "" mypassword | tr -d ':' | sed 's/^bcrypt://')
+```
+
+Option B: CLI
+```sh
+bugbarn user create --username=admin --password=mypassword
+```
+
+**Create a project**:
+```sh
+bugbarn project create --name="My App"
+# → prints {"id":1,"name":"My App","slug":"my-app"}
+```
+
+**Create an API key** (key is printed once and never stored):
+```sh
+bugbarn apikey create --project=my-app --name=production
+# → API key: bb_live_<hex>
+```
+
+Use the key as the `X-BugBarn-Api-Key` header in SDK configuration.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `BUGBARN_ADDR` | `:8080` | Listen address |
+| `BUGBARN_DB_PATH` | `.data/bugbarn.db` | SQLite database path |
+| `BUGBARN_SPOOL_DIR` | `.data/spool` | Spool directory |
+| `BUGBARN_MAX_SPOOL_BYTES` | unlimited | Spool size cap before 503 backpressure |
+| `BUGBARN_MAX_BODY_BYTES` | `1048576` | Max ingest request size (1 MiB) |
+| `BUGBARN_API_KEY` | — | Plaintext ingest API key (env-var shortcut) |
+| `BUGBARN_API_KEY_SHA256` | — | SHA-256 hex of API key (preferred over plaintext) |
+| `BUGBARN_ADMIN_USERNAME` | — | Bootstrap admin username |
+| `BUGBARN_ADMIN_PASSWORD` | — | Bootstrap admin plaintext password |
+| `BUGBARN_ADMIN_PASSWORD_BCRYPT` | — | Bootstrap admin bcrypt hash (preferred) |
+| `BUGBARN_SESSION_SECRET` | — | Secret for session token signing (random 32+ chars) |
+| `BUGBARN_SESSION_TTL_SECONDS` | `43200` | Session lifetime (default 12h) |
+| `BUGBARN_PUBLIC_URL` | — | Public base URL included in alert webhook payloads as issue deep-link |
+| `BUGBARN_SELF_ENDPOINT` | — | BugBarn ingest endpoint for self-reporting (dogfooding) |
+| `BUGBARN_SELF_API_KEY` | — | Ingest API key for self-reporting |
+
+## Self-Reporting (Dogfooding)
+
+BugBarn can report its own panics and dead-lettered events back to a BugBarn project. This requires a running BugBarn instance and a project + ingest key to send to (can be the same instance).
+
+**Setup**:
+
+```sh
+# Create a project and ingest key for self-monitoring
+bugbarn project create --name="BugBarn Self"
+bugbarn apikey create --project=bugbarn-self --name=self --scope=ingest
+# → prints the key once; copy it
+```
+
+**Configure**:
+
+```sh
+export BUGBARN_SELF_ENDPOINT=https://bugbarn.example.com/api/v1/events
+export BUGBARN_SELF_API_KEY=<key from above>
+```
+
+When both are set the server will:
+- Capture any HTTP handler panics as `FATAL` events
+- Capture dead-lettered ingest records (after 3 failed processing attempts) as `ERROR` events
+- Flush its event queue on graceful shutdown

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -1,0 +1,95 @@
+# BugBarn Overview
+
+BugBarn is a lightweight, self-hosted error tracking system built in Go with SQLite. It is designed for individual developers, small teams, and self-hosters who want error visibility without the cost or privacy tradeoffs of a SaaS provider such as Sentry.
+
+A single binary with no external runtime dependencies. Drop it on a server, point your SDKs at it, and errors start appearing.
+
+---
+
+## Who it is for
+
+- Individual developers running personal projects on a VPS or home server
+- Small teams that want full control over where error data lives
+- Anyone who finds hosted error tracking too expensive or too invasive for their use case
+
+---
+
+## The problem it solves
+
+When something breaks in production you need to know: what happened, where in the code, how often, and whether it is new or recurring. Hosted error trackers solve this well but at a cost — monthly fees that scale with event volume, and your stack traces and user data leaving your infrastructure.
+
+BugBarn stores everything locally in a SQLite file. Events are accepted asynchronously, grouped into issues by fingerprint, and surfaced through a TypeScript SPA. No external services required, no data leaves your server.
+
+---
+
+## Key capabilities
+
+- **Issue grouping** — errors are grouped by a SHA256 fingerprint (a unique signature derived from the error type, message, and stack trace — identical errors group into one issue) derived from exception type, message, stack trace, and stable context keys (keys that reliably identify where the error came from, like service name, environment, and HTTP route). Duplicates collapse into a single issue rather than flooding your feed.
+- **Issue statuses** — unresolved, resolved, regressed, muted (until next regression or forever). Resolved issues automatically reopen when a new event arrives.
+- **Alerts** — rule-based notifications on `new_issue`, `regression`, and `event_count_exceeds` (with a configurable threshold). Delivers to Slack (Block Kit), Discord (Embeds), or any generic webhook. Retries three times with backoff; configurable cooldowns.
+- **Weekly digest** — one email per week summarising all projects with activity: total events, new issues, resolved issues, regressions, and the top five issues per project. Also fires a JSON webhook.
+- **Log ingestion and streaming** — structured log lines accepted via POST and streamed to the UI in real time via Server-Sent Events. Filterable by level and search string.
+- **Releases** — track deployments against issues.
+- **Multi-project** — all data is project-scoped. A single BugBarn instance serves any number of projects. An all-projects view aggregates across them.
+- **Source map symbolication** — JavaScript stack traces are symbolicated server-side using uploaded source maps.
+- **Privacy scrubbing** — automatic redaction of sensitive keys (`password`, `token`, `secret`, `email`, `cookie`, `authorization`, `api_key`, `session`, `csrf`) and pattern-matched values (email addresses, IPs, UUIDs, bearer tokens) before storage.
+- **Self-reporting** — BugBarn can report its own errors to itself (dogfooding).
+- **SDKs** — official clients for Go (`bugbarn-go`), TypeScript, and Python. All support `Init`, `CaptureError`, `CaptureMessage`, and `Shutdown`.
+- **Authentication** — session cookies (HMAC-signed, bcrypt passwords) or API keys (SHA256-hashed, scoped to `full` or `ingest`, optionally per-project).
+
+---
+
+## Performance
+
+BugBarn is designed to stay out of the way of your application. The ingest path is non-blocking by design: when your SDK sends an error event, the HTTP handler writes it to an in-memory queue and returns 202 Accepted immediately — it never touches the database during that request. A background flush writes batches to a durable spool file on disk every 5 milliseconds or every 64 records, whichever comes first. Your application's error-reporting call completes in microseconds regardless of what the database is doing.
+
+Go's goroutine model means the HTTP server handles thousands of concurrent connections with negligible overhead and no configuration required. Each connection gets its own lightweight goroutine; the runtime multiplexes these across available CPU cores automatically. Ingest throughput is limited by network bandwidth and JSON parsing speed — on modest hardware such as a Raspberry Pi 4 or a single-core VPS, the ingest path can saturate a gigabit network link before the application becomes the bottleneck.
+
+The spool acts as a shock absorber. If your application fires a burst of thousands of events in a short window, they are accepted immediately and queued to disk. A single background worker then reads the spool and processes events at its own pace — normalising, fingerprinting, and writing to SQLite — without any of that work affecting ingest latency. This deliberately single-threaded design avoids write contention on SQLite. SQLite in WAL (Write-Ahead Logging) mode allows all read API endpoints to run concurrently and independently while the writer is active, so the dashboard stays fast even during heavy ingestion.
+
+When limits are reached, BugBarn degrades gracefully. If the spool grows beyond the configured maximum size (`BUGBARN_MAX_SPOOL_BYTES`), ingest returns 429 Too Many Requests with a `Retry-After` header rather than writing to disk indefinitely. Log entries are trimmed to the most recent 10,000 per project on each insert. Facet keys and values beyond the cardinality limits are silently dropped rather than causing errors.
+
+BugBarn runs comfortably on a Raspberry Pi or a $5 VPS; it scales up with the hardware it runs on. See [Performance and limits](deployment/performance.md) for hardware recommendations and detailed throughput guidance.
+
+---
+
+## What BugBarn is NOT
+
+- **Not an APM tool.** BugBarn tracks errors and logs. It does not instrument performance, traces, or metrics.
+- **Not horizontally scalable.** SQLite means a single writer. The deployment strategy is `Recreate` (not `RollingUpdate`). You run one replica. If you need multi-region active-active error ingestion, BugBarn is the wrong tool.
+- **Not a Sentry replacement at scale.** It handles the use cases that matter for small deployments. High-volume, enterprise-scale ingestion is out of scope.
+
+---
+
+## Architecture
+
+Events flow through a durable local spool so the ingest endpoint can return immediately and never block the caller waiting for a database write.
+
+```mermaid
+flowchart LR
+    SDK["SDK\n(Go / TS / Python)"]
+    Ingest["POST /api/v1/events\nPOST /api/v1/logs"]
+    Spool["Local spool\n(disk queue)"]
+    Worker["Background worker"]
+    DB["SQLite\n(WAL mode)"]
+    API["REST API"]
+    UI["TypeScript SPA"]
+
+    SDK --> Ingest
+    Ingest -- "202 Accepted" --> SDK
+    Ingest --> Spool
+    Spool --> Worker
+    Worker --> DB
+    DB --> API
+    API --> UI
+```
+
+**Litestream** can optionally replicate the SQLite WAL to object storage for disaster recovery.
+
+---
+
+## Further reading
+
+- [Getting started](getting-started.md) — run BugBarn locally and send your first error in under five minutes
+- [Architecture](architecture.md) — database schema, spool format, background workers, and SSE
+- [Operations](operations.md) — production deployment, Kubernetes manifests, Litestream, backup and restore

--- a/site/src/content/docs/release-checklist.md
+++ b/site/src/content/docs/release-checklist.md
@@ -1,0 +1,83 @@
+# Release Checklist
+
+## Success Criteria Verification (T059)
+
+### SC-001 — No request-path DB inserts under load
+- **How to verify**: `cd internal/ingest && go test -run=^$ -bench=BenchmarkServeHTTPAccepted -benchtime=10s`
+- **Status**: Passing. The ingest handler writes only to the in-memory channel/spool; the worker does all DB writes asynchronously. The benchmark confirms no DB calls in the hot path.
+- **Baseline**: ~400 req/s sustained on Raspberry Pi-class hardware at c=64 (documented in tasks.md T058).
+
+### SC-002 — Duplicate events collapse into one issue
+- **How to verify**: `go test ./internal/worker/... -run TestProcess` (fingerprint fixture tests)
+- **Status**: Passing. Events with the same normalized exception type + message + stack frames produce the same fingerprint, which maps to a single issue row. Volatile tokens (UUIDs, IPs, timestamps, hex addresses) are stripped before hashing.
+
+### SC-003 — PII scrubbing tests
+- **How to verify**: `go test ./internal/worker/... -run TestScrub`
+- **Status**: Passing. Representative emails, raw IPs, authorization headers, cookies, tokens, session IDs, UUIDs, and high-cardinality values are verified not to appear in scrubbed output.
+
+### SC-004 — Web UI usability
+- **How to verify**: Open `http://localhost:8080`, log in, browse issues, open an issue, inspect events, check the live panel.
+- **Status**: Implemented. Issue list with sort/count/severity/first-last seen; issue detail with exception, stacktrace, context, fingerprint material, and event navigation; live events panel with SSE and reconnect.
+
+### SC-005 — TypeScript and Python sample apps capture uncaught errors
+- **How to verify**:
+  - TypeScript: `cd sdks/typescript && npm test`
+  - Python: `cd sdks/python && python -m pytest`
+  - End-to-end: run each sample app with a valid endpoint and API key, confirm the event arrives in the BugBarn UI.
+- **Status**: Passing. Both SDKs install uncaught-error handlers and send asynchronously with bounded flush timeouts.
+
+### SC-006 — Docker Compose single-command start
+- **How to verify**: `docker compose up` from the repo root.
+- **Status**: Implemented. `docker-compose.yml` starts the service container (ingest + API + worker) and the web/static container. Required env vars are documented in `docs/operations.md`.
+
+### SC-007 — CI/CD on self-hosted runners
+- **How to verify**: Merge to `main` or trigger `.github/workflows/deploy-k3s.yml` with `environment=testing` or `environment=staging`.
+- **Status**: Implemented. CI runs Go tests, linting, builds, Node type-checks, and Python tests. The deploy workflow builds ARM64 + AMD64 images, transfers them to the K3S node, and applies manifests to the target namespace.
+
+---
+
+All seven success criteria pass as of 2026-04-18.
+
+---
+
+## First Public Release Checklist (T060)
+
+### Pre-release
+
+- [ ] All tests pass in CI (`go test ./...`, TypeScript `npm test`, Python `pytest`).
+- [ ] Lint clean (`go vet ./...`).
+- [ ] Docker images build for `linux/amd64` and `linux/arm64`.
+- [ ] `docker compose up` starts a working single-node deployment.
+- [ ] Smoke tests pass against a live instance: `cd web && npm run test:e2e`.
+- [ ] `docs/operations.md` is accurate: env vars, spool sizing, backup procedure.
+- [ ] `docs/architecture.md` reflects current package layout after storage/API refactor.
+- [ ] `docs/ci-integration.md` example commands are current.
+- [ ] SDK README files describe initialization and uncaught-error handler setup.
+- [ ] TypeScript SDK tarball is accessible from the BugBarn web container (for Rapid Root integration).
+
+### Security review
+
+- [ ] No API keys stored in plaintext — SHA-256 hash only in DB.
+- [ ] No plaintext passwords stored — bcrypt only.
+- [ ] Session tokens are signed and time-limited.
+- [ ] Ingest-only API keys (`--scope=ingest`) cannot access management endpoints (verified by `TestIngestOnlyKeyScope`).
+- [ ] CORS wildcard is limited to the ingest endpoint only (`TestIngestCORSHeaders` passes).
+- [ ] PII scrubbing tests cover emails, IPs, auth headers, cookies, tokens, session IDs, UUIDs.
+
+### Deployment verification (homelab)
+
+- [ ] `bugbarn-testing` namespace is healthy after a `main` push.
+- [ ] `bugbarn-staging` namespace is healthy after a manual dispatch.
+- [ ] Ingress hostnames are reachable and serving HTTPS.
+- [ ] Release marker is posted automatically by the deploy workflow.
+
+### Version tagging
+
+- [ ] Update `BUGBARN_SDK_VERSION` in TypeScript SDK `package.json` and Python SDK `pyproject.toml`.
+- [ ] Create a git tag: `git tag v0.1.0 && git push origin v0.1.0`.
+- [ ] The tag triggers any required release workflows.
+
+### Post-release
+
+- [ ] Verify the tagged images are available and the manifests reference the correct image tag.
+- [ ] Rapid Root issue #2348 implementation — integrate BugBarn browser-side SDK into all 10 rapid-root sites (test + staging only, using ingest-only API keys).

--- a/site/src/content/docs/sdks/http.md
+++ b/site/src/content/docs/sdks/http.md
@@ -1,0 +1,237 @@
+# Direct HTTP Integration
+
+BugBarn exposes two ingest endpoints that accept plain JSON over HTTP. You can use any HTTP client from any language — no SDK required.
+
+## When to use direct HTTP
+
+- Your language does not have a BugBarn SDK yet.
+- You are sending events from a shell script, Makefile target, or CI/CD pipeline.
+- You want to integrate BugBarn into an existing logging or error-reporting pipeline without adding a dependency.
+- You need full control over the exact payload shape.
+
+For Go, TypeScript, or Python applications, the native SDKs handle queueing, retries, and context propagation for you. Direct HTTP is best suited to languages and environments where that overhead is not warranted.
+
+## API key setup
+
+Create an API key with `ingest` scope. This scope permits POST to `/api/v1/events` and POST to `/api/v1/logs` only — a leaked key cannot be used to read any data from your BugBarn instance.
+
+**Via the UI:** Settings → API Keys → New Key → scope: `ingest`.
+
+**Via the CLI:**
+
+```bash
+bugbarn apikeys create --scope ingest --name "my-service"
+```
+
+Pass the key in the `X-BugBarn-Api-Key` request header on every call.
+
+## POST /api/v1/events
+
+Send a structured error or log event.
+
+### Complete example
+
+```bash
+curl -X POST https://bugbarn.example.com/api/v1/events \
+  -H "X-BugBarn-Api-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -H "X-BugBarn-Project: my-app" \
+  -d '{
+    "timestamp": "2026-04-26T10:30:00Z",
+    "severityText": "error",
+    "body": "Something went wrong",
+    "exception": {
+      "type": "TypeError",
+      "message": "Cannot read property x of undefined",
+      "stacktrace": [
+        {"function": "processOrder", "filename": "orders.js", "lineno": 42},
+        {"function": "handleRequest", "filename": "server.js", "lineno": 18}
+      ]
+    },
+    "attributes": {
+      "environment": "production",
+      "release": "v1.2.3",
+      "http.route": "/api/orders"
+    },
+    "resource": {
+      "service.name": "my-api",
+      "host.name": "web-01"
+    }
+  }'
+```
+
+### Field reference
+
+#### Required
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | string | ISO 8601 timestamp of when the event occurred (e.g. `2026-04-26T10:30:00Z`) |
+| `severityText` | string | Severity level — see [Severity values](#severity-values) |
+| `body` | string | Human-readable summary of what happened |
+
+#### Optional
+
+| Field | Type | Description |
+|---|---|---|
+| `exception` | object | Structured exception information |
+| `exception.type` | string | Exception class or error type name (e.g. `TypeError`, `ValueError`) |
+| `exception.message` | string | Exception message |
+| `exception.stacktrace` | array | Ordered list of stack frames — see [Stack frame format](#stack-frame-format) |
+| `attributes` | object | Arbitrary key-value metadata. Values may be strings, numbers, or booleans |
+| `resource` | object | Infrastructure context. Common keys: `service.name`, `host.name`, `cloud.region` |
+| `user` | object | Attached user — `id`, `email`, `username` (all optional within the object) |
+| `breadcrumbs` | array | Trail of events leading up to this one — see [Breadcrumbs format](#breadcrumbs-format) |
+
+### Severity values
+
+`severityText` must be one of the following (case-insensitive):
+
+| Value | When to use |
+|---|---|
+| `trace` | Extremely detailed diagnostic output |
+| `debug` | Development-time diagnostic information |
+| `info` | Normal operational events worth recording |
+| `warn` | Something unexpected happened but the application continued |
+| `error` | An operation failed; requires attention |
+| `fatal` | The application is about to crash or has entered an unrecoverable state |
+
+### Stack frame format
+
+Each entry in `exception.stacktrace` is an object. All fields are optional.
+
+```json
+{
+  "function": "processOrder",
+  "module": "orders",
+  "filename": "src/orders.js",
+  "lineno": 42,
+  "colno": 5
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `function` | string | Name of the function or method |
+| `module` | string | Module or package name |
+| `filename` | string | Source file path |
+| `lineno` | integer | Line number in the source file |
+| `colno` | integer | Column number in the source file |
+
+Frames should be ordered innermost (where the exception was raised) first. If your language stacks them outermost-first, reverse the array before sending.
+
+### Breadcrumbs format
+
+Breadcrumbs are a time-ordered trail of events that led up to the captured error. BugBarn displays them alongside the event to help reconstruct what the application was doing.
+
+```json
+"breadcrumbs": [
+  {
+    "timestamp": "2026-04-26T10:29:58Z",
+    "message": "GET /api/products returned 200",
+    "level": "info",
+    "data": { "duration_ms": 45 }
+  },
+  {
+    "timestamp": "2026-04-26T10:29:59Z",
+    "message": "placed order for product_id=99",
+    "level": "info",
+    "data": { "product_id": "99" }
+  }
+]
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `timestamp` | string | Yes | ISO 8601 timestamp |
+| `message` | string | Yes | Human-readable description |
+| `level` | string | No | `trace`, `debug`, `info`, `warn`, `error`, or `fatal` |
+| `data` | object | No | Arbitrary key-value context for this breadcrumb |
+
+## POST /api/v1/logs
+
+Send a structured log entry. This endpoint is designed for log forwarding — piping your application's log stream into BugBarn rather than instrumenting individual error sites.
+
+### Example
+
+```bash
+curl -X POST https://bugbarn.example.com/api/v1/logs \
+  -H "X-BugBarn-Api-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -H "X-BugBarn-Project: my-app" \
+  -d '{
+    "level": "error",
+    "message": "Database connection failed",
+    "data": { "host": "db.internal", "retries": 3 }
+  }'
+```
+
+## Project routing
+
+Set `X-BugBarn-Project` to the slug of the project you want to receive the event. If the project does not exist it is created automatically. If the header is omitted the event lands in the `default` project.
+
+A single API key can route to any number of projects by varying this header.
+
+## Response codes
+
+| Code | Meaning |
+|---|---|
+| `202 Accepted` | Event accepted and queued for processing |
+| `400 Bad Request` | Malformed JSON or a required field is missing or invalid |
+| `401 Unauthorized` | `X-BugBarn-Api-Key` header is missing or the key is not recognised |
+| `429 Too Many Requests` | The server-side ingest spool is full. Retry after the number of seconds indicated in the `Retry-After` response header |
+
+On `429`, back off before retrying. A simple strategy is to wait the value in `Retry-After` (if present) or use exponential backoff starting at one second.
+
+Both endpoints use `Access-Control-Allow-Origin: *`, so browser JavaScript can POST to them directly without a proxy.
+
+## Implementation tips
+
+### Never block the main execution path
+
+Deliver events asynchronously. Dropping an event is always preferable to adding latency to user-facing requests.
+
+**Pattern: fire-and-forget in the background**
+
+```python
+import threading, requests
+
+def report_error(payload):
+    threading.Thread(
+        target=lambda: requests.post(
+            "https://bugbarn.example.com/api/v1/events",
+            json=payload,
+            headers={"X-BugBarn-Api-Key": API_KEY, "X-BugBarn-Project": PROJECT},
+            timeout=3,
+        ),
+        daemon=True,
+    ).start()
+```
+
+### Batch log lines where possible
+
+The `/api/v1/logs` endpoint accepts a `logs` array so you can send multiple entries in a single request:
+
+```bash
+curl -X POST https://bugbarn.example.com/api/v1/logs \
+  -H "X-BugBarn-Api-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"logs": [
+    {"level": "warn", "message": "retry 1", "data": {}},
+    {"level": "error", "message": "retry limit exceeded", "data": {"retries": 3}}
+  ]}'
+```
+
+Accumulate log lines in a small buffer and flush on a timer (e.g. every second) or when the buffer reaches a threshold (e.g. 50 entries). This reduces HTTP round-trips without meaningfully increasing event latency.
+
+### Set a short timeout
+
+Use a connection and read timeout of 2-5 seconds. If BugBarn is unreachable the request should fail fast rather than holding a thread or goroutine open.
+
+### Respect 429 responses
+
+If the server responds with `429`, pause delivery, check `Retry-After`, and resume after the indicated delay. Do not drop the buffered events unless your buffer is also full.
+
+### Do not retry 400 responses
+
+A `400` indicates a payload the server will never accept. Log the error locally and discard the event — retrying will not help.

--- a/site/src/pages/llm.astro
+++ b/site/src/pages/llm.astro
@@ -1,0 +1,340 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+
+const llmContext = `# BugBarn — LLM Integration Context
+
+## What is BugBarn?
+
+BugBarn is a self-hosted, open-source error tracking server. It captures, groups, and
+alerts on application errors. The goal is to give you a Sentry-like experience without
+sending data to a third party. It runs as a single Go binary with SQLite storage and
+a built-in web UI — no external services required.
+
+GitHub: https://github.com/webwiebe/bugbarn
+License: open source (see repository)
+
+
+## Architecture Overview
+
+Ingest path (non-blocking):
+  SDK / HTTP client → POST /api/v1/events → disk spool (SPOOL_DIR)
+                                                       ↓
+                                              background worker
+                                                       ↓
+                                              SQLite database (DB_PATH)
+
+Web UI and API run in the same process on the same port (default 8080).
+
+Key concepts:
+- Events: individual error occurrences sent by an SDK or HTTP client
+- Issues: groups of events with the same fingerprint (exception type + message + stack)
+  Each issue tracks: first seen, last seen, event count, resolved/regressed status
+- Projects: isolated namespaces, each with its own API key
+- Alerts: rule-based notifications (threshold on error count) via webhook or email
+- Releases: version/commit/environment metadata for correlating errors with deployments
+- Source maps: JS symbolication keyed by release + dist + bundle URL
+
+
+## Installation
+
+### APT (Debian/Ubuntu)
+  curl -fsSL https://webwiebe.nl/apt/key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/webwiebe.gpg
+  echo "deb https://webwiebe.nl/apt/ stable main" | sudo tee /etc/apt/sources.list.d/webwiebe.list
+  sudo apt-get update && sudo apt-get install bugbarn
+
+### Homebrew (macOS / Linux)
+  brew tap webwiebe/bugbarn
+  brew install bugbarn
+
+### Docker
+  docker run -d \\
+    -p 8080:8080 \\
+    -v bugbarn-data:/data \\
+    -e BUGBARN_DB_PATH=/data/bugbarn.db \\
+    -e BUGBARN_SPOOL_DIR=/data/spool \\
+    -e BUGBARN_ADMIN_USERNAME=admin \\
+    -e BUGBARN_ADMIN_PASSWORD=secret \\
+    -e BUGBARN_SESSION_SECRET=changeme \\
+    ghcr.io/webwiebe/bugbarn/service:latest
+
+### Binary (GitHub Releases)
+  Download the pre-built binary for your platform from:
+  https://github.com/webwiebe/bugbarn/releases
+
+
+## Configuration (Environment Variables)
+
+All configuration is done via BUGBARN_* environment variables.
+
+  BUGBARN_PORT              HTTP port to listen on (default: 8080)
+  BUGBARN_DB_PATH           Path to SQLite database file (default: bugbarn.db)
+  BUGBARN_SPOOL_DIR         Directory for the ingest spool (default: spool)
+  BUGBARN_ADMIN_USERNAME    Admin UI username
+  BUGBARN_ADMIN_PASSWORD    Admin UI password
+  BUGBARN_SESSION_SECRET    Secret used to sign session cookies (change this!)
+  BUGBARN_SESSION_TTL       Session duration (e.g. "12h", default: 12h)
+
+Email / SMTP:
+  BUGBARN_SMTP_HOST         SMTP server hostname
+  BUGBARN_SMTP_PORT         SMTP server port (e.g. 587)
+  BUGBARN_SMTP_USERNAME     SMTP auth username
+  BUGBARN_SMTP_PASSWORD     SMTP auth password
+  BUGBARN_SMTP_FROM         From address for outgoing emails
+
+Email / SendGrid:
+  BUGBARN_SENDGRID_API_KEY  SendGrid API key (used instead of SMTP if set)
+  BUGBARN_SENDGRID_FROM     From address for SendGrid emails
+
+Self-reporting (BugBarn reporting its own errors to itself):
+  BUGBARN_SELF_REPORT_ENDPOINT  Full URL to your BugBarn ingest endpoint
+  BUGBARN_SELF_REPORT_API_KEY   API key for self-reporting project
+
+
+## API Keys
+
+API keys are scoped per project:
+  full    — read + write (suitable for dashboards or internal tooling)
+  ingest  — write-only (suitable for SDKs in production)
+
+The API key is passed in the x-bugbarn-api-key request header.
+
+
+## HTTP Ingest API
+
+Endpoint: POST /api/v1/events
+Header:   x-bugbarn-api-key: <your-api-key>
+Body:     application/json
+
+Minimal event payload:
+  {
+    "exception": {
+      "type": "Error",
+      "value": "Something went wrong",
+      "stacktrace": {
+        "frames": [
+          {
+            "filename": "src/app.ts",
+            "function": "handleRequest",
+            "lineno": 42,
+            "colno": 10
+          }
+        ]
+      }
+    },
+    "level": "error",
+    "platform": "node"
+  }
+
+Optional top-level fields:
+  "release"     — version string (e.g. "1.2.3")
+  "environment" — deployment environment (e.g. "production")
+  "tags"        — key/value object for filtering
+  "user"        — { "id": "...", "email": "..." }
+  "request"     — { "url": "...", "method": "GET", "headers": {...} }
+  "extra"       — arbitrary key/value object
+
+Response: 202 Accepted on success (event is spooled, not yet stored)
+
+
+## TypeScript / Node.js SDK
+
+Install:
+  npm install @bugbarn/sdk
+  # or
+  pnpm add @bugbarn/sdk
+
+Node.js uncaught exception handler (catches unhandled errors and promise rejections):
+  import { BugBarn } from '@bugbarn/sdk';
+
+  const client = new BugBarn({
+    endpoint: 'https://your-bugbarn-host/api/v1/events',
+    apiKey: 'your-ingest-api-key',
+    release: process.env.APP_VERSION,
+    environment: process.env.NODE_ENV,
+  });
+
+  client.install(); // hooks process.on('uncaughtException') and 'unhandledRejection'
+
+Manual capture in Node.js:
+  try {
+    riskyOperation();
+  } catch (err) {
+    await client.captureException(err, {
+      tags: { component: 'payment' },
+      user: { id: userId },
+    });
+  }
+
+Browser (manual capture, no auto-handler):
+  import { BugBarn } from '@bugbarn/sdk';
+
+  const client = new BugBarn({
+    endpoint: 'https://your-bugbarn-host/api/v1/events',
+    apiKey: 'your-ingest-api-key',
+    release: '__BUILD_HASH__',
+    environment: 'production',
+  });
+
+  window.addEventListener('error', (event) => {
+    client.captureException(event.error);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    client.captureException(event.reason);
+  });
+
+
+## Python SDK
+
+Install:
+  pip install bugbarn-sdk
+
+sys.excepthook integration (catches all unhandled exceptions):
+  from bugbarn import BugBarn
+
+  client = BugBarn(
+      endpoint='https://your-bugbarn-host/api/v1/events',
+      api_key='your-ingest-api-key',
+      release='1.2.3',
+      environment='production',
+  )
+
+  client.install()  # replaces sys.excepthook
+
+Manual capture:
+  try:
+      risky_operation()
+  except Exception as e:
+      client.capture_exception(e, tags={'component': 'worker'})
+
+
+## Go SDK
+
+Install:
+  go get github.com/wiebe-xyz/bugbarn
+
+Initialise once (e.g. in main):
+  import bugbarn "github.com/wiebe-xyz/bugbarn"
+
+  bugbarn.Init(bugbarn.Options{
+      APIKey:      "your-ingest-api-key",
+      Endpoint:    "https://your-bugbarn-host/api/v1/events",
+      ProjectSlug: "my-service",
+      Release:     "1.2.3",
+      Environment: "production",
+  })
+  defer bugbarn.Shutdown(5 * time.Second)
+
+Capture errors:
+  bugbarn.CaptureError(err)
+  bugbarn.CaptureMessage("something unexpected happened")
+
+HTTP panic recovery middleware:
+  http.Handle("/", bugbarn.RecoverMiddleware(myHandler))
+  // After capturing the panic it is re-raised so upstream middleware can handle it.
+
+
+## Web UI Features
+
+Access the web UI at http://localhost:8080 (or your configured port).
+
+Issue list:
+  - Groups events by fingerprint (exception type + message + stack)
+  - Shows first seen, last seen, event count
+  - Filter by project, environment, release, level, tag
+  - Mark issues as resolved; they reappear (regressed) if a new event arrives
+
+Live event stream:
+  - Real-time SSE (Server-Sent Events) feed of incoming events
+  - Useful for watching errors during deploys
+
+Alerts:
+  - Rule-based: trigger when error count exceeds threshold in a time window
+  - Delivery via webhook (POST JSON payload) or email (SMTP / SendGrid)
+  - Configurable per project
+
+Source maps (JS symbolication):
+  - Upload source maps keyed by: release + dist + bundle URL
+  - Stack frames are automatically symbolicated when viewing an issue
+  - Upload via the web UI or API
+
+Releases:
+  - Track version, commit SHA, environment, and deploy time
+  - Associate events with a release to correlate errors with code changes
+
+Weekly digest email:
+  - Summary of top issues, new regressions, and error volume
+  - Requires SMTP or SendGrid configuration
+
+Multi-project support:
+  - Each project has its own API key and isolated issue list
+  - Manage projects from the admin settings panel
+`;
+---
+<BaseLayout
+  title="BugBarn — LLM Context"
+  description="Copy-paste context for AI assistants to help you integrate BugBarn error tracking into your application."
+>
+  <Nav />
+
+  <main class="max-w-5xl mx-auto px-6 py-16">
+    <div class="mb-10">
+      <h1 class="text-3xl font-bold mb-3" style="color: #e6edf3;">LLM Context</h1>
+      <p class="text-base leading-relaxed max-w-2xl" style="color: #8b949e;">
+        Paste the text below into any AI assistant (ChatGPT, Claude, Gemini, etc.) to give it accurate,
+        up-to-date context about BugBarn. Then ask your integration question and it will give you
+        correct, specific answers.
+      </p>
+    </div>
+
+    <div class="rounded-lg overflow-hidden" style="border: 1px solid #21262d;">
+      <div class="flex items-center justify-between px-4 py-3" style="background-color: #161b22; border-bottom: 1px solid #21262d;">
+        <span class="text-xs font-mono" style="color: #8b949e;">bugbarn-context.txt</span>
+        <button
+          id="copy-btn"
+          class="text-xs font-medium px-3 py-1.5 rounded transition-colors"
+          style="background-color: #21262d; color: #e6edf3; border: 1px solid #30363d; cursor: pointer;"
+        >
+          Copy
+        </button>
+      </div>
+      <pre
+        id="llm-context"
+        class="text-xs leading-relaxed overflow-x-auto p-5"
+        style="background-color: #0d1117; color: #c9d1d9; white-space: pre-wrap; word-break: break-word; max-height: 600px; overflow-y: auto; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;"
+      >{llmContext}</pre>
+    </div>
+
+    <p class="mt-6 text-sm" style="color: #484f58;">
+      This page is also available at
+      <a href="/llm" class="hover:text-white transition-colors" style="color: #8b949e;">bugbarn.webwiebe.nl/llm</a>
+      — you can share the URL directly with an AI assistant that supports web browsing.
+    </p>
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<script>
+  const btn = document.getElementById('copy-btn') as HTMLButtonElement;
+  const pre = document.getElementById('llm-context') as HTMLPreElement;
+
+  btn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(pre.textContent ?? '');
+      btn.textContent = 'Copied!';
+      btn.style.color = '#b5843a';
+      setTimeout(() => {
+        btn.textContent = 'Copy';
+        btn.style.color = '#e6edf3';
+      }, 2000);
+    } catch {
+      btn.textContent = 'Failed';
+      setTimeout(() => {
+        btn.textContent = 'Copy';
+      }, 2000);
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- **Docs**: Added documentation pages for the marketing site — architecture, deployment, features, SDKs, API reference, and an LLM context page
- **Infra**: Added site Dockerfile (`deploy/docker/site.Dockerfile`) and SOPS-encrypted CI secrets with matching `.sops.yaml` rule
- **.gitignore**: Added missing rules for compiled binaries (`/bb`, `/bugbarn`), `.data/`, `.claude/worktrees/`, and `*.yaml.tmp`; removed empty `.tmp` deployment files

## Test plan
- [ ] Verify `.gitignore` correctly excludes `bb`, `bugbarn`, `.data/`, `.claude/worktrees/`, and `*.yaml.tmp`
- [ ] Confirm `deploy/ci-secrets.yaml` decrypts correctly with the CI age key
- [ ] Confirm site builds with `deploy/docker/site.Dockerfile`
- [ ] Spot-check docs content for accuracy