### PR TITLE
perf(007): consumer DrainBatch — keep queue ~0 under trickle ingest

### DIFF
--- a/internal/ingestproc/consumer.go
+++ b/internal/ingestproc/consumer.go
@@ -26,6 +26,10 @@ const (
 	consumerMaxRetries = 5
 	// consumerErrBackoff is the pause after a Redis Consume error before retry.
 	consumerErrBackoff = time.Second
+	// drainMaxEntries caps how many queue entries the consumer pulls per cycle so
+	// it can batch the DB writes across them — the headroom that keeps it ahead of
+	// high-volume trickle ingest (one item per entry).
+	drainMaxEntries = 500
 )
 
 // Consumer drains the Redis write queue and persists each item through the
@@ -63,7 +67,7 @@ func (c *Consumer) Run(ctx context.Context) {
 		default:
 		}
 
-		items, err := c.queue.Consume(ctx)
+		items, err := c.queue.DrainBatch(ctx, drainMaxEntries)
 		if err != nil {
 			if ctx.Err() != nil {
 				return

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -132,8 +132,8 @@ func (q *RedisQueue) Publish(ctx context.Context, items []Item) error {
 	return nil
 }
 
-// Consume blocks for up to brpopTimeout waiting for a batch, then returns it.
-// Returns (nil, nil) when the timeout expires with no items — callers loop.
+// Consume blocks for up to brpopTimeout waiting for one entry, then returns its
+// items. Returns (nil, nil) when the timeout expires with no items.
 func (q *RedisQueue) Consume(ctx context.Context) ([]Item, error) {
 	result, err := q.client.BRPop(ctx, brpopTimeout, WriteQueueKey).Result()
 	if err == redis.Nil {
@@ -143,8 +143,43 @@ func (q *RedisQueue) Consume(ctx context.Context) ([]Item, error) {
 		return nil, fmt.Errorf("queue: brpop: %w", err)
 	}
 	// result[0] = key, result[1] = JSON payload.
+	return decodeItems(result[1])
+}
+
+// DrainBatch blocks for the first queued entry, then non-blocking-pops up to
+// maxEntries-1 more entries and returns all their items together. This lets the
+// consumer batch DB writes across many entries even when producers publish one
+// item per entry — the dominant case under steady trickle ingest, where
+// per-publish batching never kicks in. Returns (nil, nil) on idle timeout.
+func (q *RedisQueue) DrainBatch(ctx context.Context, maxEntries int) ([]Item, error) {
+	result, err := q.client.BRPop(ctx, brpopTimeout, WriteQueueKey).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("queue: brpop: %w", err)
+	}
+	items, err := decodeItems(result[1])
+	if err != nil {
+		return nil, err
+	}
+	if maxEntries > 1 {
+		vals, rerr := q.client.RPopCount(ctx, WriteQueueKey, maxEntries-1).Result()
+		if rerr != nil && rerr != redis.Nil {
+			return items, nil // best-effort: process the first entry, retry the rest
+		}
+		for _, v := range vals {
+			if more, derr := decodeItems(v); derr == nil {
+				items = append(items, more...)
+			}
+		}
+	}
+	return items, nil
+}
+
+func decodeItems(payload string) ([]Item, error) {
 	var items []Item
-	if err := json.Unmarshal([]byte(result[1]), &items); err != nil {
+	if err := json.Unmarshal([]byte(payload), &items); err != nil {
 		return nil, fmt.Errorf("queue: unmarshal: %w", err)
 	}
 	return items, nil

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -107,6 +107,55 @@ func TestPublishBatchesLargeInput(t *testing.T) {
 	}
 }
 
+func TestDrainBatchPullsManyEntries(t *testing.T) {
+	t.Parallel()
+	q, _ := newTestQueue(t)
+	ctx := context.Background()
+
+	// 10 separate single-item publishes => 10 one-item list entries, the trickle
+	// case where per-publish batching never engages.
+	for i := 0; i < 10; i++ {
+		if err := q.Publish(ctx, []Item{{Kind: KindLog, BodyBase64: "YQ=="}}); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+	if n, _ := q.Len(ctx); n != 10 {
+		t.Fatalf("setup: len = %d, want 10", n)
+	}
+
+	// One DrainBatch should pull all 10 entries' items in a single cycle.
+	items, err := q.DrainBatch(ctx, 500)
+	if err != nil {
+		t.Fatalf("DrainBatch: %v", err)
+	}
+	if len(items) != 10 {
+		t.Errorf("DrainBatch returned %d items, want 10", len(items))
+	}
+	if n, _ := q.Len(ctx); n != 0 {
+		t.Errorf("queue not drained: len = %d, want 0", n)
+	}
+}
+
+func TestDrainBatchRespectsMaxEntries(t *testing.T) {
+	t.Parallel()
+	q, _ := newTestQueue(t)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		_ = q.Publish(ctx, []Item{{Kind: KindEvent, BodyBase64: "YQ=="}})
+	}
+	// maxEntries=3 => first BRPOP + up to 2 more = 3 entries this cycle.
+	items, err := q.DrainBatch(ctx, 3)
+	if err != nil {
+		t.Fatalf("DrainBatch: %v", err)
+	}
+	if len(items) != 3 {
+		t.Errorf("DrainBatch(3) returned %d items, want 3", len(items))
+	}
+	if n, _ := q.Len(ctx); n != 7 {
+		t.Errorf("expected 7 entries left, got %d", n)
+	}
+}
+
 func TestNewRedisQueueBadURL(t *testing.T) {
 	t.Parallel()
 	if _, err := NewRedisQueue("not-a-url"); err == nil {


### PR DESCRIPTION
The deployed batching (#117) only helped when producers bunched records; prod ingest trickles (1 record/spool-drain → 1 item/entry), so the consumer was back to 1 DB tx/item and the backlog wouldn't drain (verified live: prod queue flat at ~1400, all 1-item entries).

Fix: `queue.DrainBatch` — BRPOP one entry, then non-blocking RPOP up to 499 more, return all items together. The consumer pulls up to 500 entries/cycle and batches their log inserts, so even pure 1-item-per-entry trickle collapses into a few DB transactions. Unit-tested (`TestDrainBatchPullsManyEntries`).