### PR TITLE
chore(secrets): seed bugbarn-testing iambarn OIDC client

### DIFF
--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -12,8 +12,8 @@ stringData:
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:1BKUfrHFZtYod5w/RXNZhykl,iv:3C2hjG0c3F1Q0+ZQSmiX84na1aI5Sh1QndnC1JVc6CA=,tag:0ockuZzV5WDbocjOVn3a+A==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:o27Pyioam4bA3zK7JuRn8hdtkhXf+2PsjaNWh+Xbx7hD2EOJQAPgWpImDalsSDFa,iv:fMoVDK/QFwsmLyjYisA2W/RY//BQqrAW2Ux4pND9mqE=,tag:pp5Pl9MVDaxfXYBvi3c96Q==,type:str]
     BUGBARN_OIDC_ISSUER: ENC[AES256_GCM,data:wqbKyCfvzPcNXkOVVRUAluhcH3Rr0UbB4dc=,iv:5sXc4zq5Xdatnreo0/b8IpYTmZF7b34aoh5KQNSY3Ks=,tag:+Bx8Gz0iRPGHoiiXSIbWvg==,type:str]
-    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:KhNvbFWcBvC/bXhEnFVs3EXz,iv:tQ0XbIq3zo8iQiChWlj/DF+MaMhBChH1oUwKdJXz62o=,tag:vHXJQ4IvDCyPyfo+XcUJ8g==,type:str]
-    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:i1J+tI4fwBl7te4eJWolK3XVMN9RaCrRiZosPYWBSHQp0P2iG2CM2+3b0A==,iv:jm4wrYPf48RsN1kd9oZVDiquY1ejJWhTm+8nDuPP86U=,tag:Ft/AOK6JWEnwhPXBmCTUrw==,type:str]
+    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:j6+AXsX2KkU8lnXQsucNgnXR,iv:LtlicyOrNkZETuPrM6hXVEhi/yQy4OlczSz926mkiuA=,tag:93rNpO4dXdk2nnK8yZwhDw==,type:str]
+    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:f08KRkGTxgceIZO9cWq42J77NmzEizoVeeLdaaYVDlaySx5XCIdbSQbJOA==,iv:4K5Zae71I40YM7LE6ircIUN85tuW+veXYPF6nV0gexI=,tag:ZbVLIRTHi3DeFGl4b/gt8g==,type:str]
     BUGBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:cc+Rue3nj0dcdDgsC3o2VRvWSQqwLg+zESSI0/MDy+10m0MmwdcnQGXa6lc98HmB1DAz,iv:DrP4CAp2Y0WXNM/sC2Nw1/mbGRW8k2lYatr6oTpVAMA=,tag:pf33R4ciqtjDd/5xq+Q8Ew==,type:str]
     BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:RpWRk5bI9D162UZusFIf8/N6gevI4ZYqMpGGhmU0gyDm,iv:cIfzNtRqeCCjo+TFkgo785ZXPOEKyz3aYffRX0+dYaY=,tag:6+JF4DxK4rLIL5FN5rBMYg==,type:str]
     BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:n/NNTFl2/e5sl0HSk9ItBmdDWpkfgBS+1B8x2pkgqLu224E9mRqVUQ==,iv:8jnPwDzxW6B5hKaISAZEaPyXQLnPfNY0NNjAXKER74E=,tag:85/XLCgYoXYVp/5P8kBqxw==,type:str]
@@ -34,8 +34,8 @@ sops:
             TjRmTGMyN2FxOVVEUjdsSlRmb3BUc3MKtKPZO1Sc2ueHYsP9wELSdNdjSgR/9SWp
             rsEYda24zkgpiKdnE0lzytKojZCyIzz35rpmBSZ6TwUj7qXheyqDGA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T20:39:43Z"
-    mac: ENC[AES256_GCM,data:eR+DTfHxdOJ1mqPOkhYg9rjVM6kID3lthWw/uyrdol4/rqUdgwr5wC502O9n2gLdHmWOmQMHlfOjciTox3KlbsLwJ/cStRawNqq8zm/Tqe/45NR01j3g2cdqTZKq6Z2dcq5yw9vtdw44IxifTPkkh2eCT4m57R9t/qtAGJmlApE=,iv:db2wJl2+enUo3g3gAAddMekA4xYVN0rniMWtOF45xBg=,tag:OD0ymJugeqm5hIVuVcinhA==,type:str]
+    lastmodified: "2026-05-20T13:11:17Z"
+    mac: ENC[AES256_GCM,data:dD/4rycwESPjfM8YekZxxBs7fno8vuxGH5kVoCZV/0C587ISwsRkNfAippmviA++xnjqYftgbApki2Bj8wLexuWTwIOUUplvPwDuT3EWCwf6o4TXN4PUdAa5+fPwKFQWksyQs387h5komi3y6HsmvQ6KSZinB4tLrooIFxnD6m0=,iv:6V22hM5XOlgeNBbSk5884RfVQE/s3v9V8lk+VSwwekA=,tag:6Qcapi1gw1Yc+t1v9qg10Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **bugbarn** in **iambarn-testing** and written the credentials into `deploy/k8s/testing/secret.yaml`.

- Client id: `ibc_c55fNykm…`
- Redirect URI: `https://bugbarn.test.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_h5yxfpj72k5c7cpa`

Next deploy of bugbarn-testing picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.