### PR TITLE
fix(bugbarn): apply OTEL+OIDC bindings to staging/prod CQRS deploys

### DIFF
--- a/deploy/k8s/production/reader-deployment.yaml
+++ b/deploy/k8s/production/reader-deployment.yaml
@@ -86,6 +86,54 @@ spec:
                   name: bugbarn-secrets
                   key: BUGBARN_SESSION_SECRET
                   optional: true
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
+                  optional: true
           resources:
             requests:
               cpu: 50m

--- a/deploy/k8s/production/writer-deployment.yaml
+++ b/deploy/k8s/production/writer-deployment.yaml
@@ -140,6 +140,54 @@ spec:
                   name: smtp-secret
                   key: BUGBARN_DIGEST_WEBHOOK_URL
                   optional: true
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
+                  optional: true
           resources:
             requests:
               cpu: 100m

--- a/deploy/k8s/staging/reader-deployment.yaml
+++ b/deploy/k8s/staging/reader-deployment.yaml
@@ -67,6 +67,54 @@ spec:
                   name: bugbarn-secrets
                   key: BUGBARN_SESSION_SECRET
                   optional: true
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
+                  optional: true
           resources:
             requests:
               cpu: 25m

--- a/deploy/k8s/staging/writer-deployment.yaml
+++ b/deploy/k8s/staging/writer-deployment.yaml
@@ -126,6 +126,54 @@ spec:
                   name: smtp-secret
                   key: BUGBARN_DIGEST_WEBHOOK_URL
                   optional: true
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_ENDPOINT
+                  optional: true
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: OTEL_EXPORTER_OTLP_HEADERS
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_ENDPOINT
+                  optional: true
+            - name: BUGBARN_FUNNELBARN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_FUNNELBARN_API_KEY
+                  optional: true
+            - name: BUGBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_ISSUER
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: BUGBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: BUGBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: bugbarn-secrets
+                  key: BUGBARN_OIDC_REDIRECT_URL
+                  optional: true
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Staging/prod use writer-deployment.yaml + reader-deployment.yaml (CQRS split), not the single deployment.yaml that #85 touched. Adds the missing bindings to all four CQRS files.