### PR TITLE
fix(packaging): rename apt package bb -> bugbarn-cli

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,12 +15,11 @@ brew install bb
 
 ### APT (Debian / Ubuntu)
 
+The Linux package is named `bugbarn-cli` (to avoid a name collision with Ubuntu universe's `bb`). The binary on PATH is still `bb`.
+
 ```sh
-curl -fsSL https://webwiebe.nl/apt/key.gpg \
-  | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/webwiebe.gpg
-echo "deb https://webwiebe.nl/apt/ stable main" \
-  | sudo tee /etc/apt/sources.list.d/webwiebe.list
-sudo apt-get update && sudo apt-get install bb
+curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash
+sudo apt install bugbarn-cli
 ```
 
 ### Build from source

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,11 +16,14 @@ brew install bugbarn
 ### APT (Debian / Ubuntu)
 
 ```sh
-curl -fsSL https://webwiebe.nl/apt/key.gpg \
-  | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/webwiebe.gpg
-echo "deb https://webwiebe.nl/apt/ stable main" \
-  | sudo tee /etc/apt/sources.list.d/webwiebe.list
-sudo apt-get update && sudo apt-get install bugbarn
+curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash
+sudo apt install bugbarn
+```
+
+To also install the `bb` CLI:
+
+```sh
+sudo apt install bugbarn-cli
 ```
 
 ### Docker Compose (pre-built images)
@@ -242,7 +245,7 @@ Service worker updates are versioned by a hash of the compiled assets. New deplo
 `bb` is a standalone CLI for querying BugBarn from the terminal or from AI agents.
 
 ```sh
-brew install webwiebe/bugbarn/bb   # or: sudo apt-get install bb
+brew install webwiebe/bugbarn/bb   # or: sudo apt install bugbarn-cli
 bb login --url http://localhost:8080 --api-key <your-api-key>
 bb issues                          # list open issues (JSON)
 bb logs -f                         # live-tail logs

--- a/nfpm-bb.yaml
+++ b/nfpm-bb.yaml
@@ -1,11 +1,13 @@
-name: bb
+name: bugbarn-cli
 arch: "${GOARCH}"
 platform: linux
 version: "${VERSION}"
 maintainer: "Wiebe Zweers <bugbarn@wiebe.xyz>"
 description: |
-  bb - BugBarn CLI client.
+  BugBarn CLI client (bb).
   Query and manage BugBarn issues from the command line.
+  Installs /usr/bin/bb. Renamed from the `bb` package to avoid a
+  name collision with Ubuntu universe's bb (ASCII art demo).
 vendor: "BugBarn"
 homepage: "https://github.com/wiebe-xyz/bugbarn"
 license: "MIT"

--- a/site/src/components/Install.astro
+++ b/site/src/components/Install.astro
@@ -33,14 +33,10 @@ brew install bugbarn</pre>
           </svg>
           <span class="text-xs font-mono font-semibold uppercase tracking-wider" style="color: #8b949e;">APT (Debian/Ubuntu)</span>
         </div>
-        <pre class="rounded-lg overflow-x-auto text-xs leading-relaxed" style="background-color: #0d1117; border: 1px solid #21262d; padding: 1.25rem 1.5rem; color: #c9d1d9; white-space: pre;">curl -fsSL https://webwiebe.nl/apt/key.gpg \
-  | sudo gpg --dearmor \
-    -o /etc/apt/trusted.gpg.d/webwiebe.gpg
-echo "deb https://webwiebe.nl/apt/ stable main" \
-  | sudo tee \
-    /etc/apt/sources.list.d/webwiebe.list
-sudo apt-get update \
-  &amp;&amp; sudo apt-get install bugbarn</pre>
+        <pre class="rounded-lg overflow-x-auto text-xs leading-relaxed" style="background-color: #0d1117; border: 1px solid #21262d; padding: 1.25rem 1.5rem; color: #c9d1d9; white-space: pre;">curl -fsSL \
+  https://webwiebe.nl/apt/install.sh \
+  | sudo bash
+sudo apt install bugbarn</pre>
       </div>
 
       <!-- Docker -->
@@ -67,14 +63,24 @@ sudo apt-get update \
       <span style="color: #b5843a;">$</span> CLI client
     </h3>
     <p class="text-sm mb-4" style="color: #8b949e;">
-      <code class="font-mono" style="color: #c9d1d9;">bb</code> lets you query issues, live-tail logs, and manage projects from the terminal. JSON output for agents, interactive TUI for developers.
+      <code class="font-mono" style="color: #c9d1d9;">bb</code> lets you query issues, live-tail logs, and manage projects from the terminal. JSON output for agents, interactive TUI for developers. The CLI is packaged separately from the server.
     </p>
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
       <div>
+        <span class="text-xs font-mono font-semibold uppercase tracking-wider block mb-2" style="color: #8b949e;">Homebrew (macOS)</span>
         <pre class="rounded-lg overflow-x-auto text-xs leading-relaxed" style="background-color: #0d1117; border: 1px solid #21262d; padding: 1.25rem 1.5rem; color: #c9d1d9; white-space: pre;">brew install webwiebe/bugbarn/bb
-bb login --url https://your-instance --api-key KEY</pre>
+bb login --url https://your-instance \
+  --api-key KEY</pre>
       </div>
       <div>
+        <span class="text-xs font-mono font-semibold uppercase tracking-wider block mb-2" style="color: #8b949e;">APT (Debian/Ubuntu)</span>
+        <pre class="rounded-lg overflow-x-auto text-xs leading-relaxed" style="background-color: #0d1117; border: 1px solid #21262d; padding: 1.25rem 1.5rem; color: #c9d1d9; white-space: pre;">curl -fsSL \
+  https://webwiebe.nl/apt/install.sh \
+  | sudo bash
+sudo apt install bugbarn-cli</pre>
+      </div>
+      <div>
+        <span class="text-xs font-mono font-semibold uppercase tracking-wider block mb-2" style="color: #8b949e;">Usage</span>
         <pre class="rounded-lg overflow-x-auto text-xs leading-relaxed" style="background-color: #0d1117; border: 1px solid #21262d; padding: 1.25rem 1.5rem; color: #c9d1d9; white-space: pre;">bb issues                # list open issues (JSON)
 bb logs -f --level warn  # live-tail warnings
 bb tui                   # interactive browser</pre>

--- a/site/src/pages/llm.astro
+++ b/site/src/pages/llm.astro
@@ -39,8 +39,8 @@ Key concepts:
 
 ## Installation
 
-BugBarn ships as two separate artifacts: the `bugbarn` server (HTTP API + UI + worker)
-and the `bb` CLI client. Install one, both, or only the CLI to talk to a remote server.
+BugBarn ships as two separate artifacts: the bugbarn server (HTTP API + UI + worker)
+and the bb CLI client. Install one, both, or only the CLI to talk to a remote server.
 
 ### Server: APT (Debian/Ubuntu)
   curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash

--- a/site/src/pages/llm.astro
+++ b/site/src/pages/llm.astro
@@ -39,14 +39,23 @@ Key concepts:
 
 ## Installation
 
-### APT (Debian/Ubuntu)
-  curl -fsSL https://webwiebe.nl/apt/key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/webwiebe.gpg
-  echo "deb https://webwiebe.nl/apt/ stable main" | sudo tee /etc/apt/sources.list.d/webwiebe.list
-  sudo apt-get update && sudo apt-get install bugbarn
+BugBarn ships as two separate artifacts: the `bugbarn` server (HTTP API + UI + worker)
+and the `bb` CLI client. Install one, both, or only the CLI to talk to a remote server.
 
-### Homebrew (macOS / Linux)
+### Server: APT (Debian/Ubuntu)
+  curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash
+  sudo apt install bugbarn
+
+### Server: Homebrew (macOS / Linux)
   brew tap webwiebe/bugbarn
   brew install bugbarn
+
+### CLI: APT (Debian/Ubuntu)
+  curl -fsSL https://webwiebe.nl/apt/install.sh | sudo bash
+  sudo apt install bugbarn-cli  # binary on PATH: bb
+
+### CLI: Homebrew (macOS / Linux)
+  brew install webwiebe/bugbarn/bb
 
 ### Docker
   docker run -d \\


### PR DESCRIPTION
## Summary

- `bb` on apt was unreachable: it collided with Ubuntu universe's `bb` (ASCII-art demo) at equal priority, and Debian version comparison ranked Ubuntu's `1.3rc1-13` above webwiebe's `0.236.x`. Renaming the Linux package to `bugbarn-cli` dodges the collision. Binary on PATH stays `bb`; the Homebrew formula is untouched (no name clash on macOS).
- Marketing page's APT snippet was broken in two ways: it pointed at `https://webwiebe.nl/apt/key.gpg` (404 — the repo serves the key at `gpg.key`), and it used the deprecated `/etc/apt/trusted.gpg.d/` style with no `signed-by=`, which conflicts with anyone who already has another source pointing at the same repo (e.g. `pr-buddy.list`). Switched to the canonical `install.sh` one-liner that funnelbarn already uses.
- Marketing page now shows server vs CLI as two distinct install paths (`apt install bugbarn` for the server, `apt install bugbarn-cli` for the CLI), matching the existing Homebrew layout.

## Out of scope (separate follow-ups)

- The `binary-release` workflow has been failing every push since 2026-05-24 because the `Update Homebrew Tap (MinIO)` step hits a self-signed-cert error against MinIO (`SSL: CERTIFICATE_VERIFY_FAILED`). The apt path still publishes (the `Attach .deb to Release` job succeeds and dispatches to rapid-root), but the workflow run shows red and the brew tap is stale.
- The apt repo currently still carries the old `bb 0.236.3` package alongside whatever next-release ships `bugbarn-cli`. Pruning the renamed-out package from MinIO is an operational follow-up on the rapid-root apt-repo-update workflow.

## Test plan

- [ ] CI: `apt-rename-bb-cli` branch goes green (compile/test/lint)
- [ ] After merge + release: `apt-cache policy bugbarn-cli` resolves to `https://webwiebe.nl/apt` and `apt install bugbarn-cli` installs `/usr/bin/bb`
- [ ] `bb --version` reports the new version
- [ ] Marketing page renders correctly with three-column CLI grid (Homebrew / APT / Usage)