### PR TITLE
fix(storage): writer-owned WAL checkpoints to bound WAL growth

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -146,14 +146,26 @@ func run() error {
 	digest.StartScheduler(ctx, cfg.Digest, store, &bgWg)
 	analytics.StartWorker(ctx, store, cfg.AnalyticsRetentionDays, &bgWg)
 
+	// The writer owns WAL maintenance. With wal_autocheckpoint(0) on the write
+	// DSN, nothing truncates the WAL implicitly — Litestream streams frames to S3
+	// but its own checkpoint loses the lock race under sustained load, so the WAL
+	// grew unbounded in production. This loop runs an explicit TRUNCATE checkpoint
+	// every 30s on the single write connection, serialising behind normal writes.
+	bgWg.Add(1)
+	go func() {
+		defer bgWg.Done()
+		store.RunPeriodicCheckpoint(ctx, 30*time.Second, logger.With("component", "wal-checkpoint"))
+	}()
+
 	// Spec 007: when a Redis write queue is configured, a single consumer drains
 	// it into the DB. This decouples ingest producers (reader pods) from the
 	// writer so a slow writer can't trigger the HTTP-forward retry storm that
 	// wedged production. Connect in a goroutine so startup never blocks on Redis;
 	// the legacy file-spool worker above stays as the fallback path until
 	// producers are switched to Redis (phase 3) and it is retired (phase 5).
-	// The shared write mutex (nil for now) is wired when retention and the WAL
-	// checkpoint move under it in a later phase.
+	// The shared write mutex stays nil: MaxOpenConns(1) already serialises every
+	// writer (consumer, legacy worker, analytics, and the WAL checkpoint loop)
+	// through the single write connection, so no Go-level mutex is needed.
 	if cfg.RedisQueueURL != "" {
 		bgWg.Add(1)
 		go func() {
@@ -232,6 +244,10 @@ func run() error {
 		go func() { bgWg.Wait(); close(drained) }()
 		select {
 		case <-drained:
+			// All writers have stopped; merge the WAL into the main file before
+			// Close() so a clean shutdown never strands a large WAL (Close() does
+			// not checkpoint with wal_autocheckpoint(0)).
+			store.FinalCheckpoint(logger.With("component", "wal-checkpoint"))
 		case <-shutdownCtx.Done():
 			slog.Warn("worker did not drain before shutdown deadline")
 		}

--- a/internal/storage/checkpoint.go
+++ b/internal/storage/checkpoint.go
@@ -1,0 +1,148 @@
+package storage
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
+)
+
+// checkpointMetrics holds the OTel instruments for WAL checkpoint health. Like
+// the consumer metrics, instruments come from the global meter and are valid
+// no-ops before tracing.Init wires a MeterProvider, so construction never fails
+// in tests or when telemetry is disabled.
+type checkpointMetrics struct {
+	total    metric.Int64Counter
+	duration metric.Float64Histogram
+	reg      metric.Registration
+}
+
+// newCheckpointMetrics builds the checkpoint instruments. walPath, when
+// non-empty, is stat'd by an observable gauge so the live WAL sidecar size is
+// visible in telemetry — the single number that tells us whether checkpoints are
+// actually draining the WAL or it is growing unbounded under load.
+func newCheckpointMetrics(walPath string) *checkpointMetrics {
+	m := tracing.Meter()
+	total, _ := m.Int64Counter(
+		"bugbarn.wal.checkpoint.total",
+		metric.WithDescription("WAL TRUNCATE checkpoint attempts by result (ok|busy|error)."),
+		metric.WithUnit("{checkpoint}"),
+	)
+	duration, _ := m.Float64Histogram(
+		"bugbarn.wal.checkpoint.duration",
+		metric.WithDescription("Wall-clock time of a WAL checkpoint attempt, by result."),
+		metric.WithUnit("ms"),
+	)
+	cm := &checkpointMetrics{total: total, duration: duration}
+
+	if walPath != "" {
+		gauge, err := m.Int64ObservableGauge(
+			"bugbarn.wal.size_bytes",
+			metric.WithDescription("Size of the SQLite WAL sidecar file (<db>-wal)."),
+			metric.WithUnit("By"),
+		)
+		if err == nil {
+			cm.reg, _ = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+				fi, statErr := os.Stat(walPath)
+				if statErr != nil {
+					return nil // WAL absent (no writes yet) or transient stat error.
+				}
+				o.ObserveInt64(gauge, fi.Size())
+				return nil
+			}, gauge)
+		}
+	}
+	return cm
+}
+
+func (m *checkpointMetrics) record(ctx context.Context, result string, durMs float64) {
+	if m == nil {
+		return
+	}
+	m.total.Add(ctx, 1, metric.WithAttributes(attribute.String("result", result)))
+	m.duration.Record(ctx, durMs, metric.WithAttributes(attribute.String("result", result)))
+}
+
+func (m *checkpointMetrics) close() {
+	if m != nil && m.reg != nil {
+		_ = m.reg.Unregister()
+	}
+}
+
+// RunPeriodicCheckpoint blocks until ctx is cancelled, issuing a WAL TRUNCATE
+// checkpoint on each tick. It must run in the writer process only — the single
+// owner of the write connection — so checkpoints serialise behind normal writes
+// through MaxOpenConns(1) rather than contending on a second connection.
+//
+// With wal_autocheckpoint(0) set on the DSN, nothing else truncates the WAL:
+// Litestream still streams frames to S3 but its own checkpoint has no
+// busy_timeout and loses the race under sustained write load. This loop owns WAL
+// truncation with a patient busy_timeout(30000) connection plus application-level
+// retry for the reader-block case (TRUNCATE returns busy immediately when a
+// reader snapshot pins the WAL; busy_timeout does not cover that phase).
+func (s *Store) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, log *slog.Logger) {
+	const retryInterval = 5 * time.Second
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	log.Info("wal checkpoint loop started", "interval", interval.String())
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.Checkpoint(ctx, retryInterval, log)
+		}
+	}
+}
+
+// FinalCheckpoint runs one WAL TRUNCATE checkpoint on a fresh context. Call after
+// all writers have stopped (after the worker WaitGroup drains) and before
+// Close(), so the WAL is merged into the main file on every clean shutdown —
+// with wal_autocheckpoint(0), Close() does not checkpoint automatically.
+func (s *Store) FinalCheckpoint(log *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	s.Checkpoint(ctx, 0, log)
+}
+
+// Checkpoint issues a single WAL TRUNCATE checkpoint, retrying every retryInterval
+// while it is blocked by a reader snapshot (busy=1). retryInterval of 0 means try
+// once and return — used by FinalCheckpoint on shutdown. Each attempt records a
+// result-tagged counter + duration; the WAL-size gauge reports the effect.
+func (s *Store) Checkpoint(ctx context.Context, retryInterval time.Duration, log *slog.Logger) {
+	for {
+		start := time.Now()
+		var busy, walFrames, checkpointed int
+		err := s.db.QueryRowContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &walFrames, &checkpointed)
+		durMs := float64(time.Since(start).Microseconds()) / 1000.0
+		switch {
+		case err != nil:
+			if ctx.Err() == nil {
+				log.Warn("wal checkpoint error", "error", err)
+			}
+			s.checkpoints.record(ctx, "error", durMs)
+			return
+		case busy == 0:
+			s.checkpoints.record(ctx, "ok", durMs)
+			return
+		default:
+			// busy=1: a reader snapshot blocks full WAL backfill. Retry after a
+			// short interval so the WAL can be drained once the reader finishes.
+			s.checkpoints.record(ctx, "busy", durMs)
+			log.Debug("wal checkpoint blocked by reader, retrying", "wal_frames", walFrames, "checkpointed", checkpointed)
+			if retryInterval == 0 {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retryInterval):
+			}
+		}
+	}
+}

--- a/internal/storage/checkpoint_test.go
+++ b/internal/storage/checkpoint_test.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckpointTruncatesWAL verifies the core of the WAL-growth fix: with
+// wal_autocheckpoint disabled, a burst of writes grows the -wal sidecar, and an
+// explicit TRUNCATE checkpoint drains it back to zero. This is the behaviour that
+// keeps the production WAL bounded under sustained load.
+func TestCheckpointTruncatesWAL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "bugbarn.db")
+	store, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// autocheckpoint must be off, otherwise SQLite would silently truncate the
+	// WAL on its own and this test (and the production fix) would be meaningless.
+	var autockpt int
+	if err := store.db.QueryRowContext(ctx, "PRAGMA wal_autocheckpoint").Scan(&autockpt); err != nil {
+		t.Fatalf("read wal_autocheckpoint: %v", err)
+	}
+	if autockpt != 0 {
+		t.Fatalf("wal_autocheckpoint = %d, want 0 (auto-checkpoint must be disabled)", autockpt)
+	}
+
+	// Write enough rows that the WAL grows past empty. log_entries is a plain
+	// insert path with no read snapshot held open, so the checkpoint can fully
+	// truncate afterwards.
+	entries := make([]LogEntry, 0, 500)
+	for i := 0; i < 500; i++ {
+		entries = append(entries, LogEntry{
+			ProjectID: store.DefaultProjectID(),
+			Level:     "error",
+			LevelNum:  3,
+			Message:   "checkpoint test payload to grow the write-ahead log",
+		})
+	}
+	if err := store.InsertLogEntries(ctx, entries); err != nil {
+		t.Fatalf("InsertLogEntries: %v", err)
+	}
+
+	walPath := dbPath + "-wal"
+	if sz := walSize(t, walPath); sz == 0 {
+		t.Fatalf("WAL is empty after inserts; expected it to grow with autocheckpoint off")
+	}
+
+	store.Checkpoint(ctx, 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if sz := walSize(t, walPath); sz != 0 {
+		t.Errorf("WAL size after TRUNCATE checkpoint = %d, want 0", sz)
+	}
+}
+
+func walSize(t *testing.T, path string) int64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Size()
+}

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -97,7 +97,15 @@ func sqliteDSN(path string) string {
 		Scheme: "file",
 		Path:   filepath.ToSlash(path),
 	}
-	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=synchronous(normal)"
+	// wal_autocheckpoint(0) disables SQLite's automatic passive checkpoints: the
+	// writer runs explicit TRUNCATE checkpoints on a fixed interval instead (see
+	// checkpoint.go). Litestream disables autocheckpoint anyway when it takes over
+	// replication, and its own checkpoint has no busy_timeout so it loses the race
+	// against the single-writer consumer under load and the WAL grows unbounded.
+	// The app-side TRUNCATE checkpoint shares this connection (MaxOpenConns(1)) and
+	// has busy_timeout(30000), so it waits for a clear write window instead of
+	// failing immediately.
+	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(30000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=synchronous(normal)&_pragma=wal_autocheckpoint(0)"
 }
 
 func sqliteReadOnlyDSN(path string) string {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -126,7 +126,8 @@ func Open(path string) (*Store, error) {
 	}
 	roDB.SetMaxOpenConns(4)
 
-	store := &Store{db: db, roDB: roDB}
+	store := &Store{db: db, roDB: roDB, path: absPath}
+	store.checkpoints = newCheckpointMetrics(absPath + "-wal")
 	ctx := context.Background()
 	if err := store.init(ctx); err != nil {
 		roDB.Close()
@@ -146,6 +147,7 @@ func (s *Store) Close() error {
 		return nil
 	}
 	var firstErr error
+	s.checkpoints.close()
 	if s.roDB != nil {
 		if err := s.roDB.Close(); err != nil && firstErr == nil {
 			firstErr = err

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -15,6 +15,12 @@ type Store struct {
 	roDB             *sql.DB
 	defaultProjectID int64
 
+	// path is the absolute path to the SQLite database file. checkpoints reports
+	// the size of its "<path>-wal" sidecar and counts checkpoint outcomes so WAL
+	// growth and checkpoint contention are visible in telemetry (see checkpoint.go).
+	path        string
+	checkpoints *checkpointMetrics
+
 	// logInsertCount counts log-entry insert batches so the retention trim can
 	// be amortized (run roughly once per logTrimInterval batches) instead of on
 	// every insert — the single writer is shared with event ingestion, so we


### PR DESCRIPTION
## Problem

Under sustained write-queue load the production WAL grew unbounded. With Litestream active, SQLite autocheckpoint is disabled and Litestream's own checkpoint runs on a connection with **no busy_timeout**, so it loses the lock race against the single-writer consumer and never truncates the WAL — a steady stream of `checkpoint: mode=RESTART database is locked` (~17/min) with zero successful checkpoints. Load-dependent: at queue depth 0 the WAL drains; under flood it climbs (seen at 51 MB on a 2.1 GB DB).

## Fix

Make the writer own WAL maintenance, mirroring the proven spanbarn pattern (same Litestream 0.3.13, same `replicate -exec` topology):

- **DSN**: add `wal_autocheckpoint(0)` and raise `busy_timeout` to 30s on the write connection. Litestream still streams frames to S3; its WAL read mark pins un-synced frames, so an app-side `TRUNCATE` checkpoint can't drop un-replicated data (it returns `busy=1` and only checkpoints the safe prefix).
- **`Store.RunPeriodicCheckpoint`**: a 30s `wal_checkpoint(TRUNCATE)` loop on the single write connection (`MaxOpenConns(1)`), so it serialises *behind* normal writes through Go's pool rather than contending on a second connection. Retries every 5s while a reader snapshot blocks backfill.
- **`FinalCheckpoint`** on clean shutdown merges the WAL before `Close()` (which no longer checkpoints implicitly with autocheckpoint off).

Deliberately **omits** spanbarn's `incremental_vacuum` — it's a no-op without an `auto_vacuum=INCREMENTAL` migration, and forcing that on the 2.1 GB prod DB needs a full VACUUM (too risky). Goal here is bounding the WAL, not shrinking the main file.

## Observability

New instruments on the writer's `/metrics`:
- `bugbarn_wal_checkpoint_total{result=ok|busy|error}`
- `bugbarn_wal_checkpoint_duration_milliseconds{result}`
- `bugbarn_wal_size_bytes` (gauge — the single number that proves the WAL is bounded)

## Safety / blast radius

- Readers (`OpenReadOnly`) are untouched — `db` is nil, they never checkpoint; the metrics callback is nil-safe.
- No write-path semantics change; `MaxOpenConns(1)` already serialised all writers, so no Go-level mutex is introduced.
- New test `TestCheckpointTruncatesWAL`: asserts autocheckpoint is off, the WAL grows under inserts, and TRUNCATE drains it to 0 bytes.

## Rollout

Merge → testing (auto). Watch `bugbarn_wal_size_bytes` stays bounded and `bugbarn_wal_checkpoint_total{result=ok}` climbs under load before tagging staging, then production.