### PR TITLE
feat(web): add Edit IAMBarn profile link to user menu

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 // serveRuntimeConfig returns public (non-secret) configuration that the web
 // frontend needs at startup. This endpoint requires no authentication so the
@@ -26,10 +29,15 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		LoginURL string `json:"loginURL,omitempty"`
 	}
 
+	type iambarnConfig struct {
+		ProfileURL string `json:"profileURL,omitempty"`
+	}
+
 	type runtimeConfig struct {
 		FunnelBarn funnelBarnConfig  `json:"funnelbarn"`
 		BugBarn    bugbarnSelfConfig `json:"bugbarn"`
 		OIDC       oidcConfigOut     `json:"oidc"`
+		IAMBarn    iambarnConfig     `json:"iambarn"`
 	}
 
 	cfg := runtimeConfig{}
@@ -49,6 +57,9 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.oidc != nil {
 		cfg.OIDC = oidcConfigOut{Enabled: true, LoginURL: "/api/v1/oidc/login"}
+		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
+			cfg.IAMBarn.ProfileURL = issuer + "/admin"
+		}
 	}
 
 	writeJSON(w, cfg)

--- a/web/index.html
+++ b/web/index.html
@@ -49,6 +49,7 @@
           <div class="bb-menu" id="bb-menu" hidden role="menu">
             <div class="bb-menu-user" id="bb-menu-user">BugBarn</div>
             <div class="bb-menu-divider"></div>
+            <a class="bb-menu-item" id="bb-iambarn-profile" role="menuitem" hidden target="_blank" rel="noopener noreferrer">Edit IAMBarn profile</a>
             <button class="bb-menu-item" id="bb-logout" type="button" role="menuitem">Log out</button>
           </div>
         </div>

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -262,6 +262,7 @@ void start();
 async function start(): Promise<void> {
   void initFunnelBarn();
   void initSelfReporting();
+  void initIAMBarnProfileLink();
 
   await loadSession();
   updateBBMenuUser();
@@ -397,6 +398,23 @@ function parseStack(stack?: string): Array<{ file: string; line: number; column:
     frames.push(f);
   }
   return frames.length > 0 ? frames : undefined;
+}
+
+async function initIAMBarnProfileLink(): Promise<void> {
+  let cfg: { iambarn?: { profileURL?: string } };
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return;
+    cfg = await res.json() as typeof cfg;
+  } catch {
+    return;
+  }
+  const url = cfg?.iambarn?.profileURL;
+  if (!url) return;
+  const link = document.getElementById("bb-iambarn-profile") as HTMLAnchorElement | null;
+  if (!link) return;
+  link.href = url;
+  link.removeAttribute("hidden");
 }
 
 async function initSelfReporting(): Promise<void> {


### PR DESCRIPTION
When OIDC is configured, the user menu now shows an 'Edit IAMBarn profile' link that opens `{issuer}/admin` in a new tab.