### PR TITLE
feat(secrets): wire bugbarn-testing OIDC + per-env outbound

### DIFF
--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -34,9 +34,17 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: bugbarn-testing
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: https://spanbarn.wiebe.xyz
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_HEADERS
-              value: "Authorization=Bearer a3b4e7194bd5c44046a8cc6e984601914f3d09f1"
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
             - name: BUGBARN_SPOOL_DIR
               value: /var/lib/bugbarn/spool
             - name: BUGBARN_DB_PATH
@@ -127,6 +135,42 @@ spec:
                 secretKeyRef:
                   name: smtp-secret
                   key: BUGBARN_DIGEST_WEBHOOK_URL
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
                   optional: true
           resources:
             requests:

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -11,7 +11,19 @@ stringData:
     BUGBARN_SESSION_SECRET: ENC[AES256_GCM,data:34UbytPL5g3/xC9fIat2aVOC3pRbM+6vhTnjseqABOo=,iv:eXLBNeKB/VcwWo0p00Tx861NujMMkIsSdsobcuGuLOk=,tag:O6k9LRMJxIK/hlMelglfUw==,type:str]
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:1BKUfrHFZtYod5w/RXNZhykl,iv:3C2hjG0c3F1Q0+ZQSmiX84na1aI5Sh1QndnC1JVc6CA=,tag:0ockuZzV5WDbocjOVn3a+A==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:o27Pyioam4bA3zK7JuRn8hdtkhXf+2PsjaNWh+Xbx7hD2EOJQAPgWpImDalsSDFa,iv:fMoVDK/QFwsmLyjYisA2W/RY//BQqrAW2Ux4pND9mqE=,tag:pp5Pl9MVDaxfXYBvi3c96Q==,type:str]
+    BUGBARN_OIDC_ISSUER: ENC[AES256_GCM,data:wqbKyCfvzPcNXkOVVRUAluhcH3Rr0UbB4dc=,iv:5sXc4zq5Xdatnreo0/b8IpYTmZF7b34aoh5KQNSY3Ks=,tag:+Bx8Gz0iRPGHoiiXSIbWvg==,type:str]
+    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:KhNvbFWcBvC/bXhEnFVs3EXz,iv:tQ0XbIq3zo8iQiChWlj/DF+MaMhBChH1oUwKdJXz62o=,tag:vHXJQ4IvDCyPyfo+XcUJ8g==,type:str]
+    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:i1J+tI4fwBl7te4eJWolK3XVMN9RaCrRiZosPYWBSHQp0P2iG2CM2+3b0A==,iv:jm4wrYPf48RsN1kd9oZVDiquY1ejJWhTm+8nDuPP86U=,tag:Ft/AOK6JWEnwhPXBmCTUrw==,type:str]
+    BUGBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:cc+Rue3nj0dcdDgsC3o2VRvWSQqwLg+zESSI0/MDy+10m0MmwdcnQGXa6lc98HmB1DAz,iv:DrP4CAp2Y0WXNM/sC2Nw1/mbGRW8k2lYatr6oTpVAMA=,tag:pf33R4ciqtjDd/5xq+Q8Ew==,type:str]
+    BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:RpWRk5bI9D162UZusFIf8/N6gevI4ZYqMpGGhmU0gyDm,iv:cIfzNtRqeCCjo+TFkgo785ZXPOEKyz3aYffRX0+dYaY=,tag:6+JF4DxK4rLIL5FN5rBMYg==,type:str]
+    BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:n/NNTFl2/e5sl0HSk9ItBmdDWpkfgBS+1B8x2pkgqLu224E9mRqVUQ==,iv:8jnPwDzxW6B5hKaISAZEaPyXQLnPfNY0NNjAXKER74E=,tag:85/XLCgYoXYVp/5P8kBqxw==,type:str]
+    OTEL_EXPORTER_OTLP_ENDPOINT: ENC[AES256_GCM,data:8GtiOGOMW0Sh9m/RRGNwkXz5beQcrQe/+WNNlo1JHA==,iv:Uu9aTewJEoYMlCvXst96AP4pMj/cVSnhmbyuGAHvTYw=,tag:Qo6sEUapTbNMpF+emHntPQ==,type:str]
+    OTEL_EXPORTER_OTLP_HEADERS: ENC[AES256_GCM,data:ADv3VGgylcZkYTDa1bLNVrsLvn9/iVrK3Bx5Qtgwt2q6aB4GPyfLa5jakOjUpzfotcW6m8e8yXNBj2+Lrg==,iv:Ptby5oDPKEslOD1mFLzHYw5L/pFASS/Ac4AUp4xYAKw=,tag:Dpt3ity/Rso+zZzuvDoJIA==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -22,7 +34,8 @@ sops:
             TjRmTGMyN2FxOVVEUjdsSlRmb3BUc3MKtKPZO1Sc2ueHYsP9wELSdNdjSgR/9SWp
             rsEYda24zkgpiKdnE0lzytKojZCyIzz35rpmBSZ6TwUj7qXheyqDGA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T20:33:44Z"
-    mac: ENC[AES256_GCM,data:yowWbeuUJ9I8Q9WEN+9sUv0LuOEAx6HnwrhM0jHZsyE+zZ/B7TBA1PWPhf32VAfadwyvLryDsW4FE0NvRXoc74/bgqy+psCIOyz92Vylf40tgN1LPYlwIxOfahSry0BhTGXyZ2iBFeVE8E4dFhjyCX2ck+TsOnW6FB1TpqXhc2g=,iv:RuZ40fKQcX75OPFmjLJdmKYUFLoerH5xX43OxOJmNMw=,tag:/xbaXDcAriL71JWYToBcDQ==,type:str]
+    lastmodified: "2026-05-18T20:39:43Z"
+    mac: ENC[AES256_GCM,data:eR+DTfHxdOJ1mqPOkhYg9rjVM6kID3lthWw/uyrdol4/rqUdgwr5wC502O9n2gLdHmWOmQMHlfOjciTox3KlbsLwJ/cStRawNqq8zm/Tqe/45NR01j3g2cdqTZKq6Z2dcq5yw9vtdw44IxifTPkkh2eCT4m57R9t/qtAGJmlApE=,iv:db2wJl2+enUo3g3gAAddMekA4xYVN0rniMWtOF45xBg=,tag:OD0ymJugeqm5hIVuVcinhA==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
Three additions to bugbarn-testing's container:

- \`BUGBARN_OIDC_*\` — enables the iambarn OIDC login flow (PR #82). Client minted via \`iamctl client create --confidential\` on iambarn-testing.
- \`BUGBARN_FUNNELBARN_ENDPOINT / _API_KEY\` — bugbarn-testing now reports page views to funnelbarn-testing (was previously unset).
- \`OTEL_EXPORTER_OTLP_ENDPOINT / _HEADERS\` — moves OTEL config from a hardcoded literal that pointed at **prod** spanbarn over to a secret-sourced per-env binding, so testing actually ships traces to spanbarn-testing.

Staging and production keep their hardcoded prod-OTEL defaults until their secrets are rotated in a follow-up.

## Test plan
- [ ] After deploy: \`curl https://bugbarn.test.wiebe.xyz/api/v1/runtime-config\` reports \`oidc.enabled=true\`
- [ ] \`curl -I https://bugbarn.test.wiebe.xyz/api/v1/oidc/login\` returns 302 to iam.test.wiebe.xyz
- [ ] Confirm traces from bugbarn-testing appear in spanbarn-testing (e.g. \`gh\` activity, login attempt)
- [ ] Confirm a pageview from bugbarn-testing UI lands in funnelbarn-testing