### PR TITLE
fix(auth): redirect back to BugBarn after iambarn sign-out

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
+
+	"github.com/wiebe-xyz/bugbarn/internal/auth"
 )
 
 // serveRuntimeConfig returns public (non-secret) configuration that the web
@@ -62,7 +65,7 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 			Enabled:          true,
 			LoginURL:         "/api/v1/oidc/login",
 			SwitchAccountURL: "/api/v1/oidc/login?prompt=login",
-			EndSessionURL:    s.oidc.EndSessionURL(),
+			EndSessionURL:    buildEndSessionURL(s.oidc.EndSessionURL(), s.oidc.Config()),
 		}
 		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
 			cfg.IAMBarn.ProfileURL = issuer + "/admin#profile"
@@ -70,4 +73,29 @@ func (s *Server) serveRuntimeConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, cfg)
+}
+
+// buildEndSessionURL appends the OIDC client_id and a post_logout_redirect_uri
+// pointing at this barn's origin to the issuer's end-session endpoint.
+// iambarn (and the OIDC spec) require the URI to be allowlisted on the
+// identified client; without client_id the IdP falls through to a default
+// redirect (in iambarn's case, back to its own root), stranding the user on
+// the IdP page instead of returning them here.
+func buildEndSessionURL(raw string, cfg auth.OIDCConfig) string {
+	if raw == "" || cfg.ClientID == "" || cfg.RedirectURL == "" {
+		return raw
+	}
+	u, err := url.Parse(cfg.RedirectURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return raw
+	}
+	postLogout := u.Scheme + "://" + u.Host + "/"
+	q := url.Values{}
+	q.Set("client_id", cfg.ClientID)
+	q.Set("post_logout_redirect_uri", postLogout)
+	sep := "?"
+	if strings.Contains(raw, "?") {
+		sep = "&"
+	}
+	return raw + sep + q.Encode()
 }

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -230,6 +230,11 @@ envSelect?.addEventListener("change", () => {
 });
 
 async function logout(): Promise<void> {
+  // Snapshot before /api/v1/logout clears the hint cookie — if this session
+  // came from iambarn we must also end the IdP session, otherwise the SPA's
+  // login screen would auto-redirect back into iambarn, iambarn would reuse
+  // its still-valid session, and the user would bounce straight back in.
+  const wasOIDC = document.cookie.split("; ").some((c) => c.startsWith("bugbarn_auth_method=oidc"));
   try {
     await fetch(apiUrl("/api/v1/logout"), { method: "POST", credentials: "include" });
   } catch {
@@ -238,7 +243,25 @@ async function logout(): Promise<void> {
   state.authenticated = false;
   state.username = "";
   stopLiveStream();
+  if (wasOIDC) {
+    const endURL = await fetchIAMBarnEndSessionURL();
+    if (endURL) {
+      window.location.assign(endURL);
+      return;
+    }
+  }
   renderLogin();
+}
+
+async function fetchIAMBarnEndSessionURL(): Promise<string> {
+  try {
+    const res = await fetch("/api/v1/runtime-config");
+    if (!res.ok) return "";
+    const cfg = await res.json() as { oidc?: OIDCRuntime };
+    return cfg?.oidc?.endSessionURL ?? "";
+  } catch {
+    return "";
+  }
 }
 
 function updateBBMenuUser(): void {


### PR DESCRIPTION
## Summary
- iambarn's `end_session_endpoint` requires `client_id` + an allowlisted `post_logout_redirect_uri` to honor the redirect. We were sending neither, so iambarn fell through to a hardcoded redirect to its own `/`, stranding users on the IdP page.
- Build the end-session URL server-side in `runtime-config`, embedding `client_id` and `post_logout_redirect_uri` set to this barn's origin (derived from the OIDC RedirectURL host).
- Route the plain **Sign out** button through the same URL when the session came from iambarn, so the SPA's auto-redirect-to-OIDC doesn't silently log the user back in.

## iambarn-side step required
The BugBarn OAuth client in iambarn must list `https://bugbarn.wiebe.xyz/` in its **Post-logout URIs** (admin UI → Clients → BugBarn).

## Test plan
- [ ] After iambarn-side config: Sign out from Settings → lands on BugBarn marketing page (root), not iambarn.
- [ ] Sign out of IAMBarn link does the same.
- [ ] Local (non-OIDC) Sign out unaffected.