### PR TITLE
feat(web): sortable/filterable project list and reliable home redirect

### DIFF
--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -13,7 +13,13 @@
         file_server
     }
 
-    # Marketing site
+    # Marketing site — redirect logged-in users straight to the dashboard
+    @loggedInHome {
+        path /
+        header_regexp Cookie bugbarn_csrf=
+    }
+    redir @loggedInHome /app/ 302
+
     handle {
         root * /srv/site
         file_server

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -2066,6 +2066,8 @@ function wireSettingsActions(): void {
     }
   });
 
+  wireProjectListControls();
+
   elements.overviewView.querySelectorAll<HTMLButtonElement>("[data-approve-project]").forEach((btn) => {
     btn.addEventListener("click", () => {
       const slug = btn.dataset["approveProject"];
@@ -2129,6 +2131,58 @@ function wireSettingsActions(): void {
       if (slug) void deleteAlias(slug);
     });
   });
+}
+
+function wireProjectListControls(): void {
+  const list = elements.overviewView.querySelector<HTMLElement>("#project-list");
+  const filter = elements.overviewView.querySelector<HTMLInputElement>("#project-filter");
+  const sort = elements.overviewView.querySelector<HTMLSelectElement>("#project-sort");
+  const statusFilter = elements.overviewView.querySelector<HTMLSelectElement>("#project-status-filter");
+  if (!list) return;
+
+  const rows = Array.from(list.querySelectorAll<HTMLElement>(".project-row"));
+
+  const apply = (): void => {
+    const q = (filter?.value ?? "").trim().toLowerCase();
+    const statusVal = statusFilter?.value ?? "all";
+    const sortVal = sort?.value ?? "default";
+
+    const visible = rows.filter((row) => {
+      const name = row.dataset["name"] ?? "";
+      const slug = (row.dataset["slug"] ?? "").toLowerCase();
+      const status = row.dataset["status"] ?? "";
+      if (q && !name.includes(q) && !slug.includes(q)) return false;
+      if (statusVal !== "all" && status !== statusVal) return false;
+      return true;
+    });
+
+    rows.forEach((row) => { row.hidden = !visible.includes(row); });
+
+    const num = (row: HTMLElement, key: string): number => Number(row.dataset[key] ?? 0);
+    const byName = (a: HTMLElement, b: HTMLElement, dir: 1 | -1): number =>
+      (a.dataset["name"] ?? "").localeCompare(b.dataset["name"] ?? "") * dir;
+
+    let sorted = [...visible];
+    switch (sortVal) {
+      case "name-asc": sorted.sort((a, b) => byName(a, b, 1)); break;
+      case "name-desc": sorted.sort((a, b) => byName(a, b, -1)); break;
+      case "issues-desc": sorted.sort((a, b) => num(b, "issues") - num(a, "issues")); break;
+      case "events-desc": sorted.sort((a, b) => num(b, "events") - num(a, "events")); break;
+      case "logs-desc": sorted.sort((a, b) => num(b, "logs") - num(a, "logs")); break;
+      case "status": sorted.sort((a, b) => (a.dataset["status"] ?? "").localeCompare(b.dataset["status"] ?? "") || byName(a, b, 1)); break;
+      default:
+        sorted.sort((a, b) => {
+          const ap = a.dataset["status"] === "pending" ? 0 : 1;
+          const bp = b.dataset["status"] === "pending" ? 0 : 1;
+          return ap - bp || byName(a, b, 1);
+        });
+    }
+    sorted.forEach((row) => { list.appendChild(row); });
+  };
+
+  filter?.addEventListener("input", apply);
+  sort?.addEventListener("change", apply);
+  statusFilter?.addEventListener("change", apply);
 }
 
 async function approveProject(slug: string): Promise<void> {

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -838,10 +838,38 @@ function renderSettingsProjects(
   groups: import("./types.js").ApiProjectGroup[],
   aliases: import("./types.js").ApiAlias[],
 ): string {
+  const sortedProjects = [...projects].sort((a, b) => {
+    const aPending = (a.status ?? a.Status) === "pending" ? 0 : 1;
+    const bPending = (b.status ?? b.Status) === "pending" ? 0 : 1;
+    if (aPending !== bPending) return aPending - bPending;
+    const aName = String(a.name ?? a.Name ?? a.slug ?? a.Slug ?? "").toLowerCase();
+    const bName = String(b.name ?? b.Name ?? b.slug ?? b.Slug ?? "").toLowerCase();
+    return aName.localeCompare(bName);
+  });
+
   const projectList = `
     <div class="section">
       <h3>Projects</h3>
-      ${projects.length === 0 ? `<p class="muted">No projects yet. Use the Quick Setup URL on the <a href="#/settings/overview">Settings overview</a>.</p>` : projects.map(p => {
+      ${projects.length === 0 ? `<p class="muted">No projects yet. Use the Quick Setup URL on the <a href="#/settings/overview">Settings overview</a>.</p>` : `
+      <div class="project-controls">
+        <input type="search" id="project-filter" placeholder="Filter projects…" autocomplete="off" />
+        <select id="project-sort">
+          <option value="default">Pending first, then A–Z</option>
+          <option value="name-asc">Name A–Z</option>
+          <option value="name-desc">Name Z–A</option>
+          <option value="issues-desc">Most issues</option>
+          <option value="events-desc">Most events</option>
+          <option value="logs-desc">Most logs</option>
+          <option value="status">Status</option>
+        </select>
+        <select id="project-status-filter">
+          <option value="all">All statuses</option>
+          <option value="pending">Pending</option>
+          <option value="active">Active</option>
+        </select>
+      </div>
+      <div id="project-list">
+      ${sortedProjects.map(p => {
         const slug = String(p.slug ?? p.Slug ?? '');
         const name = String(p.name ?? p.Name ?? slug);
         const status = String(p.status ?? p.Status ?? 'active');
@@ -851,7 +879,7 @@ function renderSettingsProjects(
         const logs = p.log_count ?? 0;
         const group = p.group_id != null ? groups.find(g => g.id === p.group_id) : undefined;
         return `
-          <div class="project-row">
+          <div class="project-row" data-slug="${escapeAttr(slug)}" data-name="${escapeAttr(name.toLowerCase())}" data-status="${escapeAttr(status)}" data-issues="${issues}" data-events="${events}" data-logs="${logs}">
             <div class="project-info">
               <strong>${escapeHtml(name)}</strong>
               <span class="project-slug">${escapeHtml(slug)}</span>
@@ -871,6 +899,7 @@ function renderSettingsProjects(
             </div>
           </div>`;
       }).join('')}
+      </div>`}
     </div>`;
 
   const groupsSection = `

--- a/web/styles.css
+++ b/web/styles.css
@@ -1127,6 +1127,11 @@ button:disabled {
   padding: 0 10px;
 }
 
+.ghost.btn-sm {
+  min-height: 24px;
+  padding: 3px 10px;
+}
+
 .ghost {
   display: inline-flex;
   align-items: center;
@@ -1895,6 +1900,20 @@ button:disabled {
 }
 
 /* ── Project rows (settings page) ──────────────────────── */
+
+.project-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.project-controls #project-filter {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+.project-controls select {
+  flex: 0 1 auto;
+}
 
 .project-row {
   display: flex;


### PR DESCRIPTION
## Summary
- Float pending projects to the top of the settings projects list; add filter input and sort/status dropdowns
- Fix Setup button being taller than Approve/Reject/Delete by overriding `.ghost` min-height when combined with `.btn-sm`
- Add server-side Caddy redirect from `/` to `/app/` when the `bugbarn_csrf` cookie is set, so logged-in users no longer land on the marketing page

## Test plan
- [ ] Open Settings → Projects, confirm pending projects appear at top
- [ ] Type in the filter input — only matching projects remain visible
- [ ] Change the sort dropdown — order updates
- [ ] Visually compare Setup vs Approve/Reject/Delete heights — should match
- [ ] While logged in, visit https://bugbarn.wiebe.xyz/ — should redirect to /app/