### PR TITLE
fix(storage): checkpoint the WAL through the single writer connection

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -143,6 +143,16 @@ func run() error {
 	digest.StartScheduler(ctx, cfg.Digest, store, &bgWg)
 	analytics.StartWorker(ctx, store, cfg.AnalyticsRetentionDays, &bgWg)
 
+	// Keep the WAL bounded by running explicit TRUNCATE checkpoints through the
+	// single writer connection. With wal_autocheckpoint(0) this is the only thing
+	// that reclaims the WAL; Litestream's out-of-process checkpoint cannot (it
+	// loses the lock race and logs "database is locked"). See Store.checkpoint.
+	bgWg.Add(1)
+	go func() {
+		defer bgWg.Done()
+		store.RunPeriodicCheckpoint(ctx, 30*time.Second, logger)
+	}()
+
 	apiAuthorizer, err := newAPIAuthorizer(cfg, store)
 	if err != nil {
 		return err
@@ -208,6 +218,10 @@ func run() error {
 		case <-shutdownCtx.Done():
 			slog.Warn("worker did not drain before shutdown deadline")
 		}
+		// All writers have stopped: merge the WAL into the main file so the next
+		// start (and Litestream's restore) sees a small WAL. Must run before the
+		// deferred store.Close(), since wal_autocheckpoint(0) disables Close's own.
+		store.FinalCheckpoint(logger)
 		if selfReporting {
 			bb.Shutdown(2 * time.Second)
 		}

--- a/internal/storage/checkpoint.go
+++ b/internal/storage/checkpoint.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RunPeriodicCheckpoint blocks until ctx is cancelled, issuing a WAL TRUNCATE
+// checkpoint on each tick. When a checkpoint returns busy=1 (a reader snapshot
+// blocks full WAL backfill) it retries every retryInterval until the readers
+// release or the next full-interval tick arrives.
+//
+// The checkpoint MUST run on the writer connection (s.db), not a second
+// connection or an out-of-process tool. SQLite permits one writer at the file
+// level; a separate connection upgrades its deferred transaction to a write
+// lock and returns SQLITE_BUSY immediately, bypassing busy_timeout. That is
+// exactly why Litestream's out-of-process PASSIVE checkpoint logs
+// "checkpoint: database is locked" every second under write load. Serialising
+// the checkpoint through s.db means it simply queues in Go's pool behind the
+// other (tiny) write transactions and always gets a clean window.
+//
+// Litestream stays active for S3 replication. Its WAL-level reader lock holds a
+// snapshot at the last frame it has shipped, so this TRUNCATE checkpoint can
+// never reclaim frames Litestream has not yet confirmed — SQLite blocks the
+// backfill at that boundary (busy=1) and we retry. Dual checkpointing is safe.
+func (s *Store) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, log *slog.Logger) {
+	if s == nil || s.db == nil {
+		return
+	}
+	retryInterval := 5 * time.Second
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.checkpoint(ctx, retryInterval, log)
+		}
+	}
+}
+
+// FinalCheckpoint runs one WAL TRUNCATE checkpoint on a fresh context. Call
+// after all writers have stopped (worker drained, HTTP server shut down) and
+// before Close(), so the WAL is merged into the main file on clean shutdown —
+// with wal_autocheckpoint(0), Close() does not checkpoint automatically.
+func (s *Store) FinalCheckpoint(log *slog.Logger) {
+	if s == nil || s.db == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	s.checkpoint(ctx, 0, log)
+}
+
+func (s *Store) checkpoint(ctx context.Context, retryInterval time.Duration, log *slog.Logger) {
+	for {
+		var busy, walFrames, checkpointed int
+		if err := s.db.QueryRowContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &walFrames, &checkpointed); err != nil {
+			if ctx.Err() == nil && log != nil {
+				log.Warn("wal checkpoint error", "error", err)
+			}
+			return
+		}
+		if busy == 0 {
+			return
+		}
+		// busy=1: a reader snapshot blocks full WAL backfill. TRUNCATE does not
+		// honour busy_timeout in this phase (that only covers write-lock conflicts),
+		// so retry at the application level until the readers release or ctx ends.
+		if log != nil {
+			log.Debug("wal checkpoint blocked by reader, retrying", "wal_frames", walFrames, "checkpointed", checkpointed)
+		}
+		if retryInterval == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retryInterval):
+		}
+	}
+}

--- a/internal/storage/checkpoint_test.go
+++ b/internal/storage/checkpoint_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
+)
+
+// TestCheckpointTruncatesWAL verifies that with wal_autocheckpoint(0) the WAL
+// grows under writes and is reclaimed by an explicit TRUNCATE checkpoint. This
+// is the mechanism that keeps the on-disk WAL bounded without relying on
+// Litestream's (out-of-process, lock-losing) checkpoint.
+func TestCheckpointTruncatesWAL(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "bugbarn.db")
+	store, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	ctx := context.Background()
+	projectID := store.defaultProjectID
+
+	// Write enough log entries to grow the WAL well past empty. With
+	// wal_autocheckpoint(0) nothing reclaims it until we checkpoint explicitly.
+	entries := make([]domain.LogEntry, 2000)
+	for i := range entries {
+		entries[i] = domain.LogEntry{
+			ProjectID:  projectID,
+			ReceivedAt: time.Now().UTC(),
+			LevelNum:   30,
+			Level:      "info",
+			Message:    "checkpoint test log line padding padding padding",
+		}
+	}
+	if err := store.InsertLogEntries(ctx, entries); err != nil {
+		t.Fatalf("InsertLogEntries: %v", err)
+	}
+
+	walPath := dbPath + "-wal"
+	grown := walSize(t, walPath)
+	if grown == 0 {
+		t.Fatal("expected WAL to grow under writes with wal_autocheckpoint(0)")
+	}
+
+	// No concurrent readers in this test, so TRUNCATE should fully succeed and
+	// shrink the WAL file back to (near) zero.
+	store.FinalCheckpoint(nil)
+
+	after := walSize(t, walPath)
+	if after >= grown {
+		t.Fatalf("expected WAL to shrink after checkpoint: before=%d after=%d", grown, after)
+	}
+}
+
+func walSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -97,7 +97,12 @@ func sqliteDSN(path string) string {
 		Scheme: "file",
 		Path:   filepath.ToSlash(path),
 	}
-	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=synchronous(normal)"
+	// wal_autocheckpoint(0): disable SQLite's automatic PASSIVE checkpoints. They
+	// stop at the oldest reader snapshot and never TRUNCATE, so under sustained
+	// read load (the reader pods hold the WAL file open) they let the WAL grow to
+	// a high-water mark that never shrinks. The writer instead runs explicit
+	// TRUNCATE checkpoints through its single connection — see Store.checkpoint.
+	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=synchronous(normal)&_pragma=wal_autocheckpoint(0)"
 }
 
 func sqliteReadOnlyDSN(path string) string {
@@ -105,7 +110,7 @@ func sqliteReadOnlyDSN(path string) string {
 		Scheme: "file",
 		Path:   filepath.ToSlash(path),
 	}
-	return u.String() + "?mode=ro&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)"
+	return u.String() + "?mode=ro&_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)"
 }
 
 func marshalEvent(evt event.Event) ([]byte, error) {


### PR DESCRIPTION
## Problem

Prod was logging `checkpoint: mode=PASSIVE err="database is locked"` ~once per second, continuously. Litestream's checkpoint runs from a separate process, and SQLite only allows one writer at the file level — a second connection's deferred-tx upgrade returns `SQLITE_BUSY` *immediately*, bypassing `busy_timeout`. So under sustained write load Litestream's checkpoint never wins the lock, the WAL sat at a **358 MB** high-water mark, and that bloat is what made even single-row log inserts occasionally exceed their deadline.

## Fix

Adopt the pattern spanbarn uses (`internal/repository/db.go`): stop relying on an out-of-process checkpoint and run explicit `wal_checkpoint(TRUNCATE)` **through the writer's single connection**, where it queues in Go's pool behind the (tiny) write transactions and always gets a clean window.

- **DSN**: `wal_autocheckpoint(0)` (SQLite's PASSIVE auto-checkpoints stop at reader snapshots and never truncate, so they let the WAL grow unbounded under read load); `busy_timeout` 10s → 30s.
- **`Store.RunPeriodicCheckpoint`**: `TRUNCATE` every 30s via `s.db`, retrying every 5s on `busy=1` (a reader snapshot blocking backfill — `TRUNCATE` doesn't honour `busy_timeout` in that phase).
- **`Store.FinalCheckpoint`**: merge the WAL on clean shutdown (with `wal_autocheckpoint(0)`, `Close()` no longer checkpoints).
- Wired both into the writer's `run()` loop.

### Why dual checkpointing with Litestream is safe

Litestream stays active for S3 replication. Its WAL reader lock holds a snapshot at the last frame it has shipped, so the app's `TRUNCATE` can never reclaim frames Litestream hasn't confirmed — SQLite blocks the backfill at that boundary (`busy=1`) and we retry. With `sync-interval=1s`, at most ~1s of frames are ever protected. And once the app keeps the WAL small, Litestream rarely hits its own checkpoint threshold, so the per-second lock errors stop too.

## Testing

`go test ./...` passes. New `TestCheckpointTruncatesWAL` verifies the WAL grows under writes (autocheckpoint off) and is reclaimed by the explicit `TRUNCATE`.