### PR TITLE
feat(auth): friendly OIDC access-denied with switch-account flow

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -25,8 +25,10 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type oidcConfigOut struct {
-		Enabled  bool   `json:"enabled"`
-		LoginURL string `json:"loginURL,omitempty"`
+		Enabled          bool   `json:"enabled"`
+		LoginURL         string `json:"loginURL,omitempty"`
+		SwitchAccountURL string `json:"switchAccountURL,omitempty"`
+		EndSessionURL    string `json:"endSessionURL,omitempty"`
 	}
 
 	type iambarnConfig struct {
@@ -56,7 +58,12 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if s.oidc != nil {
-		cfg.OIDC = oidcConfigOut{Enabled: true, LoginURL: "/api/v1/oidc/login"}
+		cfg.OIDC = oidcConfigOut{
+			Enabled:          true,
+			LoginURL:         "/api/v1/oidc/login",
+			SwitchAccountURL: "/api/v1/oidc/login?prompt=login",
+			EndSessionURL:    s.oidc.EndSessionURL(),
+		}
 		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
 			cfg.IAMBarn.ProfileURL = issuer + "/admin#profile"
 		}

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
@@ -25,7 +26,17 @@ func (s *Server) oidcLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	state := randomToken()
 	nonce := randomToken()
-	authURL, err := s.oidc.AuthorizeURL(state, nonce)
+	// Allow the SPA to ask iambarn to re-prompt (e.g. after we rejected the
+	// previous identity for not having access). Only the two standard OIDC
+	// values are accepted.
+	prompt := ""
+	switch r.URL.Query().Get("prompt") {
+	case "login":
+		prompt = "login"
+	case "select_account":
+		prompt = "select_account"
+	}
+	authURL, err := s.oidc.AuthorizeURL(state, nonce, prompt)
 	if err != nil {
 		s.logger.Warn("oidc: build authorize url", "error", err)
 		http.Error(w, "oidc unavailable", http.StatusServiceUnavailable)
@@ -69,7 +80,17 @@ func (s *Server) oidcCallback(w http.ResponseWriter, r *http.Request) {
 	if !s.oidc.Allowed(claims) {
 		s.logger.Warn("oidc: access denied",
 			"sub", claims.Subject, "groups", claims.Groups, "roles", claims.Roles)
-		http.Error(w, "access denied: user is not a member of the required group", http.StatusForbidden)
+		// Clear the short-lived state/nonce cookies before redirecting so the
+		// SPA's "Switch account" button starts a clean flow.
+		secure := secureCookie(r)
+		http.SetCookie(w, oidcShortLivedCookie(oidcStateCookie, "", secure))
+		http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, "", secure))
+		q := url.Values{}
+		q.Set("oidc_error", "access_denied")
+		if id := claims.PreferredName(); id != "" {
+			q.Set("identity", id)
+		}
+		http.Redirect(w, r, "/?"+q.Encode(), http.StatusFound)
 		return
 	}
 	if s.sessions == nil {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -57,12 +57,33 @@ func (c *OIDCClient) Config() OIDCConfig { return c.cfg }
 
 // AuthorizeURL builds the URL the browser should be redirected to. The caller
 // is responsible for storing state + nonce in short-lived cookies and matching
-// them on callback.
-func (c *OIDCClient) AuthorizeURL(state, nonce string) (string, error) {
+// them on callback. If prompt is non-empty (e.g. "login", "select_account"),
+// it is forwarded to the IdP so the user is re-prompted instead of silently
+// reusing an existing IdP session.
+func (c *OIDCClient) AuthorizeURL(state, nonce, prompt string) (string, error) {
 	if err := c.ensureReady(context.Background()); err != nil {
 		return "", err
 	}
-	return c.oauth.AuthCodeURL(state, oidcv3.Nonce(nonce)), nil
+	opts := []oauth2.AuthCodeOption{oidcv3.Nonce(nonce)}
+	if prompt != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("prompt", prompt))
+	}
+	return c.oauth.AuthCodeURL(state, opts...), nil
+}
+
+// EndSessionURL returns the issuer's RP-initiated logout endpoint, or "" if
+// the issuer's discovery document doesn't advertise one.
+func (c *OIDCClient) EndSessionURL() string {
+	if err := c.ensureReady(context.Background()); err != nil {
+		return ""
+	}
+	var meta struct {
+		EndSessionEndpoint string `json:"end_session_endpoint"`
+	}
+	if err := c.provider.Claims(&meta); err != nil {
+		return ""
+	}
+	return meta.EndSessionEndpoint
 }
 
 // Exchange swaps an authorization code for tokens and verifies the ID token's

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1757,10 +1757,15 @@ function _renderDetail(): void {
 
 function renderLogin(error = ""): void {
   stopLiveStream();
-  // If OIDC is configured server-side, auto-redirect to the OIDC login URL
-  // instead of showing the local password form. The local form is still wired
-  // up and reachable by other code paths when OIDC is not enabled.
-  void maybeRedirectToOIDC();
+  // If the OIDC callback bounced us here with ?oidc_error=…, show an inline
+  // error card with switch/sign-out actions instead of silently looping the
+  // user back into the IdP (which would just re-reject the same identity).
+  const oidcErr = readOIDCErrorFromURL();
+  if (oidcErr) {
+    void renderOIDCAccessDenied(oidcErr);
+  } else {
+    void maybeRedirectToOIDC();
+  }
   if (loginScreen) loginScreen.hidden = false;
   if (appFrame) appFrame.hidden = true;
   if (loginError) {
@@ -1770,13 +1775,68 @@ function renderLogin(error = ""): void {
   (loginForm?.querySelector('input[name="username"]') as HTMLInputElement | null)?.focus();
 }
 
+type OIDCRuntime = {
+  enabled?: boolean;
+  loginURL?: string;
+  switchAccountURL?: string;
+  endSessionURL?: string;
+};
+
+function readOIDCErrorFromURL(): { code: string; identity: string } | null {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("oidc_error");
+  if (!code) return null;
+  return { code, identity: params.get("identity") ?? "" };
+}
+
+async function renderOIDCAccessDenied(err: { code: string; identity: string }): Promise<void> {
+  let oc: OIDCRuntime | undefined;
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (res.ok) {
+      const cfg = await res.json() as { oidc?: OIDCRuntime };
+      oc = cfg?.oidc;
+    }
+  } catch {
+    // Best-effort — we still render a useful message even without runtime config.
+  }
+  if (loginError) {
+    const who = err.identity ? ` as ${err.identity}` : "";
+    loginError.hidden = false;
+    loginError.textContent = "";
+    const msg = document.createElement("div");
+    msg.textContent = `You're signed in to IAMBarn${who}, but that account doesn't have access to BugBarn.`;
+    loginError.appendChild(msg);
+    const actions = document.createElement("div");
+    actions.className = "login-error-actions";
+    if (oc?.switchAccountURL ?? oc?.loginURL) {
+      const a = document.createElement("a");
+      a.href = oc.switchAccountURL ?? oc.loginURL!;
+      a.textContent = "Switch account";
+      actions.appendChild(a);
+    }
+    if (oc?.endSessionURL) {
+      const a = document.createElement("a");
+      const ret = `${window.location.origin}/`;
+      const sep = oc.endSessionURL.includes("?") ? "&" : "?";
+      a.href = `${oc.endSessionURL}${sep}post_logout_redirect_uri=${encodeURIComponent(ret)}`;
+      a.textContent = "Sign out of IAMBarn";
+      actions.appendChild(a);
+    }
+    if (actions.children.length) loginError.appendChild(actions);
+  }
+  // Strip the query string so a reload doesn't re-show the error (and doesn't
+  // leak the identity into browser history beyond this view).
+  history.replaceState(null, "", window.location.pathname + window.location.hash);
+}
+
 let oidcRedirectStarted = false;
 async function maybeRedirectToOIDC(): Promise<void> {
   if (oidcRedirectStarted) return;
   try {
     const res = await fetch("/api/v1/runtime-config");
     if (!res.ok) return;
-    const cfg = await res.json() as { oidc?: { enabled?: boolean; loginURL?: string } };
+    const cfg = await res.json() as { oidc?: OIDCRuntime };
     const oc = cfg?.oidc;
     if (oc?.enabled && oc.loginURL) {
       oidcRedirectStarted = true;

--- a/web/styles.css
+++ b/web/styles.css
@@ -167,6 +167,17 @@ h2 {
   display: none;
 }
 
+.login-error-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.login-error-actions a {
+  color: var(--danger);
+  text-decoration: underline;
+}
+
 .app-frame {
   display: grid;
   grid-template-columns: var(--sidebar-collapsed) minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- iambarn callback no longer dumps a plain-text 403 when the authenticated identity isn't a member of the required group — it redirects back to the SPA login screen with an inline error card.
- The error card names the rejected identity and offers **Switch account** (re-runs OIDC with `prompt=login`) and **Sign out of IAMBarn** (hits the issuer's `end_session_endpoint` with `post_logout_redirect_uri`).
- SPA suppresses its auto-redirect to OIDC while the error is being shown so the user doesn't bounce straight back into the same loop.

No iambarn changes required — `end_session_endpoint` is already advertised in discovery, and `prompt=login` is OIDC core.

## Test plan
- [ ] Sign in to iambarn as a user without the BugBarn group → BugBarn login screen shows the access-denied card with the rejected identity.
- [ ] Click "Switch account" → iambarn re-prompts (doesn't silently reuse the session).
- [ ] Click "Sign out of IAMBarn" → iambarn logout flow, then back to BugBarn.
- [ ] Sign in as an authorized user → still works.