### PR TITLE
chore(ci): bump upload-pages-artifact off Node 20

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist/
 


### PR DESCRIPTION
## Summary

- `actions/upload-pages-artifact@v3` runs on Node 20, which GitHub has deprecated.
- Bump to `@v5` in `.github/workflows/deploy-site.yml` (matches what funnelbarn already uses for Pages publishing).
- Pairs cleanly with the existing `actions/deploy-pages@v4`.

## Scope

One-line change in one file. No other deprecated actions in this repo — checkout/setup-go/setup-node are on v6, download/upload-artifact on v7+, configure-pages on v5.

## Test plan

- [ ] CI green
- [ ] Pages deploy workflow runs on next push to `main` paths it watches