### PR TITLE
feat(bugbarn): per-env outbound + OIDC bindings for staging/prod

### DIFF
--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -48,9 +48,17 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: bugbarn
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: https://spanbarn.wiebe.xyz
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_HEADERS
-              value: "Authorization=Bearer a3b4e7194bd5c44046a8cc6e984601914f3d09f1"
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
             - name: BUGBARN_SPOOL_DIR
               value: /var/lib/bugbarn/spool
             - name: BUGBARN_DB_PATH
@@ -141,6 +149,42 @@ spec:
                 secretKeyRef:
                   name: smtp-secret
                   key: BUGBARN_DIGEST_WEBHOOK_URL
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
                   optional: true
           resources:
             requests:

--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -15,7 +15,15 @@ stringData:
     BUGBARN_WEB_PROJECT: ENC[AES256_GCM,data:QoPCVSnlMCj2WZk=,iv:HCAMDGq3jc8fOeKKfbEG3EVCGpbIJCfTGhzg277ISBg=,tag:EdOZRu0hGb9megf746pCzg==,type:str]
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:UjsGQL07b7injxjZ9MSj+6Fk,iv:55UZP1V6CBZPqEPRdO/HtCMXPWFFcEVnTa03s6PWkek=,tag:QzXJmc5POc9oj+7peC3rWg==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:0SWyRZw7eTTzyf9iKISrEZxAoeQJ6Pyr5DTSicgfKSwue6guHoecpsEv/uVObfl+,iv:ATDcqK4s7HBKI5VxH+Kk4rU+WdX21qe1RFJ6Wwhfvc0=,tag:lHhQlQVEM2uAgV6D/q629A==,type:str]
+    OTEL_EXPORTER_OTLP_ENDPOINT: ENC[AES256_GCM,data:7AiC+6CQZtRa+krwGOeFOIV8O2BRXy85msM=,iv:3ddSQcch6+lhm75thHDLGvFUtmWbWtAQD8eKUdjrMik=,tag:r7H+fkm/DQ1m8ev83311WQ==,type:str]
+    OTEL_EXPORTER_OTLP_HEADERS: ENC[AES256_GCM,data:/HX158d4N/g2SFWWGEyTdxyXK7XkXXXUJXiGQw582GoFyZ6DUlRldtwd3WsXgk3pIU6Uk23JDtz2xYqdyw==,iv:XjM10iqBUSR6gFbSJNIB5bdhV03bhZnWIYwf46edI1Y=,tag:d/wQFPAgNzluLnHKR2tA3g==,type:str]
+    BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:KFPRpOEKvBG9m1K+8Cc4SqRwLPdFy6wWSS6eZQ==,iv:78fS12priD0bWT5Smho4m+rPxXA2dBBqj6t2pL9dO/4=,tag:IfpHC8E1BVrwV+6Uv28mFA==,type:str]
+    BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:XH03DWjjOUH15zBQHlfgK4k+AoCEcFTiRVeYVXI+wctXSG9mo9rZ0g==,iv:Rx5qNUssUNR0EjLNpzQSutBG1oKGorth2zkYAfuL0vY=,tag:zi4jgHfUa7uh4BYjRgIIpQ==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -26,7 +34,8 @@ sops:
             RDNNVkNKT1hQS0pteUtKOXg4ZmNwNG8KCXUZkh8kV76oS2ZdIWDbVLv1qeKUN7q5
             YTsyCudfbr/ryBV4aU2u3xLOeObBRxds1DmgWU4ZQPj8sAwN7Nbx8g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T20:33:48Z"
-    mac: ENC[AES256_GCM,data:Q8CtukeC7l7YRP0vPi5+100wQUkK82NSJ7RWPoQgOJRZ3GfdS4SHpuIk6LEhxXt4F4NansfRpOzZerjutRYZ7p1aMXpjl/0ZHq7p7gWWbD81V0+AKk65+byBCmu4dNPHMCG3k3lV9iWbL1IxGCsnXEwlNnVOCgVIEKweKQu/4ic=,iv:olhCLzBODKNEzArkkWhMcKdSHW7SU3+rRmn90hmZccM=,tag:03+eQey+Z1bDzinG/7lBcA==,type:str]
+    lastmodified: "2026-05-19T09:39:42Z"
+    mac: ENC[AES256_GCM,data:rYUFjuZvt+YJebPWMuATwHXSsBXweD0z92iyL6+7sAqM25DHLTkNafT1kZZMWDHm/lwEEaloZN6E8JSp85Gm9u225+ukIK6AbbUHjYEe6Mj42THXlMKKkLNz882n/54DkgQUgK7DH9InMF2yqd1NibBaDlUCQGz+No23YoKQGtA=,iv:xCBkylj+CaLn5j5UGQZwuMdkLZLSPJT8u+ipTa3RI98=,tag:ULKXAo+fm9Luh98oRCG0hg==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -34,9 +34,17 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: bugbarn-staging
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: https://spanbarn.wiebe.xyz
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
             - name: OTEL_EXPORTER_OTLP_HEADERS
-              value: "Authorization=Bearer a3b4e7194bd5c44046a8cc6e984601914f3d09f1"
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
             - name: BUGBARN_SPOOL_DIR
               value: /var/lib/bugbarn/spool
             - name: BUGBARN_DB_PATH
@@ -127,6 +135,42 @@ spec:
                 secretKeyRef:
                   name: smtp-secret
                   key: BUGBARN_DIGEST_WEBHOOK_URL
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
                   optional: true
           resources:
             requests:

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -11,7 +11,15 @@ stringData:
     BUGBARN_SESSION_SECRET: ENC[AES256_GCM,data:NNMBTHyA1caBEYxHo5Bzi4TngRu47RohRuhPsaCdNg==,iv:V8vUsr4JfT5Cr93eMt8lbi55uvtiSf6SvN8uDm0lgPs=,tag:nfyAstnzG9GS8UmlsvpAnA==,type:str]
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:5wi7AIZ4VjuGF2U5ZuQ0Pi0N,iv:Zco5XYOQ3d3X7cl3Au1puOltestyiWAj388F+NeaEBw=,tag:iTW/HeafkhErvohMRIqUXg==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:w2HCu5qcc0/jFh50PfPIBoP0+PppigOzubmwvzdDVj2gtrWtQBdPLeD6/eVhec4s,iv:bDjLJAMsv0VoOrrSsz70qffbta4kGTW0Go94HH3XjVM=,tag:t+lUOTd3fg100oHW5iLkWA==,type:str]
+    OTEL_EXPORTER_OTLP_ENDPOINT: ENC[AES256_GCM,data:8FKXq8bq14C6ywtdmu+jxM6XOf6Kjyrm7EeK+c6Wkw/3Dw==,iv:l9Y/rRSeEX91AFyv3aX21KNHR9HL8YqVGsructRofhw=,tag:w9jz5Xs90ipi0GrB4jykdQ==,type:str]
+    OTEL_EXPORTER_OTLP_HEADERS: ENC[AES256_GCM,data:SZiqRfZni+1Hq2cgYF8mPcqm1buqdn5UZRpWmXa6wZJM7wrUAu33sBlg3SfK2MtlbIlT7x9lVuDVvHi7dg==,iv:oF3Hbdrb8xR+7sExdqDxdab1k3J14cctR8ceiopRZbg=,tag:PyYj7blMWVgr4JhXABiu+g==,type:str]
+    BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:S+KiqVp6Ymt8YnajVBHmrOZYZZRofacXjxeauSWGiYhu0yHc,iv:JB6dp796AIH4Y0Ozc+K9jid3PCmEn4Z4zriEtL0mV4k=,tag:Pvdj0sWpz72fg6b/4H4lYA==,type:str]
+    BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:Fv60fthy2RwU558y7FKFY/q6JijJ02Ot4Sods4Xe3pd+ZOucIA96fw==,iv:axwYtKY3nTl4AzUymTUonT/aUykoJqxfO1XXDqV780o=,tag:69YgYpjjG4hH58BiDNcfCQ==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -22,7 +30,8 @@ sops:
             Lzh0WTdqSGd2Mk1QMTM4YkVoVEUxamMKDSHgxHhdSWADgqmNVJgzO7O7d4jRIGrc
             U7/75mIF3aDD3sVjQ+WuX39jEArRqfS88jiyk+arYmjblBK5rzj3hA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T20:33:48Z"
-    mac: ENC[AES256_GCM,data:yY7TWLdI6aRzNmx4k+QzA+RqueMk9IHztL0uVz6GV0lGXORxlrWvIn9ZCVJVbc4h/1z1/dbB7SJwRPOE3zL3Mld3EkPKr4cMKdhqgO2+gvd6TcYTqpxZYKa5K6elTNjNUOJVnLSaQtNSE+ESG2CqOkExEeQ6BYOFNP9jI963tKc=,iv:t7LMfRuasPUuPNMnftFArd6EriQ5vmkzpyal+COwEpk=,tag:ItD+VXLdHaEPI2pBNnIlnw==,type:str]
+    lastmodified: "2026-05-19T09:39:34Z"
+    mac: ENC[AES256_GCM,data:xREZOPY8CFwcqbRyO1WgVeoz6+/OssplHsqM9cvXM/8QE2GjVAXjQ1W6bYJPNV1XFmKMobWj2CBkfi0aYQzfW/59KoZZ27fNRiQa/Nk3hxnHl8S1ISDJGBI24giba8rC7Pp6bNiLIiploMVYln3TZQfL1Nsz/EgPzk7aGJwvEM8=,iv:d1Qb7VCApvoZnpsOR/hCAINxnHzXfzPft6PzcHoIntg=,tag:4fpTTchxIPoLKrX0aBaWfQ==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
Mirrors the testing migration from #83 onto staging and production.

- \`deploy/k8s/{staging,production}/deployment.yaml\`: removes the hardcoded \`OTEL_EXPORTER_OTLP_ENDPOINT\` + \`_HEADERS\` literals (both pointed at prod spanbarn regardless of env) and switches to \`secretKeyRef\`. Adds \`BUGBARN_FUNNELBARN_*\` and \`BUGBARN_OIDC_*\` bindings with \`optional: true\` so missing keys don't block rollout.
- \`deploy/k8s/staging/secret.yaml\`: \`OTEL_EXPORTER_OTLP_*\` now targets spanbarn-staging; \`BUGBARN_FUNNELBARN_*\` targets funnelbarn-staging.
- \`deploy/k8s/production/secret.yaml\`: same shape with prod peer URLs/keys.

OIDC values left blank for now — they'll be populated once iambarn-staging / iambarn-prod ship the iamctl binary (PR webwiebe/iambarn#18 needs a tagged release first).

## Test plan
- [ ] CI staging deploy: pod env contains \`OTEL_EXPORTER_OTLP_ENDPOINT=https://spanbarn.staging.wiebe.xyz\` (not prod)
- [ ] Trace from staging shows up under spanbarn-staging, not prod
- [ ] Pageview from staging shows up in funnelbarn-staging
- [ ] Prod deploy left for manual rollout