### PR TITLE
fix(web): make Sign out visible on mobile Settings

### DIFF
--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -835,7 +835,7 @@ function renderSettingsOverview(
       </a>
     </div>`;
 
-  return errorBanner + pendingBanner + noProjectsBanner + statsBar + navItems + setupCard + sessionCard;
+  return errorBanner + pendingBanner + noProjectsBanner + sessionCard + statsBar + navItems + setupCard;
 }
 
 function renderSettingsProjects(

--- a/web/styles.css
+++ b/web/styles.css
@@ -183,13 +183,28 @@ h2 {
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
-  margin-top: 12px;
+  margin-top: 16px;
 }
 
 .session-actions a {
   color: var(--text);
   text-decoration: underline;
-  font-size: 13px;
+  font-size: 14px;
+}
+
+#settings-logout {
+  font-size: 14px;
+  padding: 8px 16px;
+  min-height: 36px;
+  border: 1px solid var(--danger);
+  background: transparent;
+  color: var(--danger);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+#settings-logout:hover {
+  background: #401423;
 }
 
 .app-frame {


### PR DESCRIPTION
## Summary
Follow-up to #103. The Session card with the Sign out button was at the bottom of Settings → Overview, below stats / nav / Quick Setup — on a phone that's two screenfuls of scroll, so users reported not seeing the button at all.

- Move the Session card to the top of Settings → Overview (right after any error / pending banners).
- Style the Sign out button with a danger-colored border and 36px min-height so it reads as a clear action.

## Test plan
- [ ] On mobile, Settings → Overview shows the Session card and Sign out button without scrolling.
- [ ] Sign out still works.