### PR TITLE
fix(staging): correct ingest-spool volume readOnly placement

### DIFF
--- a/deploy/k8s/staging/reader-deployment.yaml
+++ b/deploy/k8s/staging/reader-deployment.yaml
@@ -149,7 +149,7 @@ spec:
         - name: bugbarn-data
           persistentVolumeClaim:
             claimName: bugbarn-data
+            readOnly: true
         - name: ingest-spool
           emptyDir:
             sizeLimit: 512Mi
-            readOnly: true


### PR DESCRIPTION
v0.236.70 staging deploy failed: `emptyDir.readOnly` is invalid. The reader's bugbarn-data PVC `readOnly: true` was displaced under the new ingest-spool emptyDir when it was added. Move it back to the PVC. Fixes the staging deploy for #117.