### PR TITLE
chore(secrets): seed bugbarn-staging iambarn OIDC client

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -16,8 +16,8 @@ stringData:
     BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:S+KiqVp6Ymt8YnajVBHmrOZYZZRofacXjxeauSWGiYhu0yHc,iv:JB6dp796AIH4Y0Ozc+K9jid3PCmEn4Z4zriEtL0mV4k=,tag:Pvdj0sWpz72fg6b/4H4lYA==,type:str]
     BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:Fv60fthy2RwU558y7FKFY/q6JijJ02Ot4Sods4Xe3pd+ZOucIA96fw==,iv:axwYtKY3nTl4AzUymTUonT/aUykoJqxfO1XXDqV780o=,tag:69YgYpjjG4hH58BiDNcfCQ==,type:str]
     BUGBARN_OIDC_ISSUER: ENC[AES256_GCM,data:9iwFc55jUmN12n98jgTtDP8bRgj8f9QAkp7PbWc=,iv:Sff4EXUz4oMqs7peHMPFQtgReu6HF/NPcSCr6DRpp3A=,tag:hkxy5btFjSkBpEwJDMU6tQ==,type:str]
-    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:QO7zQogGZH/tCpNtw4uzagSg,iv:BOscD8WiQ0e2dzGAj/pn3dYMKHeLjA2BhPw9SAWlK44=,tag:Vvmuj3rBPGXDvS3P9+7dPw==,type:str]
-    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:1yuEpDT5OG2zc1+RwcYCDa/zUY7u36azzUfoNOf1TiiaVYUxTdIyVfmRrw==,iv:1La8JdBwjvmrFd61aFs/JaTAAhowMVd64uVpj9HoCuw=,tag:0cW2jUWp9NbvAD75Dt7tTg==,type:str]
+    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:NekaKC+2sw7g1lvtsLr4x6KX,iv:T231NA7C9VSmjyRskAk0ZVj5rIPxeeH4f8bBGyIXHhs=,tag:I/t6yAWoMTV6Iw7w/qVnig==,type:str]
+    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:3Fk+sc+vPc8zPxn38+6JR1yN9YkRFW0Hu61WlSaftFhJvmWp11de6PsF3g==,iv:N6QzSxMwrI9q1Fn85i8slk59TOvJQDmEGn1jhFqGij4=,tag:iOtKT1NpQ8PC+14k3K/rmw==,type:str]
     BUGBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:P26WK8kkzKUyhrANVBsU82iiY6edePLlRXKaMS3zy+sNj6GjdqIbpVxxheFi+QKGkXsrCMrv,iv:wVoh7Ysi+Yvu3nS3O6gox5Cp4xq0+Z9N39IbyPzG1mY=,tag:2MFTvo8/7/w7o2jEJBhz7w==,type:str]
 sops:
     kms: []
@@ -34,8 +34,8 @@ sops:
             Lzh0WTdqSGd2Mk1QMTM4YkVoVEUxamMKDSHgxHhdSWADgqmNVJgzO7O7d4jRIGrc
             U7/75mIF3aDD3sVjQ+WuX39jEArRqfS88jiyk+arYmjblBK5rzj3hA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T09:56:19Z"
-    mac: ENC[AES256_GCM,data:LXnI3vz7yIIQSvYVRJ9ddEZ+bX4Adkl+gKQtok6vo2ZBlpA/t6QZnDzAZtzXCC6nWZO8YAfbgYiOdsshc/q7vS9Ztc5I1/mHs/E8PZjKMHNCtYrvQqC7kYDe1j+SwdDLBU7DLgnSp3AW+Z1X94wdiM5vtEHKw9728pxAIeohruQ=,iv:Shuu0kXVKmNXq1zR/MG33z45t6amq+pxdJpzCE7jFm4=,tag:IxgAuIPBzmWM/H7Gwf4a9w==,type:str]
+    lastmodified: "2026-05-20T13:11:24Z"
+    mac: ENC[AES256_GCM,data:crGBn5Q7/JRJzflQF5acdUhgqVVft4UZSlvTJvnSE1Z3DSgnEHvWnP6JNrbWKEXillr63s0nYqByaZOKpW7+wgjBgxgSDwR/ysW2ZVF9Vj68vkLSQJe3QHzk8Ted4daHG0FSjOy7kIE/mHU9HudSyougMsKCknEi0F3s/d3RY7c=,iv:QLtgnS9VEdjWw7qWRquc6BZeEY5h08ej58UWMsa96TE=,tag:ioAbXGI9h7bPZV1BvNdaBA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **bugbarn** in **iambarn-staging** and written the credentials into `deploy/k8s/staging/secret.yaml`.

- Client id: `ibc_KCr2va4j…`
- Redirect URI: `https://bugbarn.staging.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_g4cl3dgbyqcjhgct`

Next deploy of bugbarn-staging picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.