### PR TITLE
fix(iambarn-profile): only show link for OIDC sessions

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -93,6 +93,15 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	secure := secureCookie(r)
 	http.SetCookie(w, auth.ClearSessionCookie(secure))
 	http.SetCookie(w, auth.ClearCSRFCookie(secure))
+	// Clear the auth-method hint set by the OIDC callback.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "bugbarn_auth_method",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 	writeJSON(w, map[string]any{"authenticated": false})
 }
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -58,7 +58,7 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	if s.oidc != nil {
 		cfg.OIDC = oidcConfigOut{Enabled: true, LoginURL: "/api/v1/oidc/login"}
 		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
-			cfg.IAMBarn.ProfileURL = issuer + "/admin"
+			cfg.IAMBarn.ProfileURL = issuer + "/admin#profile"
 		}
 	}
 

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -88,6 +88,17 @@ func (s *Server) oidcCallback(w http.ResponseWriter, r *http.Request) {
 	secure := secureCookie(r)
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, s.sessions.CSRFCookie(token, expires, secure))
+	// Non-HttpOnly hint so the SPA can show OIDC-specific UI (e.g. the
+	// IAMBarn profile link) only for sessions that actually came from
+	// iambarn. Same expiry as the session.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "bugbarn_auth_method",
+		Value:    "oidc",
+		Path:     "/",
+		Expires:  expires,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 	// Clear the short-lived state/nonce cookies.
 	http.SetCookie(w, oidcShortLivedCookie(oidcStateCookie, "", secure))
 	http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, "", secure))

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -401,6 +401,13 @@ function parseStack(stack?: string): Array<{ file: string; line: number; column:
 }
 
 async function initIAMBarnProfileLink(): Promise<void> {
+  // Only show the IAMBarn profile link when the current session was
+  // actually established via the iambarn OIDC callback — local
+  // single-user installs shouldn't be linking to a remote profile
+  // they don't have.
+  if (!document.cookie.split("; ").some((c) => c.startsWith("bugbarn_auth_method=oidc"))) {
+    return;
+  }
   let cfg: { iambarn?: { profileURL?: string } };
   try {
     const res = await fetch("/api/v1/runtime-config");


### PR DESCRIPTION
Adds a non-HttpOnly `bugbarn_auth_method` cookie set by the OIDC callback (and cleared on logout). The SPA renders the Edit IAMBarn profile menu entry only when the cookie says `oidc`, so local-only sessions don't see a link to a profile they don't have. Also adds `#profile` to the deep-link URL.