### PR TITLE
feat(tracing): tail-based sampler — error traces always, 10% otherwise

### DIFF
--- a/internal/tracing/sampler.go
+++ b/internal/tracing/sampler.go
@@ -1,0 +1,160 @@
+package tracing
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TailSampler is a SpanProcessor that makes per-trace sampling decisions after
+// all spans have ended (tail-based). It wraps an inner processor (typically the
+// batch exporter) and only forwards traces that pass the sampling policy:
+//
+//   - Traces containing at least one error span are always forwarded.
+//   - All other traces are forwarded with probability ratio.
+//
+// Spans are buffered in memory until the root span ends, at which point the
+// whole trace is either forwarded or dropped. Traces whose root span never
+// arrives are evicted after ttl and dropped (errors in those traces are still
+// captured via the selflog handler before they reach the tracing layer).
+type TailSampler struct {
+	inner sdktrace.SpanProcessor
+	ratio float64
+	ttl   time.Duration
+
+	mu     sync.Mutex
+	traces map[trace.TraceID]*traceEntry
+	done   chan struct{}
+}
+
+type traceEntry struct {
+	spans    []sdktrace.ReadOnlySpan
+	hasError bool
+	lastSeen time.Time
+}
+
+// NewTailSampler wraps inner with tail-based sampling. ratio must be in [0, 1];
+// 0.1 keeps 10% of non-error traces.
+func NewTailSampler(inner sdktrace.SpanProcessor, ratio float64) *TailSampler {
+	s := &TailSampler{
+		inner:  inner,
+		ratio:  ratio,
+		ttl:    30 * time.Second,
+		traces: make(map[trace.TraceID]*traceEntry),
+		done:   make(chan struct{}),
+	}
+	go s.janitor()
+	return s
+}
+
+func (s *TailSampler) OnStart(parent context.Context, span sdktrace.ReadWriteSpan) {
+	s.inner.OnStart(parent, span)
+}
+
+func (s *TailSampler) OnEnd(span sdktrace.ReadOnlySpan) {
+	traceID := span.SpanContext().TraceID()
+	// Flush on local root: either a true root (no parent at all) or a span whose
+	// parent lives in another process. HTTP handler spans often have a remote
+	// parent from a traceparent header sent by the client or SDK; without this,
+	// those traces would never flush and get evicted by the janitor instead.
+	isRoot := !span.Parent().IsValid() || span.Parent().IsRemote()
+
+	s.mu.Lock()
+	entry := s.traces[traceID]
+	if entry == nil {
+		entry = &traceEntry{}
+		s.traces[traceID] = entry
+	}
+	entry.spans = append(entry.spans, span)
+	entry.lastSeen = time.Now()
+	if span.Status().Code == codes.Error {
+		entry.hasError = true
+	}
+	s.mu.Unlock()
+
+	if isRoot {
+		s.flush(traceID)
+	}
+}
+
+func (s *TailSampler) Shutdown(ctx context.Context) error {
+	close(s.done)
+	s.flushAll()
+	return s.inner.Shutdown(ctx)
+}
+
+func (s *TailSampler) ForceFlush(ctx context.Context) error {
+	return s.inner.ForceFlush(ctx)
+}
+
+func (s *TailSampler) flush(traceID trace.TraceID) {
+	s.mu.Lock()
+	entry := s.traces[traceID]
+	delete(s.traces, traceID)
+	s.mu.Unlock()
+
+	s.export(traceID, entry)
+}
+
+func (s *TailSampler) flushAll() {
+	s.mu.Lock()
+	remaining := s.traces
+	s.traces = make(map[trace.TraceID]*traceEntry)
+	s.mu.Unlock()
+
+	for id, entry := range remaining {
+		s.export(id, entry)
+	}
+}
+
+func (s *TailSampler) export(traceID trace.TraceID, entry *traceEntry) {
+	if entry == nil {
+		return
+	}
+	if entry.hasError || s.keep(traceID) {
+		for _, sp := range entry.spans {
+			s.inner.OnEnd(sp)
+		}
+	}
+}
+
+// keep returns a deterministic, consistent sampling decision for a trace ID.
+// The first 8 bytes of the ID are treated as a big-endian uint64 and compared
+// against a threshold derived from ratio. Because trace IDs are random, this
+// gives approximately ratio fraction of traces.
+func (s *TailSampler) keep(traceID trace.TraceID) bool {
+	var n uint64
+	for i := range 8 {
+		n = n<<8 | uint64(traceID[i])
+	}
+	return n <= uint64(s.ratio*float64(math.MaxUint64))
+}
+
+func (s *TailSampler) janitor() {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.evictStale()
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *TailSampler) evictStale() {
+	cutoff := time.Now().Add(-s.ttl)
+	s.mu.Lock()
+	for id, entry := range s.traces {
+		if entry.lastSeen.Before(cutoff) {
+			delete(s.traces, id)
+		}
+	}
+	s.mu.Unlock()
+}

--- a/internal/tracing/sampler_test.go
+++ b/internal/tracing/sampler_test.go
@@ -1,0 +1,205 @@
+package tracing
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// captureProcessor records spans forwarded to it.
+type captureProcessor struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *captureProcessor) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (c *captureProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	c.mu.Lock()
+	c.spans = append(c.spans, s)
+	c.mu.Unlock()
+}
+func (c *captureProcessor) Shutdown(context.Context) error   { return nil }
+func (c *captureProcessor) ForceFlush(context.Context) error { return nil }
+
+func (c *captureProcessor) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.spans)
+}
+
+// fakeSpan satisfies sdktrace.ReadOnlySpan minimally.
+type fakeSpan struct {
+	sdktrace.ReadOnlySpan
+	sc       trace.SpanContext
+	parentSC trace.SpanContext
+	status   sdktrace.Status
+}
+
+func (f fakeSpan) SpanContext() trace.SpanContext { return f.sc }
+func (f fakeSpan) Parent() trace.SpanContext      { return f.parentSC }
+func (f fakeSpan) Status() sdktrace.Status        { return f.status }
+
+func makeTraceID(b byte) trace.TraceID {
+	var id trace.TraceID
+	id[0] = b
+	return id
+}
+
+func makeSpanID(b byte) trace.SpanID {
+	var id trace.SpanID
+	id[0] = b
+	return id
+}
+
+func rootSpan(traceID trace.TraceID, spanID trace.SpanID, status codes.Code) fakeSpan {
+	return fakeSpan{
+		sc:     trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled}),
+		status: sdktrace.Status{Code: status},
+	}
+}
+
+func childSpan(traceID trace.TraceID, spanID, parentID trace.SpanID, status codes.Code) fakeSpan {
+	return fakeSpan{
+		sc:       trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled}),
+		parentSC: trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: parentID, TraceFlags: trace.FlagsSampled}),
+		status:   sdktrace.Status{Code: status},
+	}
+}
+
+// TestErrorTraceAlwaysExported verifies that a trace with an error child span
+// is always forwarded regardless of the ratio.
+func TestErrorTraceAlwaysExported(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 0) // ratio=0 → only error traces pass
+
+	traceID := makeTraceID(0x01)
+	root := rootSpan(traceID, makeSpanID(0x01), codes.Ok)
+	child := childSpan(traceID, makeSpanID(0x02), makeSpanID(0x01), codes.Error)
+
+	ts.OnEnd(child)
+	ts.OnEnd(root) // root last → triggers flush
+
+	if got := cap.count(); got != 2 {
+		t.Fatalf("expected 2 spans exported, got %d", got)
+	}
+}
+
+// TestNonErrorTraceDroppedAtRatioZero verifies that a healthy trace is dropped
+// when ratio is 0.
+func TestNonErrorTraceDroppedAtRatioZero(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 0)
+
+	traceID := makeTraceID(0x01)
+	root := rootSpan(traceID, makeSpanID(0x01), codes.Ok)
+	child := childSpan(traceID, makeSpanID(0x02), makeSpanID(0x01), codes.Ok)
+
+	ts.OnEnd(child)
+	ts.OnEnd(root)
+
+	if got := cap.count(); got != 0 {
+		t.Fatalf("expected 0 spans exported, got %d", got)
+	}
+}
+
+// TestNonErrorTraceKeptAtRatioOne verifies that all traces pass when ratio=1.
+func TestNonErrorTraceKeptAtRatioOne(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 1.0)
+
+	traceID := makeTraceID(0x01)
+	root := rootSpan(traceID, makeSpanID(0x01), codes.Ok)
+	child := childSpan(traceID, makeSpanID(0x02), makeSpanID(0x01), codes.Ok)
+
+	ts.OnEnd(child)
+	ts.OnEnd(root)
+
+	if got := cap.count(); got != 2 {
+		t.Fatalf("expected 2 spans exported, got %d", got)
+	}
+}
+
+// TestKeepRatioApproximate verifies that the sampling ratio is approximately
+// correct over a large number of traces.
+func TestKeepRatioApproximate(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 0.1)
+
+	const n = 10_000
+	for i := range n {
+		var id trace.TraceID
+		// Use coprime multipliers so the most-significant bytes vary uniformly;
+		// keep() reads the first 8 bytes as a big-endian uint64.
+		id[0] = byte(i * 251)
+		id[1] = byte(i * 127)
+		id[2] = byte(i * 223)
+		id[3] = byte(i * 191)
+		id[4] = byte(i >> 8)
+		id[5] = byte(i)
+		id[6] = byte(i * 13)
+		id[7] = byte(i * 17)
+		ts.OnEnd(rootSpan(id, makeSpanID(0x01), codes.Ok))
+	}
+
+	got := cap.count()
+	// Allow ±3% of n around the 10% target.
+	const lo, hi = n*7/100, n*13/100
+	if got < lo || got > hi {
+		t.Fatalf("expected ~%d traces kept (10%%), got %d", n/10, got)
+	}
+}
+
+// TestRemoteParentFlushes verifies that a span with a remote parent (e.g. an
+// HTTP handler span that received a traceparent header) is treated as a local
+// root and triggers the flush immediately.
+func TestRemoteParentFlushes(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 1.0)
+
+	traceID := makeTraceID(0x01)
+	// Simulate a remote parent: valid but IsRemote=true.
+	remoteSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     makeSpanID(0xFF),
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	dbSpan := fakeSpan{
+		sc:       trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: makeSpanID(0x02), TraceFlags: trace.FlagsSampled}),
+		parentSC: trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: makeSpanID(0x01), TraceFlags: trace.FlagsSampled}),
+		status:   sdktrace.Status{Code: codes.Ok},
+	}
+	handlerSpan := fakeSpan{
+		sc:       trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: makeSpanID(0x01), TraceFlags: trace.FlagsSampled}),
+		parentSC: remoteSC,
+		status:   sdktrace.Status{Code: codes.Ok},
+	}
+
+	ts.OnEnd(dbSpan)
+	ts.OnEnd(handlerSpan) // remote parent → local root → flush
+
+	if got := cap.count(); got != 2 {
+		t.Fatalf("expected 2 spans exported, got %d", got)
+	}
+}
+
+// TestShutdownFlushesErrorTraces verifies that error traces buffered without a
+// root span are forwarded on Shutdown.
+func TestShutdownFlushesErrorTraces(t *testing.T) {
+	cap := &captureProcessor{}
+	ts := NewTailSampler(cap, 0)
+
+	traceID := makeTraceID(0xAA)
+	// Only add a child error span; no root span arrives.
+	ts.OnEnd(childSpan(traceID, makeSpanID(0x01), makeSpanID(0x00), codes.Error))
+
+	_ = ts.Shutdown(context.Background())
+
+	if got := cap.count(); got != 1 {
+		t.Fatalf("expected 1 span exported on shutdown, got %d", got)
+	}
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -65,11 +65,14 @@ func Init(_ context.Context, version string) (shutdown func(context.Context) err
 		return func(context.Context) error { return nil }, nil
 	}
 
+	batcher := sdktrace.NewBatchSpanProcessor(exporter,
+		sdktrace.WithExportTimeout(5*time.Second),
+	)
+
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter,
-			sdktrace.WithExportTimeout(5*time.Second),
-		),
+		sdktrace.WithSpanProcessor(NewTailSampler(batcher, 0.1)),
 		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(


### PR DESCRIPTION
## Summary

- Introduces `TailSampler`, a `SpanProcessor` wrapper that buffers spans per trace and makes a sampling decision when the local root span ends
- Error traces (any span with `codes.Error`) are always forwarded to the exporter
- Non-error traces are kept with 10% probability, deterministic per trace ID so all spans of a sampled trace travel together
- Local root detection handles both true roots and spans with a remote parent (HTTP handler spans that receive a W3C `traceparent` header from a browser or SDK)
- A janitor goroutine evicts orphaned traces after 30s; on `Shutdown`, buffered error traces are flushed before the inner processor stops

## Test plan

- [ ] `TestErrorTraceAlwaysExported` — error child triggers full trace export even at ratio 0
- [ ] `TestNonErrorTraceDroppedAtRatioZero` — healthy traces dropped at ratio 0
- [ ] `TestNonErrorTraceKeptAtRatioOne` — all traces kept at ratio 1
- [ ] `TestKeepRatioApproximate` — 10k traces land within ±3% of 10% target
- [ ] `TestRemoteParentFlushes` — span with remote parent triggers flush (covers HTTP handler spans from SDK/browser clients)
- [ ] `TestShutdownFlushesErrorTraces` — error traces without a root span are exported on shutdown