### PR TITLE
fix(web): logged-in redirect from marketing site; left-align mobile project rows

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,6 +11,11 @@ import Footer from '../components/Footer.astro';
   title="BugBarn — Self-hosted error tracking"
   description="Error tracking that lives on your infrastructure. Self-hosted, no per-event pricing, your data stays on your servers. Single binary, SQLite, open source."
 >
+  <script is:inline>
+    if (document.cookie.split('; ').some((c) => c.startsWith('bugbarn_csrf='))) {
+      window.location.replace('/app/');
+    }
+  </script>
   <Nav />
   <main>
     <Hero />

--- a/web/styles.css
+++ b/web/styles.css
@@ -1572,10 +1572,16 @@ button:disabled {
     flex-shrink: 0;
   }
 
-  /* Fix cramped project rows on mobile — stack vertically */
+  /* Fix cramped project rows on mobile — stack vertically, left-align */
   .project-row {
     flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .project-info,
+  .project-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
   .project-actions {
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Marketing homepage redirects to `/app/` when the JS-readable `bugbarn_csrf` cookie is present (same origin).
- Mobile projects settings rows pin name + actions to the left edge instead of appearing centered.

## Test plan
- [ ] Logged-in visit to `/` → bounces to `/app/`.
- [ ] Logged-out visit to `/` → renders marketing site as before.
- [ ] Mobile `Settings → Projects` → name and action chips align left.