### PR TITLE
infra: bump github runner to 2.334.0

### DIFF
--- a/infra/github-runner.yml
+++ b/infra/github-runner.yml
@@ -5,7 +5,7 @@
   vars:
     github_runner_enabled: true
     github_runner_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
-    github_runner_version: "2.332.0"
+    github_runner_version: "2.334.0"
     github_runner_base_dir: /home/deployer/github-runner
     github_runner_user: deployer
     github_runners:

--- a/infra/host_vars/mac-laptop.yml
+++ b/infra/host_vars/mac-laptop.yml
@@ -2,7 +2,7 @@
 # Battery-aware runners should only run when on AC power.
 
 github_runner_enabled: true
-github_runner_version: "2.332.0"
+github_runner_version: "2.334.0"
 github_runner_base_dir: /Users/wiebe/github-runners
 github_runner_user: wiebe
 github_runner_battery_aware: true

--- a/infra/host_vars/mac-mini.yml
+++ b/infra/host_vars/mac-mini.yml
@@ -1,7 +1,7 @@
 # Mac Mini - GitHub Actions runner configuration for BugBarn
 
 github_runner_enabled: true
-github_runner_version: "2.332.0"
+github_runner_version: "2.334.0"
 github_runner_base_dir: /Users/wiebe/github-runners
 github_runner_user: wiebe
 github_runner_battery_aware: false


### PR DESCRIPTION
## Summary

- Bumps `github_runner_version` from `2.332.0` to `2.334.0` across all runner configs
- Updated: `infra/github-runner.yml`, `infra/host_vars/mac-mini.yml`, `infra/host_vars/mac-laptop.yml`

## Test plan

- [ ] Re-provision runners using `make setup-runners` after merge
- [ ] Verify runners register and pick up jobs