### PR TITLE
fix(releases): make POST /releases fire-and-forget via the ingest spool

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -993,6 +993,11 @@ paths:
       operationId: createRelease
       tags: [Releases]
       summary: Create a release marker
+      description: >
+        Accepts a release marker and enqueues it for asynchronous creation by the
+        background worker, returning 202 immediately. This keeps the request off
+        the single SQLite writer connection. The marker is typically persisted
+        within ~1s and becomes visible via GET /api/v1/releases shortly after.
       requestBody:
         required: true
         content:
@@ -1000,15 +1005,17 @@ paths:
             schema:
               $ref: "#/components/schemas/ReleaseInput"
       responses:
-        "200":
-          description: Release created
+        "202":
+          description: Release marker accepted for asynchronous creation
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  release:
-                    $ref: "#/components/schemas/Release"
+                  accepted:
+                    type: boolean
+                  ingestId:
+                    type: string
 
   /api/v1/releases/{releaseId}:
     get:

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -31,6 +32,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/cli"
 	"github.com/wiebe-xyz/bugbarn/internal/config"
 	"github.com/wiebe-xyz/bugbarn/internal/digest"
+	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
 	"github.com/wiebe-xyz/bugbarn/internal/ingestproc"
@@ -528,7 +530,21 @@ func runWorkerOnce(cfg config.Config) error {
 		return err
 	}
 
-	processed, err := worker.ProcessRecords(records)
+	// Release markers share the spool with events but take a different path.
+	eventRecords := make([]spool.Record, 0, len(records))
+	releaseCount := 0
+	for _, record := range records {
+		if record.Kind == ingest.RecordKindRelease {
+			if err := persistReleaseRecord(context.Background(), persistentStore, record); err != nil {
+				return err
+			}
+			releaseCount++
+			continue
+		}
+		eventRecords = append(eventRecords, record)
+	}
+
+	processed, err := worker.ProcessRecords(eventRecords)
 	if err != nil {
 		return err
 	}
@@ -542,9 +558,10 @@ func runWorkerOnce(cfg config.Config) error {
 	}
 
 	return json.NewEncoder(os.Stdout).Encode(map[string]any{
-		"records": len(records),
-		"events":  len(processed),
-		"issues":  store.Len(),
+		"records":  len(records),
+		"events":   len(processed),
+		"releases": releaseCount,
+		"issues":   store.Len(),
 	})
 }
 
@@ -568,6 +585,48 @@ func isTransientPersistError(err error) bool {
 	return strings.Contains(msg, "SQLITE_BUSY") ||
 		strings.Contains(msg, "database is locked") ||
 		strings.Contains(msg, "database table is locked")
+}
+
+// persistReleaseRecord decodes a spooled release marker and creates it. Release
+// markers are enqueued by POST /api/v1/releases so the create stays off the
+// request path — the worker owns the single SQLite writer connection. The body
+// mirrors the JSON the API handler accepted; the resolved project is carried on
+// the record so it need not be re-resolved here.
+func persistReleaseRecord(ctx context.Context, store *storage.Store, record spool.Record) error {
+	body, err := base64.StdEncoding.DecodeString(record.BodyBase64)
+	if err != nil {
+		return fmt.Errorf("decode release body: %w", err)
+	}
+	var req struct {
+		Name        string `json:"name"`
+		Environment string `json:"environment"`
+		ObservedAt  string `json:"observedAt"`
+		Version     string `json:"version"`
+		CommitSHA   string `json:"commitSha"`
+		URL         string `json:"url"`
+		Notes       string `json:"notes"`
+		CreatedBy   string `json:"createdBy"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return fmt.Errorf("unmarshal release: %w", err)
+	}
+	release := domain.Release{
+		Name:        req.Name,
+		Environment: req.Environment,
+		Version:     req.Version,
+		CommitSHA:   req.CommitSHA,
+		URL:         req.URL,
+		Notes:       req.Notes,
+		CreatedBy:   req.CreatedBy,
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, req.ObservedAt); err == nil {
+		release.ObservedAt = parsed
+	}
+	if record.ProjectID > 0 {
+		ctx = storage.WithProjectID(ctx, record.ProjectID)
+	}
+	_, err = store.CreateRelease(ctx, release)
+	return err
 }
 
 func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir string, store *storage.Store, svc *service.EventPublisher, selfReporting bool, ws *worker.Status) {
@@ -607,6 +666,45 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 						attribute.String("project_slug", record.ProjectSlug),
 					),
 				)
+
+				// Release markers are enqueued by POST /api/v1/releases so the
+				// create stays off the request path. Handle them here instead of
+				// the event pipeline.
+				if record.Kind == ingest.RecordKindRelease {
+					if err := persistReleaseRecord(recordCtx, store, record); err != nil {
+						recordSpan.SetStatus(codes.Error, err.Error())
+						recordSpan.End()
+						retryCounts[record.IngestID]++
+						slog.Error("worker failed to persist release", "ingest_id", record.IngestID, "attempt", retryCounts[record.IngestID], "error", err)
+						if retryCounts[record.IngestID] >= workerMaxRetries {
+							slog.Error("worker dead-lettering release record", "ingest_id", record.IngestID, "attempts", retryCounts[record.IngestID])
+							if dlErr := spool.AppendDeadLetter(spoolDir, record); dlErr != nil {
+								slog.Error("worker failed to write dead letter", "ingest_id", record.IngestID, "error", dlErr)
+							}
+							delete(retryCounts, record.IngestID)
+							offset = entry.EndOffset
+							if err := spool.WriteCursor(spoolDir, offset); err != nil {
+								slog.Error("worker failed to write cursor", "error", err)
+							}
+							if ws != nil {
+								ws.RecordAdvance()
+							}
+						}
+						// Stop processing this batch; retry remaining records next tick.
+						break
+					}
+					recordSpan.End()
+					delete(retryCounts, record.IngestID)
+					offset = entry.EndOffset
+					if err := spool.WriteCursor(spoolDir, offset); err != nil {
+						slog.Error("worker failed to write cursor", "error", err)
+					}
+					if ws != nil {
+						ws.RecordAdvance()
+						ws.RecordProcessed(1)
+					}
+					continue
+				}
 
 				processed, err := worker.ProcessRecord(record)
 				if err != nil {

--- a/internal/api/releases.go
+++ b/internal/api/releases.go
@@ -1,11 +1,16 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
+	"github.com/wiebe-xyz/bugbarn/internal/spool"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
 func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
@@ -18,6 +23,38 @@ func (s *Server) serveReleasesRoot(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, map[string]any{"releases": releases})
 	case http.MethodPost:
+		// Fire-and-forget: when an ingest spool/worker is wired, enqueue the
+		// release marker and return immediately. Creating it synchronously here
+		// would grab the single SQLite writer connection that the background
+		// worker also holds while persisting events, so under load the create
+		// blocks for many seconds and frequently times out. Auth was already
+		// validated upstream in ServeHTTP. The worker creates the release within
+		// one tick (~1s). When no ingest handler is configured (e.g. unit tests
+		// or a writer without a worker), fall back to a synchronous create so the
+		// release is immediately listable.
+		if s.ingestHandler != nil {
+			body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.ingestHandler.MaxBodyBytes()))
+			if err != nil {
+				http.Error(w, "invalid release payload", http.StatusBadRequest)
+				return
+			}
+			projectID, _ := storage.ProjectIDFromContext(r.Context())
+			ingestID, err := s.ingestHandler.SpoolRelease(projectID, r.Header.Get("Content-Type"), r.RemoteAddr, body)
+			if err != nil {
+				if errors.Is(err, spool.ErrFull) {
+					w.Header().Set("Retry-After", "1")
+					http.Error(w, "ingest spool full", http.StatusTooManyRequests)
+					return
+				}
+				http.Error(w, "release enqueue failed", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{"accepted": true, "ingestId": ingestID})
+			return
+		}
+
 		var request struct {
 			Name        string `json:"name"`
 			Environment string `json:"environment"`

--- a/internal/api/releases_async_test.go
+++ b/internal/api/releases_async_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/auth"
+	"github.com/wiebe-xyz/bugbarn/internal/ingest"
+	"github.com/wiebe-xyz/bugbarn/internal/spool"
+)
+
+// When an ingest spool is wired, POST /api/v1/releases must enqueue the marker
+// and return 202 instead of writing it synchronously — keeping the request off
+// the single SQLite writer connection that the background worker holds.
+func TestCreateReleaseFireAndForget(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	eventSpool, err := spool.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ingestHandler := ingest.NewHandler(auth.New(""), eventSpool, 1<<20)
+	server := NewServer(ingestHandler, store, nil)
+
+	payload := `{"name":"v2.0.0","environment":"production","version":"2.0.0","commitSha":"deadbeef","url":"https://example.com/r","notes":"async deploy"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/releases", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	server.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("release create status: got %d want %d body=%q", rr.Code, http.StatusAccepted, rr.Body.String())
+	}
+	var resp struct {
+		Accepted bool   `json:"accepted"`
+		IngestID string `json:"ingestId"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Accepted || resp.IngestID == "" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	// Nothing should have been written synchronously.
+	releases, err := store.ListReleases(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(releases) != 0 {
+		t.Fatalf("expected no synchronous release write, got %d", len(releases))
+	}
+
+	// The marker must be on the spool as a release record.
+	records, err := spool.ReadRecords(eventSpool.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 spooled record, got %d", len(records))
+	}
+	if records[0].Kind != ingest.RecordKindRelease {
+		t.Fatalf("spooled record kind: got %q want %q", records[0].Kind, ingest.RecordKindRelease)
+	}
+	body, err := base64.StdEncoding.DecodeString(records[0].BodyBase64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "v2.0.0" {
+		t.Fatalf("spooled release name: got %q want %q", got.Name, "v2.0.0")
+	}
+}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -52,6 +52,43 @@ func (h *Handler) ValidAPIKey(r *http.Request) bool {
 	return ok
 }
 
+// RecordKindRelease marks a spool record as a release marker rather than an
+// ingest event. The worker dispatches on spool.Record.Kind.
+const RecordKindRelease = "release"
+
+// MaxBodyBytes returns the configured maximum request body size.
+func (h *Handler) MaxBodyBytes() int64 {
+	return h.maxBodyBytes
+}
+
+// SpoolRelease enqueues a release-marker payload onto the ingest spool for
+// asynchronous creation by the background worker. The raw JSON body is stored
+// verbatim and decoded by the worker; projectID is the already-resolved project
+// captured at enqueue time. Returns the generated ingest ID.
+//
+// This keeps release creation off the request path: the worker owns the single
+// SQLite writer connection, so a synchronous create contends with event
+// persistence and can block for many seconds under load.
+func (h *Handler) SpoolRelease(projectID int64, contentType, remoteAddr string, body []byte) (string, error) {
+	if h == nil || h.spool == nil {
+		return "", errors.New("ingest spool unavailable")
+	}
+	record := spool.Record{
+		IngestID:      h.idFn(),
+		ReceivedAt:    h.now().UTC(),
+		Kind:          RecordKindRelease,
+		ContentType:   contentType,
+		RemoteAddr:    remoteAddr,
+		ContentLength: int64(len(body)),
+		BodyBase64:    base64.StdEncoding.EncodeToString(body),
+		ProjectID:     projectID,
+	}
+	if err := h.spool.Append(record); err != nil {
+		return "", err
+	}
+	return record.IngestID, nil
+}
+
 // APIKeyProject validates the API key from the request and returns the
 // associated project ID. For env-var static keys, projectID=0 is returned.
 // Both full-scope and ingest-scope keys are accepted here.

--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -21,13 +21,20 @@ const deadLetterFileName = "deadletter.ndjson"
 var ErrFull = errors.New("spool is full")
 
 type Record struct {
-	IngestID      string    `json:"ingestId"`
-	ReceivedAt    time.Time `json:"receivedAt"`
-	ContentType   string    `json:"contentType,omitempty"`
-	RemoteAddr    string    `json:"remoteAddr,omitempty"`
-	ContentLength int64     `json:"contentLength,omitempty"`
-	BodyBase64    string    `json:"bodyBase64"`
-	ProjectSlug   string    `json:"projectSlug,omitempty"`
+	IngestID   string    `json:"ingestId"`
+	ReceivedAt time.Time `json:"receivedAt"`
+	// Kind discriminates the payload. An empty value means an ingest event
+	// (the historical default, so already-spooled records keep working);
+	// "release" means a release marker created via POST /api/v1/releases.
+	Kind          string `json:"kind,omitempty"`
+	ContentType   string `json:"contentType,omitempty"`
+	RemoteAddr    string `json:"remoteAddr,omitempty"`
+	ContentLength int64  `json:"contentLength,omitempty"`
+	BodyBase64    string `json:"bodyBase64"`
+	ProjectSlug   string `json:"projectSlug,omitempty"`
+	// ProjectID is the resolved project for non-event records (e.g. releases),
+	// captured at enqueue time so the worker need not re-resolve it.
+	ProjectID int64 `json:"projectId,omitempty"`
 }
 
 // cursor tracks the byte offset of the last successfully processed record.


### PR DESCRIPTION
## Problem

`POST /api/v1/releases` (the deploy "release marker" CI sends after every deploy) created the marker **synchronously**, grabbing the single SQLite writer connection (`SetMaxOpenConns(1)`) that the background worker also holds while draining spooled events. Under load the create queued behind worker write transactions — succeeding slowly (3–17s) or timing out (>20s, ~70%). `POST /events` stayed fast because it's fire-and-forget to the on-disk spool.

There is **no** "correlate releases with regressions" work in the path (that phrase is only marketing copy in `internal/api/setup.go`). The bottleneck was pure writer-connection contention.

## Fix

Route release markers through the existing on-disk spool, mirroring `/events` — which is still the durability front-door for all HTTP ingest today:

- `serveReleasesRoot` POST enqueues a `Kind="release"` spool record and returns **202** (auth is already validated upstream in `ServeHTTP`). The resolved project ID is captured on the record at enqueue time.
- The background worker dispatches on `record.Kind` and calls `CreateRelease` off the request path (`persistReleaseRecord`), with the same retry/dead-letter/cursor semantics as events.
- `runWorkerOnce` partitions release records out of the event pipeline.
- Falls back to a **synchronous** create when no ingest handler/worker is wired (unit tests, or a writer without a worker) so the release stays immediately listable there.

Releases are not part of the Spec 007 Redis-queue migration yet, so this stays on the file-spool path that everything currently enters through; nothing in `internal/queue`/`internal/ingestproc` is touched.

## Behavior change

- `POST /api/v1/releases` now returns **202 `{accepted, ingestId}`** instead of 200 + release object (in production where a worker is wired). No client reads the body: CI uses `curl -sf` (status only); the dashboard re-fetches via `GET`. OpenAPI updated.
- Minor: the dashboard "Add release" form won't show the new marker until the next refresh (~1s worker tick), since creation is now async.

## Tests
- New `TestCreateReleaseFireAndForget`: asserts 202, no synchronous write, and a `Kind="release"` record on the spool.
- Existing `release list and create` test still passes via the synchronous fallback (`NewServer(nil, …)`).
- `go build ./...`, `go test ./...`, `make spec-check` all green.