### PR TITLE
ci: guard against non-semver tag formats

### DIFF
--- a/.github/workflows/tag-check.yml
+++ b/.github/workflows/tag-check.yml
@@ -1,0 +1,25 @@
+name: Tag format guard
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  validate-semver:
+    name: Validate semver tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check tag format
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "Validating tag: ${TAG}"
+          # SemVer 2.0.0 with leading v: vMAJOR.MINOR.PATCH[-prerelease][+build]
+          SEMVER='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          if [[ ! "${TAG}" =~ ${SEMVER} ]]; then
+            echo "::error::Tag '${TAG}' does not match semver vX.Y.Z[-prerelease][+build]"
+            echo "Valid examples: v1.2.3, v1.2.3-rc.1, v1.2.3+build.5, v1.2.3-rc.1+build.5"
+            echo "Datever (e.g. v2026.05.16) and other formats are not accepted."
+            exit 1
+          fi
+          echo "Tag '${TAG}' is valid semver"

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -218,7 +218,7 @@ pickerList?.addEventListener("keydown", (e) => {
   const items = Array.from(pickerList.querySelectorAll<HTMLButtonElement>(".picker-item"));
   const idx = items.indexOf(document.activeElement as HTMLButtonElement);
   if (e.key === "ArrowDown" && idx < items.length - 1) { items[idx + 1].focus(); e.preventDefault(); }
-  if (e.key === "ArrowUp") { idx > 0 ? items[idx - 1].focus() : pickerFilter?.focus(); e.preventDefault(); }
+  if (e.key === "ArrowUp") { if (idx > 0) items[idx - 1].focus(); else pickerFilter?.focus(); e.preventDefault(); }
   if (e.key === "Escape") { closePicker(); pickerBtn?.focus(); }
 });
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tag-check.*` that runs on every tag push.
- Fails CI if the tag does not match SemVer 2.0.0 (`vMAJOR.MINOR.PATCH[-prerelease][+build]`).
- Catches datever-style and other random tag formats before they propagate to releases or deploys.

## Why
The barn subprojects have been drifting on tag conventions — most use semver (`vX.Y.Z`), but stray formats like `v2026.05.16-1` have slipped in. The guard makes it loud the moment a non-semver tag is pushed, so the next release pipeline doesn't quietly act on garbage.

## Test plan
- [ ] Push a `vX.Y.Z` tag — workflow passes.
- [ ] Push a `v2026.05.16` tag in a fork — workflow fails with a clear error.
- [ ] Regular CI on `main` is unaffected (workflow only triggers on tag push).