### PR TITLE
feat(web): add Sign out + IAMBarn links to Settings on mobile

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -400,6 +400,35 @@ function parseStack(stack?: string): Array<{ file: string; line: number; column:
   return frames.length > 0 ? frames : undefined;
 }
 
+// Populates the IAMBarn profile + sign-out links on the Settings → Session
+// card. Mobile users have no sidebar/bb-menu, so this is their only path to
+// log out or hop to their iambarn profile.
+async function initSettingsIAMBarnLinks(): Promise<void> {
+  if (!document.cookie.split("; ").some((c) => c.startsWith("bugbarn_auth_method=oidc"))) {
+    return;
+  }
+  let cfg: { iambarn?: { profileURL?: string }; oidc?: OIDCRuntime } = {};
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return;
+    cfg = await res.json() as typeof cfg;
+  } catch {
+    return;
+  }
+  const profile = elements.overviewView.querySelector<HTMLAnchorElement>("#settings-iambarn-profile");
+  if (profile && cfg.iambarn?.profileURL) {
+    profile.href = cfg.iambarn.profileURL;
+    profile.removeAttribute("hidden");
+  }
+  const signOut = elements.overviewView.querySelector<HTMLAnchorElement>("#settings-iambarn-logout");
+  if (signOut && cfg.oidc?.endSessionURL) {
+    const ret = `${window.location.origin}/`;
+    const sep = cfg.oidc.endSessionURL.includes("?") ? "&" : "?";
+    signOut.href = `${cfg.oidc.endSessionURL}${sep}post_logout_redirect_uri=${encodeURIComponent(ret)}`;
+    signOut.removeAttribute("hidden");
+  }
+}
+
 async function initIAMBarnProfileLink(): Promise<void> {
   // Only show the IAMBarn profile link when the current session was
   // actually established via the iambarn OIDC callback — local
@@ -2125,6 +2154,10 @@ function wireSettingsActions(): void {
       setTimeout(() => { copySetupBtn.textContent = "⧉"; }, 1500);
     }
   });
+
+  const logoutBtn = elements.overviewView.querySelector<HTMLButtonElement>("#settings-logout");
+  logoutBtn?.addEventListener("click", () => { void logout(); });
+  void initSettingsIAMBarnLinks();
 
   wireProjectListControls();
 

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -809,6 +809,11 @@ function renderSettingsOverview(
         ${displayName ? `<div class="kv"><span>Display name</span><span>${escapeHtml(displayName)}</span></div>` : ""}
         ${timezone ? `<div class="kv"><span>Timezone</span><span>${escapeHtml(timezone)}</span></div>` : ""}
       </div>
+      <div class="session-actions">
+        <a id="settings-iambarn-profile" target="_blank" rel="noopener noreferrer" hidden>Edit IAMBarn profile</a>
+        <a id="settings-iambarn-logout" hidden>Sign out of IAMBarn</a>
+        <button type="button" id="settings-logout" class="btn-sm">Sign out</button>
+      </div>
     </div>`;
 
   const navItems = `

--- a/web/styles.css
+++ b/web/styles.css
@@ -178,6 +178,20 @@ h2 {
   text-decoration: underline;
 }
 
+.session-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.session-actions a {
+  color: var(--text);
+  text-decoration: underline;
+  font-size: 13px;
+}
+
 .app-frame {
   display: grid;
   grid-template-columns: var(--sidebar-collapsed) minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- The bb-menu (Log out + Edit IAMBarn profile) lives in the sidebar, which is hidden on screens ≤768px — phone users had no way to sign out or jump to their iambarn profile.
- Settings is in the mobile tab bar, so this adds the actions to the Session card on Settings → Overview where they're reachable on mobile (and harmless on desktop, where bb-menu still works).

For OIDC sessions, also surfaces "Edit IAMBarn profile" and "Sign out of IAMBarn" (calls the issuer's `end_session_endpoint` with `post_logout_redirect_uri`).

## Test plan
- [ ] On mobile, Settings → Session shows Sign out + (for OIDC sessions) IAMBarn links.
- [ ] Sign out clears the BugBarn session and shows the login screen.
- [ ] Sign out of IAMBarn logs out of iambarn, then lands back on BugBarn login.
- [ ] Desktop bb-menu still works.