### PR TITLE
fix(ingress): route /.well-known/iambarn-theme.json to backend

### DIFF
--- a/deploy/k8s/production/ingress.yaml
+++ b/deploy/k8s/production/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: bugbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: bugbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: bugbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary

`https://bugbarn.wiebe.xyz/.well-known/iambarn-theme.json` was returning 404 because the ingress only routed `/api` to the Go backend. Everything else (including the well-known path) fell through to the `bugbarn-web` SPA, where nginx has no entry for that file and returns 404.

The backend handler for this path was added in #91 and is correct — only the ingress needed updating.

## Changes

Added an `Exact`-match path rule for `/.well-known/iambarn-theme.json` before the `/` catch-all in all three environments, pointing at the same backend service/port as `/api`:

- `deploy/k8s/testing/ingress.yaml`
- `deploy/k8s/staging/ingress.yaml`
- `deploy/k8s/production/ingress.yaml`

## Test plan

- [ ] CI green
- [ ] After merge + testing deploy: `curl https://bugbarn.test.wiebe.xyz/.well-known/iambarn-theme.json` returns the backend JSON, not nginx 404
- [ ] After staging tag + deploy: same check against `bugbarn.staging.wiebe.xyz`
- [ ] After production deploy: same check against `bugbarn.wiebe.xyz`