### PR TITLE
fix(ci): use RELEASE_TAG_TOKEN for auto-tag push so release.yml fires

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # Authenticate the checkout (and subsequent `git push`) with a PAT
+          # instead of the default GITHUB_TOKEN so that the auto-generated v*
+          # tag triggers downstream workflows. Events created by GITHUB_TOKEN
+          # are explicitly suppressed by Actions (except workflow_dispatch /
+          # repository_dispatch), which is why the tag-push from this job
+          # never used to fire `release.yml` (staging deploy) — tags had to
+          # be re-pushed manually under a human identity to start staging.
+          token: ${{ secrets.RELEASE_TAG_TOKEN }}
 
       - name: Get latest tag
         id: latest_tag


### PR DESCRIPTION
## Summary

Auth the \`actions/checkout@v6\` in the auto-tag job with \`RELEASE_TAG_TOKEN\` (a webwiebe-owned classic PAT) instead of the default \`GITHUB_TOKEN\`. The subsequent \`git push origin <newtag>\` then runs under the PAT's identity rather than \`github-actions[bot]\`, which lets the resulting \`push:tags\` event fire \`release.yml\`.

## Why

Actions suppresses workflow triggers for events created by \`GITHUB_TOKEN\` (only \`workflow_dispatch\` and \`repository_dispatch\` are excepted). The auto-tag step's \`git push\` is exactly that case, so the tag it creates never starts the staging deploy. We last hit this on v0.236.37 — had to delete-and-rePush the tag locally for staging to begin.

## What this closes out

End state: pushing to \`main\` will (1) build .debs, (2) auto-tag, (3) **automatically** trigger \`release.yml\` (staging retag + deploy), and (4) keep dispatching to rapid-root for the apt repo. No more manual tag re-pushes between merge and staging.

## Test plan

After merge:
- Push any change to main → check the resulting `Binary Release` run creates `v0.236.38`.
- Check `gh run list --workflow=release.yml` shows a new `Release and Deploy Staging` run with `event: push, headBranch: v0.236.38` — fired by the bot tag, not a manual re-push.
- No need to dispatch staging manually.

Encrypted reference for the token lives at \`deploy/ci-secrets.yaml\` (\`github.release_tag_pat\`).