### PR TITLE
feat(ingest): distinguish accepted vs dropped events via HTTP status codes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -208,6 +208,20 @@ paths:
       description: |
         Accepts error events from SDKs. Uses wildcard CORS so browser SDKs can POST
         from any origin. Accepts ingest-scoped or full-scoped API keys.
+
+        The response status draws a hard line between accepted and dropped events:
+
+        - **2xx** — accepted: the event was validated and durably queued, and
+          will be processed. The body is `IngestAccepted`.
+        - **4xx (400, 401, 413)** — dropped permanently: the request is bad and
+          will never succeed as-is. Do **not** retry.
+        - **429 / 503** — dropped transiently: backpressure or a temporary
+          outage. Retry after the `Retry-After` delay.
+
+        Dropped responses carry an `IngestDropped` body whose `retryable` flag
+        restates whether retrying the identical request could succeed. Events are
+        validated synchronously, so a `202` means the event was genuinely
+        accepted rather than queued and later discarded.
       security:
         - apiKey: []
       parameters:
@@ -220,11 +234,51 @@ paths:
               $ref: "#/components/schemas/IngestEvent"
       responses:
         "202":
-          description: Event accepted for processing
+          description: Event accepted — durably queued and will be processed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestAccepted"
         "400":
-          description: Invalid payload
+          description: Dropped — malformed event payload (permanent, do not retry)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestDropped"
         "401":
-          description: Missing or invalid API key
+          description: Dropped — missing or invalid API key (permanent, do not retry)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestDropped"
+        "413":
+          description: Dropped — payload exceeds the size limit (permanent, do not retry)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestDropped"
+        "429":
+          description: Dropped — ingest buffer full (transient, retry after Retry-After)
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestDropped"
+        "503":
+          description: Dropped — ingest pipeline unavailable (transient, retry after Retry-After)
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before retrying
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestDropped"
 
   /api/v1/logs:
     post:
@@ -1659,6 +1713,45 @@ components:
         ok:
           type: boolean
           example: true
+
+    IngestAccepted:
+      type: object
+      description: Returned with a 2xx when an event is durably queued for processing.
+      required: [accepted]
+      properties:
+        accepted:
+          type: boolean
+          const: true
+          description: Always true.
+        ingestId:
+          type: string
+          description: Server-assigned id for the accepted event (omitted on reader pods).
+
+    IngestDropped:
+      type: object
+      description: |
+        Returned with every non-2xx ingest response. `retryable` tells the SDK
+        whether retrying the identical request could ever succeed: false for
+        permanent client errors (400/401/413), true for transient backpressure
+        or outages (429/503).
+      required: [accepted, reason, retryable]
+      properties:
+        accepted:
+          type: boolean
+          const: false
+          description: Always false.
+        reason:
+          type: string
+          description: Stable, machine-readable drop reason.
+          enum:
+            - malformed_payload
+            - unauthorized
+            - payload_too_large
+            - spool_full
+            - ingest_unavailable
+        retryable:
+          type: boolean
+          description: Whether retrying the identical request could succeed.
 
     HealthResponse:
       type: object

--- a/internal/api/spool_forwarder.go
+++ b/internal/api/spool_forwarder.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
+	"github.com/wiebe-xyz/bugbarn/internal/normalize"
 	"github.com/wiebe-xyz/bugbarn/internal/queue"
 )
 
@@ -127,6 +129,11 @@ func NewRedisSpoolForwarder(dir string, q *queue.RedisQueue, maxBodyBytes int64,
 // Forward captures the request body and headers, appends to the spool, and
 // responds 202 Accepted. Returns 503 if the spool write fails — the SDK will
 // retry, which is the correct behavior for fire-and-forget telemetry.
+//
+// Event payloads are validated synchronously before spooling so a malformed
+// event is dropped here with a 400 rather than queued and silently discarded by
+// the writer. This keeps the accepted/dropped distinction honest even on reader
+// pods, which return 202 before the writer ever sees the event.
 func (s *SpoolForwarder) Forward(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	if r.Body != nil {
@@ -134,14 +141,21 @@ func (s *SpoolForwarder) Forward(w http.ResponseWriter, r *http.Request) {
 		if s.maxBodyByte > 0 {
 			body, err = io.ReadAll(io.LimitReader(r.Body, s.maxBodyByte+1))
 			if err == nil && int64(len(body)) > s.maxBodyByte {
-				http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+				ingestresp.WriteDropped(w, ingestresp.DropTooLarge)
 				return
 			}
 		} else {
 			body, err = io.ReadAll(r.Body)
 		}
 		if err != nil {
-			http.Error(w, "read body", http.StatusBadRequest)
+			ingestresp.WriteDropped(w, ingestresp.DropMalformed)
+			return
+		}
+	}
+
+	if kindForPath(r.URL.Path) == queue.KindEvent {
+		if err := normalize.Validate(body); err != nil {
+			ingestresp.WriteDropped(w, ingestresp.DropMalformed)
 			return
 		}
 	}
@@ -163,13 +177,11 @@ func (s *SpoolForwarder) Forward(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.append(rec); err != nil {
 		s.logger.Error("spool forward append failed", "error", err)
-		http.Error(w, "spool unavailable", http.StatusServiceUnavailable)
+		ingestresp.WriteDropped(w, ingestresp.DropUnavailable)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_, _ = w.Write([]byte(`{"accepted":true}`))
+	ingestresp.WriteAccepted(w, "")
 }
 
 func (s *SpoolForwarder) append(rec spooledRequest) error {

--- a/internal/api/spool_forwarder_redis_test.go
+++ b/internal/api/spool_forwarder_redis_test.go
@@ -37,12 +37,15 @@ func TestRedisSpoolForwarderPublishes(t *testing.T) {
 	cases := []struct {
 		path string
 		want string
+		body string
 	}{
-		{"/api/v1/events", queue.KindEvent},
-		{"/api/v1/logs", queue.KindLog},
+		// Events are validated synchronously, so the body must be a valid event
+		// payload (a JSON object). Logs are forwarded as-is.
+		{"/api/v1/events", queue.KindEvent, `{"message":"PAYLOAD-event"}`},
+		{"/api/v1/logs", queue.KindLog, "PAYLOAD-log"},
 	}
 	for _, c := range cases {
-		req := httptest.NewRequest("POST", c.path, strings.NewReader("PAYLOAD-"+c.want))
+		req := httptest.NewRequest("POST", c.path, strings.NewReader(c.body))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Bugbarn-Project", "svc")
 		rec := httptest.NewRecorder()
@@ -73,7 +76,7 @@ func TestRedisSpoolForwarderPublishes(t *testing.T) {
 			t.Errorf("%s: project = %q, want svc", c.path, got.ProjectSlug)
 		}
 		body, _ := base64.StdEncoding.DecodeString(got.BodyBase64)
-		if string(body) != "PAYLOAD-"+c.want {
+		if string(body) != c.body {
 			t.Errorf("%s: body = %q", c.path, string(body))
 		}
 	}

--- a/internal/api/spool_forwarder_test.go
+++ b/internal/api/spool_forwarder_test.go
@@ -32,6 +32,40 @@ func spoolRecord(t *testing.T, sf *SpoolForwarder) {
 	}
 }
 
+func TestSpoolForwarder_RejectsMalformedEvent(t *testing.T) {
+	t.Parallel()
+
+	sf := newTestSpool(t, "http://localhost:0")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	sf.Forward(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Forward status = %d, want 400", rec.Code)
+	}
+	// A rejected event must not be spooled for forwarding.
+	if sf.Pending() != 0 {
+		t.Fatalf("expected 0 pending after reject, got %d", sf.Pending())
+	}
+}
+
+func TestSpoolForwarder_DoesNotValidateNonEventPaths(t *testing.T) {
+	t.Parallel()
+
+	// Only events are validated; logs/analytics bodies are forwarded as-is so
+	// the writer (which owns their parsing) decides their fate.
+	sf := newTestSpool(t, "http://localhost:0")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	sf.Forward(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("Forward status = %d, want 202", rec.Code)
+	}
+}
+
 func TestSpoolForwarder_DrainOnce_EmptySpool(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
+	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
+	"github.com/wiebe-xyz/bugbarn/internal/normalize"
 	"github.com/wiebe-xyz/bugbarn/internal/spool"
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
@@ -112,7 +113,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ctx)
 
 	if h == nil || h.auth == nil || h.spool == nil {
-		http.Error(w, "ingest unavailable", http.StatusServiceUnavailable)
+		ingestresp.WriteDropped(w, ingestresp.DropUnavailable)
 		return
 	}
 
@@ -126,7 +127,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if !h.ValidAPIKey(r) {
 		span.SetStatus(codes.Error, "unauthorized")
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		ingestresp.WriteDropped(w, ingestresp.DropUnauthorized)
 		return
 	}
 
@@ -136,11 +137,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			ingestresp.WriteDropped(w, ingestresp.DropTooLarge)
 			return
 		}
 
-		http.Error(w, "unable to read request body", http.StatusBadRequest)
+		ingestresp.WriteDropped(w, ingestresp.DropMalformed)
+		return
+	}
+
+	// Validate synchronously so a malformed event is dropped here with a clear
+	// 400 instead of being durably queued and then silently discarded by the
+	// worker. A body that passes this check will not fail to parse downstream,
+	// so the 202 below honestly means "accepted".
+	if err := normalize.Validate(body); err != nil {
+		span.SetStatus(codes.Error, "malformed payload")
+		ingestresp.WriteDropped(w, ingestresp.DropMalformed)
 		return
 	}
 
@@ -165,21 +176,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		spoolSpan.SetStatus(codes.Error, err.Error())
 		spoolSpan.End()
 		if errors.Is(err, spool.ErrFull) {
-			w.Header().Set("Retry-After", "1")
-			http.Error(w, "ingest spool full", http.StatusTooManyRequests)
+			ingestresp.WriteDropped(w, ingestresp.DropSpoolFull)
 			return
 		}
-		http.Error(w, "ingest unavailable", http.StatusServiceUnavailable)
+		ingestresp.WriteDropped(w, ingestresp.DropUnavailable)
 		return
 	}
 	spoolSpan.End()
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"accepted": true,
-		"ingestId": record.IngestID,
-	})
+	ingestresp.WriteAccepted(w, record.IngestID)
 }
 
 func generateIngestID() string {

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -66,6 +66,48 @@ func TestServeHTTPAcceptedAndSpoolsBody(t *testing.T) {
 	}
 }
 
+func TestServeHTTPRejectsMalformedBody(t *testing.T) {
+	dir := t.TempDir()
+	eventSpool, err := spool.New(dir)
+	if err != nil {
+		t.Fatalf("new spool: %v", err)
+	}
+	defer eventSpool.Close()
+
+	handler := NewHandler(auth.New(""), eventSpool, 1024)
+
+	// Not a JSON object — the worker would drop this as a parse error, so the
+	// handler must reject it up front instead of returning 202 and losing it.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if accepted, ok := response["accepted"].(bool); !ok || accepted {
+		t.Fatalf("expected accepted false, got %#v", response["accepted"])
+	}
+	if retryable, ok := response["retryable"].(bool); !ok || retryable {
+		t.Fatalf("expected retryable false, got %#v", response["retryable"])
+	}
+
+	// A dropped event must never be written to the spool.
+	records, err := spool.ReadRecords(filepath.Join(dir, spool.DefaultFileName))
+	if err != nil {
+		t.Fatalf("read spool: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected malformed event not spooled, got %d records", len(records))
+	}
+}
+
 func TestServeHTTPRejectsMissingAPIKeyWhenEnabled(t *testing.T) {
 	handler := NewHandler(auth.New("secret"), mustSpool(t), 1024)
 

--- a/internal/ingestresp/ingestresp.go
+++ b/internal/ingestresp/ingestresp.go
@@ -1,0 +1,86 @@
+// Package ingestresp defines the shared HTTP response contract for BugBarn's
+// ingest endpoints. Every ingest response tells an SDK two things without
+// requiring it to parse prose: whether the event was accepted, and — if it was
+// dropped — whether retrying the identical request could ever succeed.
+//
+// The contract:
+//
+//	202   accepted   durably queued, will be processed       {"accepted":true,...}
+//	4xx   dropped     permanent — never succeeds as-is, do not retry
+//	429   dropped     transient backpressure — retry after Retry-After
+//	503   dropped     transient outage — retry after Retry-After
+//
+// Accepted responses are always 2xx; dropped responses are always non-2xx and
+// carry a stable machine reason plus a retryable flag. This keeps the
+// accepted/dropped distinction legible from the status code alone, while the
+// body lets clients act on the reason and back off correctly.
+package ingestresp
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Accepted is the body returned with a 202 when an event is durably queued.
+type Accepted struct {
+	Accepted bool   `json:"accepted"` // always true
+	IngestID string `json:"ingestId,omitempty"`
+}
+
+// Dropped is the body returned with every non-2xx ingest response. Reason is a
+// stable, machine-readable token; Retryable reports whether a later retry of
+// the identical request could succeed.
+type Dropped struct {
+	Accepted  bool   `json:"accepted"` // always false
+	Reason    string `json:"reason"`
+	Retryable bool   `json:"retryable"`
+}
+
+// Drop classifies a dropped event: the HTTP status to return, a stable reason
+// token, and whether the SDK should retry.
+type Drop struct {
+	Status    int
+	Reason    string
+	Retryable bool
+}
+
+// Permanent drops — the request is bad and will never succeed as-is. The SDK
+// must not retry; retrying only wastes the event.
+var (
+	// DropMalformed: the body is not a structurally valid event payload.
+	DropMalformed = Drop{Status: http.StatusBadRequest, Reason: "malformed_payload", Retryable: false}
+	// DropUnauthorized: missing or invalid API key.
+	DropUnauthorized = Drop{Status: http.StatusUnauthorized, Reason: "unauthorized", Retryable: false}
+	// DropTooLarge: the body exceeds the ingest size limit.
+	DropTooLarge = Drop{Status: http.StatusRequestEntityTooLarge, Reason: "payload_too_large", Retryable: false}
+)
+
+// Transient drops — the event was refused right now, but an identical retry may
+// succeed once backpressure clears or the writer recovers.
+var (
+	// DropSpoolFull: the ingest buffer is full. Retry after backoff.
+	DropSpoolFull = Drop{Status: http.StatusTooManyRequests, Reason: "spool_full", Retryable: true}
+	// DropUnavailable: the ingest pipeline is temporarily unavailable. Retry.
+	DropUnavailable = Drop{Status: http.StatusServiceUnavailable, Reason: "ingest_unavailable", Retryable: true}
+)
+
+// WriteAccepted writes a 202 with the accepted body. ingestID may be empty
+// (e.g. reader pods that have not yet assigned one).
+func WriteAccepted(w http.ResponseWriter, ingestID string) {
+	writeJSON(w, http.StatusAccepted, Accepted{Accepted: true, IngestID: ingestID})
+}
+
+// WriteDropped writes d's status and dropped body. Retryable drops carry a
+// Retry-After header so SDKs back off instead of hot-looping.
+func WriteDropped(w http.ResponseWriter, d Drop) {
+	if d.Retryable {
+		w.Header().Set("Retry-After", "1")
+	}
+	writeJSON(w, d.Status, Dropped{Accepted: false, Reason: d.Reason, Retryable: d.Retryable})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/ingestresp/ingestresp_test.go
+++ b/internal/ingestresp/ingestresp_test.go
@@ -1,0 +1,97 @@
+package ingestresp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteAccepted(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteAccepted(rr, "abc123")
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rr.Code)
+	}
+	var body Accepted
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Accepted {
+		t.Fatalf("accepted = false, want true")
+	}
+	if body.IngestID != "abc123" {
+		t.Fatalf("ingestId = %q, want abc123", body.IngestID)
+	}
+}
+
+func TestWriteAcceptedOmitsEmptyIngestID(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteAccepted(rr, "")
+	if got := rr.Body.String(); got != `{"accepted":true}`+"\n" {
+		t.Fatalf("body = %q, want accepted-only object", got)
+	}
+}
+
+func TestWriteDropped(t *testing.T) {
+	cases := []struct {
+		name            string
+		drop            Drop
+		wantStatus      int
+		wantRetryable   bool
+		wantRetryHeader bool
+	}{
+		{"malformed", DropMalformed, http.StatusBadRequest, false, false},
+		{"unauthorized", DropUnauthorized, http.StatusUnauthorized, false, false},
+		{"too large", DropTooLarge, http.StatusRequestEntityTooLarge, false, false},
+		{"spool full", DropSpoolFull, http.StatusTooManyRequests, true, true},
+		{"unavailable", DropUnavailable, http.StatusServiceUnavailable, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			WriteDropped(rr, c.drop)
+
+			if rr.Code != c.wantStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, c.wantStatus)
+			}
+			var body Dropped
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if body.Accepted {
+				t.Fatalf("accepted = true, want false for a drop")
+			}
+			if body.Reason != c.drop.Reason {
+				t.Fatalf("reason = %q, want %q", body.Reason, c.drop.Reason)
+			}
+			if body.Retryable != c.wantRetryable {
+				t.Fatalf("retryable = %v, want %v", body.Retryable, c.wantRetryable)
+			}
+			gotHeader := rr.Header().Get("Retry-After") != ""
+			if gotHeader != c.wantRetryHeader {
+				t.Fatalf("Retry-After present = %v, want %v", gotHeader, c.wantRetryHeader)
+			}
+		})
+	}
+}
+
+// TestDropContract pins the permanent-vs-retryable split: 4xx-class client
+// errors must never be retryable, and transient drops must be.
+func TestDropContract(t *testing.T) {
+	permanent := []Drop{DropMalformed, DropUnauthorized, DropTooLarge}
+	for _, d := range permanent {
+		if d.Retryable {
+			t.Errorf("%q is a permanent drop but marked retryable", d.Reason)
+		}
+		if d.Status < 400 || d.Status >= 500 {
+			t.Errorf("%q permanent drop has non-4xx status %d", d.Reason, d.Status)
+		}
+	}
+	for _, d := range []Drop{DropSpoolFull, DropUnavailable} {
+		if !d.Retryable {
+			t.Errorf("%q is a transient drop but not marked retryable", d.Reason)
+		}
+	}
+}

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -12,6 +12,18 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/privacy"
 )
 
+// Validate reports whether raw is a structurally valid event payload: a JSON
+// object (or JSON null) that Normalize can turn into an event. It mirrors the
+// only way Normalize fails, so a body that passes Validate will not be dropped
+// later in the pipeline as a parse error. It is cheap by design — a single
+// decode, no scrubbing or fingerprinting — so the synchronous ingest path can
+// reject malformed events before durably queuing them, making a 202 mean the
+// event was genuinely accepted rather than accepted-then-silently-dropped.
+func Validate(raw []byte) error {
+	var payload map[string]any
+	return json.Unmarshal(raw, &payload)
+}
+
 func Normalize(raw []byte, ingestID string, receivedAt time.Time) (event.Event, error) {
 	var payload map[string]any
 	if err := json.Unmarshal(raw, &payload); err != nil {

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -166,3 +166,39 @@ func TestNormalizeBreadcrumbCap(t *testing.T) {
 		t.Errorf("expected breadcrumbs capped at 100, got %d", len(evt.Breadcrumbs))
 	}
 }
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{"object", `{"message":"boom"}`, false},
+		{"empty object", `{}`, false},
+		{"null", `null`, false},
+		{"not json", `not json`, true},
+		{"empty body", ``, true},
+		{"json array", `[1,2,3]`, true},
+		{"json string", `"boom"`, true},
+		{"json number", `123`, true},
+		{"truncated", `{"message":`, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate([]byte(c.raw))
+			if c.wantErr && err == nil {
+				t.Fatalf("Validate(%q) = nil, want error", c.raw)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("Validate(%q) = %v, want nil", c.raw, err)
+			}
+			// A body that passes Validate must also Normalize without a parse
+			// error — that is the contract that makes a 202 honest.
+			if err == nil {
+				if _, nerr := Normalize([]byte(c.raw), "id", time.Time{}); nerr != nil {
+					t.Fatalf("Validate accepted %q but Normalize rejected it: %v", c.raw, nerr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why
The events ingest path spooled the request body **before** parsing it and returned `202 Accepted` immediately. A malformed event then got silently dropped deep in the worker (`parse_error`) with no signal to the SDK — so `202` did not actually mean "accepted".

## What
- **Synchronous validation** (`normalize.Validate`) runs before spooling on both event-ingest entry points (the direct `ingest.Handler` and the reader-pod `SpoolForwarder`). It mirrors the worker's only parse-failure mode, so any body that gets a `202` will not be dropped later as a parse error.
- **Shared `ingestresp` contract** makes accepted-vs-dropped legible from the status code alone:

  | Status | Meaning | Retryable |
  |---|---|---|
  | `202` | accepted — durably queued | — |
  | `400` malformed / `401` unauthorized / `413` too large | dropped, permanent | `false` |
  | `429` spool full / `503` unavailable | dropped, transient (+`Retry-After`) | `true` |

- **OpenAPI** documents `202/400/401/413/429/503` with `IngestAccepted` / `IngestDropped` schemas.

## Scope
Focused on `/api/v1/events` (the endpoint with the silent-drop bug). `/logs` and `/analytics/collect` already parse synchronously and signal drops with `400`, so they're unchanged. Async drops after a valid event is queued (DB persist failure, retry exhaustion) remain server-side faults observable via metrics/logs — they can't be reflected in an already-sent HTTP response.

## Tests
New tests for the contract, validation, and both ingest paths. Full `go test ./...`, `go vet`, `gofmt`, and `make spec-check` pass.