### PR TITLE
chore(ci-secrets): add github.release_tag_pat reference

### DIFF
--- a/deploy/ci-secrets.yaml
+++ b/deploy/ci-secrets.yaml
@@ -8,7 +8,13 @@ npm:
     token: ENC[AES256_GCM,data:qfm+8J7cCBco6aq9X2vfeoCkPQoIOxP90qnVcjTTPOPJxcJl5TEEug==,iv:gopSnSwuB2iQVUgTe2FyBELW4RhUXR1+Jg9Y7ulPWqA=,tag:ZL464A5TiSNh9mACmekQbg==,type:str]
 pypi:
     token: ENC[AES256_GCM,data:E3S/SCC3uKYCY9qMoMlR66BLrXeOLM0/iN2V95oz61GffmVBFpJFoRAC9v5Somxl48UOm2skfxXmArjVPBNqxFwH/EcCrRkXMn7z5vx2QkI32rnjTcjH0MWQ1wjFqjHZHJMvyU0SprFUhts+x6X7Nxjyz58/wmQmGEYaQ3F3JM6lwslhzgy7IQInKyhuMAdfljBFn80TJ2xT184S4RnXrmuiHNTgu3k9wDj06xqUd9bAdjw=,iv:PpBXkbGW6b52BtznxSO3037BPwLD7A+rYvstuZAsCq0=,tag:C/KpXesEzfxEDqBj47Nd0w==,type:str]
+github:
+    release_tag_pat: ENC[AES256_GCM,data:9XI/O7FwotbVpohApnQ+pCqMnVE3wqyZ6ym1UnFhfj2YPn1v6zWOkw==,iv:M5aKFIOdfolfa4PxLVVu/GxaGVX3Au5CosDEGzfkPT0=,tag:kQiDfrr+i9Y/hRwJhi5wBQ==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -19,7 +25,8 @@ sops:
             bUxVK01xR3VCNEEwYzBqMnVvZmE2NjQKLL9MbTRwWyp/auRXeWytQR29W/Exbi9Y
             fDXC0Ob8zoMLpzMmCdHfP4filAWuMY/COXQj1PH6MPJolw+/dliuog==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T10:22:37Z"
-    mac: ENC[AES256_GCM,data:S4IwISw6oZHAod0c+7Vd+tqguA8q9JhYH+QCt5NY6Dsvubb5N77HQmDkn7iM8yonBy/twxumvy35vF2CW+1ge5L8f+QxV8QrfHUDcvfD/8mkhmcUlgDW0nTOne8WafZx9K3Na/ZAoZcAyKHFIrvADUgjVz/+x2+4KrA9bGLq5Hs=,iv:OZCRstyOQa6PzeZl+F5Qp8a/vcYHrhHDcZ0cNrVldxE=,tag:CxATsH/52o3oZ+zvFyQ0xA==,type:str]
+    lastmodified: "2026-05-29T20:16:52Z"
+    mac: ENC[AES256_GCM,data:xscxWaU6Bc2uB/KglVeQ92rnJ1/KsOC1XSUuJ0oA2qPAsOu3I/JmbW6I5LezXBc8s+cMYxLhtW3QqBUDrH7vTcK9B7Zx1GyOF5cbGlLtD2byMbWdSFS0D0dlDLxs6HiIlBpiLOch39MDnjjFvcAXp7rq1Rqq2suKFMy0DcHj/d0=,iv:z5NqKPnYm8VjEKkHTHIVZJxIXR/E0GKGXosG+zR9Idc=,tag:th7O1WzVFddsXjCGHzqOGg==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

Adds the GitHub classic PAT used by the upcoming `binary-release.yml` auto-tag patch as an encrypted reference inside `deploy/ci-secrets.yaml`. The live value is already set on this repo as the GitHub Actions secret `RELEASE_TAG_TOKEN`.

## What's the PAT for

- `binary-release.yml` currently pushes its auto-generated `v*` tags using the default `GITHUB_TOKEN`. GitHub Actions explicitly suppresses workflow triggers for events generated by `GITHUB_TOKEN`, so the auto-tag never fires `release.yml` (the staging deploy). Tags have to be re-pushed manually under a human identity to get staging going (we hit this today on v0.236.37).
- Swapping the auto-tag step to use `RELEASE_TAG_TOKEN` instead — webwiebe-authored — makes the bot-tag → staging-deploy chain self-running. The workflow PR is the follow-up after this lands.

## What's in this PR

- `deploy/ci-secrets.yaml`: adds `github.release_tag_pat` key under the existing SOPS-encrypted reference file.

## Properties of the token

- Owner: webwiebe (verified via `GET /user`)
- Type: classic PAT
- Scopes (from `X-OAuth-Scopes`): `repo`, `workflow`, plus broader admin scopes
- Push permission on `webwiebe/bugbarn`: confirmed by pushing + deleting a non-`v*` test tag (`test-pat-perms-*`); no spurious workflows triggered.

## Test plan

- [ ] CI green
- [ ] After merge: separate PR will wire `RELEASE_TAG_TOKEN` into `binary-release.yml`'s tag job; once that lands, the next push to main should auto-trigger staging deploy without manual tag re-push.