### PR TITLE
fix(logs): don't log client cancellation as an error

### DIFF
--- a/internal/service/logs/service.go
+++ b/internal/service/logs/service.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -57,6 +58,12 @@ func (s *Service) Insert(ctx context.Context, entries []domain.LogEntry) error {
 		case <-time.After(time.Duration(100*(1<<attempt)) * time.Millisecond):
 		}
 	}
+	if errors.Is(err, context.Canceled) {
+		// Client disconnected mid-insert; this is not a server error worth
+		// alerting on (and selflog would otherwise capture it as one).
+		s.logger.InfoContext(ctx, "insert log entries canceled", "count", len(entries))
+		return err
+	}
 	span.SetStatus(codes.Error, err.Error())
 	s.logger.ErrorContext(ctx, "insert log entries", "count", len(entries), "error", err)
 	return err
@@ -67,6 +74,11 @@ func (s *Service) List(ctx context.Context, projectID int64, levelMin int, query
 	defer span.End()
 	entries, err := s.repo.ListLogEntries(ctx, projectID, levelMin, query, limit, beforeID)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Client disconnected mid-query; not a server error worth alerting on.
+			s.logger.InfoContext(ctx, "list log entries canceled", "project_id", projectID)
+			return nil, err
+		}
 		span.SetStatus(codes.Error, err.Error())
 		s.logger.ErrorContext(ctx, "list log entries", "project_id", projectID, "error", err)
 		return nil, err

--- a/internal/service/logs/service_test.go
+++ b/internal/service/logs/service_test.go
@@ -1,8 +1,11 @@
 package logs
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/wiebe-xyz/bugbarn/internal/apperr"
@@ -61,6 +64,26 @@ func TestInsert_Error(t *testing.T) {
 	}
 	if !errors.Is(err, apperr.ErrInternal) {
 		t.Errorf("expected ErrInternal, got %v", err)
+	}
+}
+
+func TestInsert_CanceledNotLoggedAsError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	svc := New(&fakeRepo{}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := svc.Insert(ctx, []domain.LogEntry{{Message: "x"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	// A client disconnect must not surface as an ERROR (selflog captures those).
+	if strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Errorf("canceled insert logged at ERROR: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

When a client disconnects mid-request, the request context is canceled and `service.logs.Insert`/`List` logged that `context.Canceled` at **ERROR** level. selflog captures ERROR logs and reports them to BugBarn itself — so these benign client disconnects showed up as a real issue (**BS2-97**, "insert log entries: context canceled", 481 events).

## Fix

Log `context.Canceled` at INFO (and skip the error span status) in both `Insert` and `List`. `context.DeadlineExceeded` (a genuine timeout) and all other failures still log at ERROR as before. Matches the existing precedent of suppressing context-cancel/not_found noise in selflog.

## Testing

`go test ./...` passes. New `TestInsert_CanceledNotLoggedAsError` asserts a canceled insert returns `context.Canceled` and does not emit an ERROR-level log.