### PR TITLE
chore(secrets): seed bugbarn-production iambarn OIDC client

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -20,8 +20,8 @@ stringData:
     BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:KFPRpOEKvBG9m1K+8Cc4SqRwLPdFy6wWSS6eZQ==,iv:78fS12priD0bWT5Smho4m+rPxXA2dBBqj6t2pL9dO/4=,tag:IfpHC8E1BVrwV+6Uv28mFA==,type:str]
     BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:XH03DWjjOUH15zBQHlfgK4k+AoCEcFTiRVeYVXI+wctXSG9mo9rZ0g==,iv:Rx5qNUssUNR0EjLNpzQSutBG1oKGorth2zkYAfuL0vY=,tag:zi4jgHfUa7uh4BYjRgIIpQ==,type:str]
     BUGBARN_OIDC_ISSUER: ENC[AES256_GCM,data:PjSDy2L8Ne71CvTqVfKGALGKX8uC,iv:JR5sZjaoxFrNQ4j/5oC27kwRQ/JA2UK0vAWqy9+9o9g=,tag:Jg8MJbzcx1CQ+z4f9JPygw==,type:str]
-    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:VQz5xK6Biokr/oWZg2F6axka,iv:icolDkK79V78NPWCttNfl6X4jujJM3T81jFvpsxXXBU=,tag:+rTJojKSMK1OMztI3KgoRw==,type:str]
-    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:Z/uKDYBO+sUuxNt+A5Smez4BiKUG2vXJiZaIoxMpiEW5xKQjHJfwAsRi5Q==,iv:BWvZEu0uO0H68r3/ilpQKS0HmQPCAnlG8s9STdPPYOo=,tag:9Rjp2nXdcHyx8ycINT22sQ==,type:str]
+    BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:wuHSExPYX3k88lmBRRouzNPG,iv:jrb+lLSwZgZP6daumG/AEGZded1EwnQBnVNbOaIQaq8=,tag:gYvVnbW1Si2tklOcBXOGfA==,type:str]
+    BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:J6N/fvZvRuJU+9sG7TWa3CTUdJCJGWcg7pMRgSjrBpxnCYznhIaJAf6JJg==,iv:0xwTCfPNt/KJIKzoZHgXDI/BLoXE6HiNwu0VDyvBI5w=,tag:p/Eot8L6P3Dr6BLfkGQjVQ==,type:str]
     BUGBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:EcIjA0p8t6o+/HJnT6vUAQM9MpqCDlAi9Q8jgf0+Jjd6U1Ptar6SjYtmVtLT8w==,iv:RShvmHGe+6jHtSGTZrVnAyzWxUw7xRx4OP/WQ6cXXNw=,tag:MTc0mnLp8E68xtGVmiGINw==,type:str]
 sops:
     kms: []
@@ -38,8 +38,8 @@ sops:
             RDNNVkNKT1hQS0pteUtKOXg4ZmNwNG8KCXUZkh8kV76oS2ZdIWDbVLv1qeKUN7q5
             YTsyCudfbr/ryBV4aU2u3xLOeObBRxds1DmgWU4ZQPj8sAwN7Nbx8g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T10:46:58Z"
-    mac: ENC[AES256_GCM,data:BXgalwjO4WIf4IOSwtdPuMDiG6bWzE3De+T+nYm/RSRyL4uu4MTw+xPpK3G0QUmevOJVmJB6hy8r4pMQWXVFJ5jTIV+rxVohIa/t0Qk89EoUL7gOqEaIYu8Wsmb6OdCylHGupD4BhagBX7eXyW0AjcyoJ3Gnji7HqiPapRTp0Ig=,iv:WB1m84/5m0RyxI+CW40R8ap7h4Tb9Zzzsj9GV5XXgT0=,tag:0gdQxLawzS0wiDidyF6i0A==,type:str]
+    lastmodified: "2026-05-20T13:11:32Z"
+    mac: ENC[AES256_GCM,data:QM80lTHiWiGM+T/HFx2KzRJg1lKuei/7hL+nymHOgzEx96fgweUMXIIZ5oIFcssMmrWORRIw2DooWkoTaMSAqt4q0yoHIjN4ZQ9rptsC+9VL3Kizc+9VTTeCdYCVd+I8uxh2DLU6FtVjlf66dS7f2I2afT46Orve6i4RTcXYLbM=,iv:Tem1hlSqyEDfSRdyQjIwhr9hRekp3f2Tg+zhhhVZ/Zw=,tag:7mbP6vj9eJ+onvE26a1b4g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **bugbarn** in **iambarn-production** and written the credentials into `deploy/k8s/production/secret.yaml`.

- Client id: `ibc__LNd9T_1…`
- Redirect URI: `https://bugbarn.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_qbwyqure4p2lm2hg`

Next deploy of bugbarn-production picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.