### PR TITLE
feat: serve /.well-known/iambarn-theme.json

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -254,6 +254,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// IAMBarn theme manifest — public, no auth, no redirect.
+	if r.URL.Path == "/.well-known/iambarn-theme.json" && r.Method == http.MethodGet {
+		s.serveThemeManifest(w, r)
+		return
+	}
+
 	// Analytics JS snippet — public, no auth required.
 	if r.URL.Path == "/analytics.js" && r.Method == http.MethodGet {
 		s.serveAnalyticsSnippet(w, r)

--- a/internal/api/theme.go
+++ b/internal/api/theme.go
@@ -1,0 +1,35 @@
+package api
+
+import "net/http"
+
+// themeManifest mirrors the iambarn relying-party theme manifest schema.
+// See: https://iam.wiebe.xyz/.well-known/iambarn-theme.json
+type themeManifest struct {
+	Name            string `json:"name"`
+	LogoURL         string `json:"logo_url"`
+	PrimaryColor    string `json:"primary_color"`
+	BackgroundColor string `json:"background_color"`
+	CardColor       string `json:"card_color"`
+	BodyTextColor   string `json:"body_text_color"`
+	SupportURL      string `json:"support_url"`
+	Locale          string `json:"locale"`
+}
+
+// bugbarnThemeManifest reflects the BugBarn brand as defined in
+// web/styles.css (--bg, --panel, --accent, --text) and web/manifest.json.
+var bugbarnThemeManifest = themeManifest{
+	Name:            "BugBarn",
+	LogoURL:         "https://bugbarn.wiebe.xyz/icons/icon-512.png",
+	PrimaryColor:    "#a6e22e",
+	BackgroundColor: "#171812",
+	CardColor:       "#24251c",
+	BodyTextColor:   "#f8f8f2",
+	SupportURL:      "https://bugbarn.wiebe.xyz/",
+	Locale:          "en",
+}
+
+// serveThemeManifest serves the iambarn relying-party theme manifest used by
+// iambarn to skin its login page when a user is redirected here for OIDC.
+func (s *Server) serveThemeManifest(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, bugbarnThemeManifest)
+}

--- a/internal/api/theme_test.go
+++ b/internal/api/theme_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServeThemeManifest(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+	server := NewServer(nil, store, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/iambarn-theme.json", nil)
+	req.Header.Set("Accept", "application/json")
+
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want %d (body=%q)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type: got %q want it to contain application/json", ct)
+	}
+
+	type manifest struct {
+		Name            string `json:"name"`
+		LogoURL         string `json:"logo_url"`
+		PrimaryColor    string `json:"primary_color"`
+		BackgroundColor string `json:"background_color"`
+		CardColor       string `json:"card_color"`
+		BodyTextColor   string `json:"body_text_color"`
+		SupportURL      string `json:"support_url"`
+		Locale          string `json:"locale"`
+	}
+	var m manifest
+	if err := json.NewDecoder(rr.Body).Decode(&m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if m.Name == "" {
+		t.Errorf("name should be populated, got empty")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a public, unauthenticated handler that serves the BugBarn brand as an iambarn relying-party theme manifest at `GET /.well-known/iambarn-theme.json`.

iambarn fetches this file when a user is redirected here for OIDC login and uses the manifest to skin its login page (name, logo, colors, locale), so the visual jump between BugBarn and iambarn stays consistent for users.

## Theme values

Derived from `web/styles.css` (`--bg`, `--panel`, `--accent`, `--text`) and the existing PWA icon set:

- `name`: BugBarn
- `logo_url`: https://bugbarn.wiebe.xyz/icons/icon-512.png
- `primary_color`: #a6e22e (Monokai green accent)
- `background_color`: #171812
- `card_color`: #24251c
- `body_text_color`: #f8f8f2
- `support_url`: https://bugbarn.wiebe.xyz/
- `locale`: en

## Test plan

- [x] Returns HTTP 200, no redirect
- [x] `Content-Type` contains `application/json`
- [x] Decodes into the manifest struct shape iambarn expects
- [x] `name` field is populated
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` for the new handler passes
- [ ] CI green on the PR