### PR TITLE
fix(ci): use long-lived PAT for cluster GHCR pull secret

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,8 +98,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,8 +102,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "


### PR DESCRIPTION
## Summary
- `secrets.GITHUB_TOKEN` is only valid for the workflow's lifetime, so the cluster's `ghcr-secret` went stale the moment CI ended. Any pod that needed to pull afterwards (HPA scale-up, node reboot, eviction) got a 403 from GHCR.
- Swap the `kubectl create secret docker-registry ghcr-secret` calls in `build-and-test.yml`, `release.yml`, and `deploy-production.yml` to use the long-lived `GHCR_PULL_PAT` secret (with `webwiebe` as the username).
- Other uses of `secrets.GITHUB_TOKEN` (workflow-scoped `docker login` for image push, `gh` API calls) are left untouched since they only need workflow-duration validity.

Mirrors webwiebe/geobarn#13.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm `ghcr-secret` in each namespace authenticates beyond the workflow window (e.g. trigger a pod restart later and check the pull succeeds)