### PR TITLE
feat: race-with-queue fallback for resolve/reopen/mute/unmute

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/ingestproc"
 	"github.com/wiebe-xyz/bugbarn/internal/issues"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
+	"github.com/wiebe-xyz/bugbarn/internal/mutqueue"
 	"github.com/wiebe-xyz/bugbarn/internal/queue"
 	"github.com/wiebe-xyz/bugbarn/internal/selflog"
 	"github.com/wiebe-xyz/bugbarn/internal/service"
@@ -113,6 +114,12 @@ func run() error {
 	}
 	defer eventSpool.Close()
 
+	mutQueue, err := mutqueue.New(cfg.SpoolDir)
+	if err != nil {
+		return err
+	}
+	defer mutQueue.Close()
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -142,7 +149,7 @@ func run() error {
 	bgWg.Add(1)
 	go func() {
 		defer bgWg.Done()
-		runBackgroundWorker(ctx, eventSpool, cfg.SpoolDir, store, eventPub, selfReporting, workerStatus)
+		runBackgroundWorker(ctx, eventSpool, cfg.SpoolDir, store, eventPub, selfReporting, workerStatus, mutQueue)
 	}()
 
 	digest.StartScheduler(ctx, cfg.Digest, store, &bgWg)
@@ -189,6 +196,7 @@ func run() error {
 	apiServer.SetLogHub(logHub)
 	apiServer.SetSetupConfig(cfg.SessionSecret, cfg.PublicURL)
 	apiServer.SetDigest(cfg.Digest, store)
+	apiServer.SetMutQueue(mutQueue)
 	if len(cfg.TrustedProxies) > 0 {
 		apiServer.SetTrustedProxies(cfg.TrustedProxies)
 	}
@@ -629,7 +637,7 @@ func persistReleaseRecord(ctx context.Context, store *storage.Store, record spoo
 	return err
 }
 
-func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir string, store *storage.Store, svc *service.EventPublisher, selfReporting bool, ws *worker.Status) {
+func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir string, store *storage.Store, svc *service.EventPublisher, selfReporting bool, ws *worker.Status, mq *mutqueue.Queue) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
@@ -651,6 +659,14 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Drain queued admin mutations (resolve/reopen/mute/unmute) before
+			// processing ingest events so user-initiated actions are applied first.
+			if err := mq.Drain(func(r mutqueue.Record) error {
+				return applyMutation(ctx, store, r)
+			}); err != nil {
+				slog.Error("worker failed to drain mutation queue", "error", err)
+			}
+
 			entries, err := spool.ReadRecordsFrom(spool.Path(spoolDir), offset)
 			if err != nil {
 				slog.Error("worker failed to read spool", "error", err)
@@ -854,5 +870,26 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 				slog.Error("worker failed to rotate spool", "error", err)
 			}
 		}
+	}
+}
+
+// applyMutation executes a single queued admin mutation against the store.
+func applyMutation(ctx context.Context, store *storage.Store, r mutqueue.Record) error {
+	switch r.Op {
+	case mutqueue.OpResolve:
+		_, err := store.ResolveIssue(ctx, r.IssueID)
+		return err
+	case mutqueue.OpReopen:
+		_, err := store.ReopenIssue(ctx, r.IssueID)
+		return err
+	case mutqueue.OpMute:
+		_, err := store.MuteIssue(ctx, r.IssueID, r.MuteMode)
+		return err
+	case mutqueue.OpUnmute:
+		_, err := store.UnmuteIssue(ctx, r.IssueID)
+		return err
+	default:
+		slog.Warn("mutqueue: unknown op, skipping", "op", r.Op, "issue_id", r.IssueID)
+		return nil
 	}
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,13 +1,49 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
+	"github.com/wiebe-xyz/bugbarn/internal/mutqueue"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
+
+const mutateTimeout = 5 * time.Second
+
+// tryMutate races fn against a 5-second deadline.
+// Returns (issue, queued=false, err) on completion, or (zero, queued=true, nil) when
+// the deadline fires and the mutation was successfully queued for async application.
+func tryMutate(ctx context.Context, q *mutqueue.Queue, rec mutqueue.Record, fn func(context.Context) (domain.Issue, error)) (domain.Issue, bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, mutateTimeout)
+	defer cancel()
+
+	type outcome struct {
+		issue domain.Issue
+		err   error
+	}
+	ch := make(chan outcome, 1)
+	go func() {
+		issue, err := fn(ctx)
+		ch <- outcome{issue, err}
+	}()
+
+	select {
+	case o := <-ch:
+		return o.issue, false, o.err
+	case <-ctx.Done():
+		if q != nil {
+			if err := q.Append(rec); err != nil {
+				return domain.Issue{}, false, fmt.Errorf("mutqueue: %w", err)
+			}
+		}
+		return domain.Issue{}, true, nil
+	}
+}
 
 // serveIssueRoute handles /api/v1/issues/{id} and sub-paths.
 func (s *Server) serveIssueRoute(w http.ResponseWriter, r *http.Request) {
@@ -131,22 +167,36 @@ func (s *Server) getIssue(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) resolveIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/resolve")
-	item, err := s.issues.Resolve(r.Context(), issueID)
+	issue, queued, err := tryMutate(r.Context(), s.mutQueue,
+		mutqueue.Record{Op: mutqueue.OpResolve, IssueID: issueID},
+		func(ctx context.Context) (domain.Issue, error) { return s.issues.Resolve(ctx, issueID) },
+	)
+	if queued {
+		writeJSONStatus(w, http.StatusAccepted, map[string]any{"queued": true, "issue_id": issueID})
+		return
+	}
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{"issue": item})
+	writeJSON(w, map[string]any{"issue": issue})
 }
 
 func (s *Server) reopenIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/reopen")
-	item, err := s.issues.Reopen(r.Context(), issueID)
+	issue, queued, err := tryMutate(r.Context(), s.mutQueue,
+		mutqueue.Record{Op: mutqueue.OpReopen, IssueID: issueID},
+		func(ctx context.Context) (domain.Issue, error) { return s.issues.Reopen(ctx, issueID) },
+	)
+	if queued {
+		writeJSONStatus(w, http.StatusAccepted, map[string]any{"queued": true, "issue_id": issueID})
+		return
+	}
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{"issue": item})
+	writeJSON(w, map[string]any{"issue": issue})
 }
 
 func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
@@ -158,20 +208,34 @@ func (s *Server) muteIssue(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid mute payload", http.StatusBadRequest)
 		return
 	}
-	item, err := s.issues.Mute(r.Context(), issueID, body.MuteMode)
+	issue, queued, err := tryMutate(r.Context(), s.mutQueue,
+		mutqueue.Record{Op: mutqueue.OpMute, IssueID: issueID, MuteMode: body.MuteMode},
+		func(ctx context.Context) (domain.Issue, error) { return s.issues.Mute(ctx, issueID, body.MuteMode) },
+	)
+	if queued {
+		writeJSONStatus(w, http.StatusAccepted, map[string]any{"queued": true, "issue_id": issueID})
+		return
+	}
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{"issue": item})
+	writeJSON(w, map[string]any{"issue": issue})
 }
 
 func (s *Server) unmuteIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/issues/"), "/unmute")
-	item, err := s.issues.Unmute(r.Context(), issueID)
+	issue, queued, err := tryMutate(r.Context(), s.mutQueue,
+		mutqueue.Record{Op: mutqueue.OpUnmute, IssueID: issueID},
+		func(ctx context.Context) (domain.Issue, error) { return s.issues.Unmute(ctx, issueID) },
+	)
+	if queued {
+		writeJSONStatus(w, http.StatusAccepted, map[string]any{"queued": true, "issue_id": issueID})
+		return
+	}
 	if err != nil {
 		writeServiceError(w, err)
 		return
 	}
-	writeJSON(w, map[string]any{"issue": item})
+	writeJSON(w, map[string]any{"issue": issue})
 }

--- a/internal/api/issues_test.go
+++ b/internal/api/issues_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/wiebe-xyz/bugbarn/internal/event"
+	"github.com/wiebe-xyz/bugbarn/internal/fingerprint"
 	alertsvc "github.com/wiebe-xyz/bugbarn/internal/service/alerts"
 	analyticssvc "github.com/wiebe-xyz/bugbarn/internal/service/analytics"
 	issuesvc "github.com/wiebe-xyz/bugbarn/internal/service/issues"
@@ -246,24 +247,43 @@ func TestListIssuesRegressedFirst(t *testing.T) {
 
 	// Create two issues with distinct fingerprints.
 	issueA := persistTestIssueWithFingerprint(t, store, "fp-regress-a", "normal error")
-	issueB := persistTestIssueWithFingerprint(t, store, "fp-regress-b", "will regress error")
+
+	// Use a real fingerprint for issueB so migrateFingerprints is a no-op and
+	// the subsequent regression PersistProcessedEvent finds the muted issue.
+	evtB := event.Event{
+		ObservedAt: time.Now().UTC(),
+		ReceivedAt: time.Now().UTC().Add(time.Second),
+		Severity:   "ERROR",
+		Message:    "will regress error",
+		Exception:  event.Exception{Type: "TestError", Message: "will regress error"},
+	}
+	fpB := fingerprint.Fingerprint(evtB)
+	snapB := fingerprint.SnapshotFor(evtB)
+	issueB, _, _, _, err := store.PersistProcessedEvent(ctx, worker.ProcessedEvent{
+		Event:               evtB,
+		Fingerprint:         fpB,
+		FingerprintMaterial: snapB.Material,
+	})
+	if err != nil {
+		t.Fatalf("persist issueB: %v", err)
+	}
 
 	// Mute issueB with until_regression, then trigger a regression.
 	if _, err := store.MuteIssue(ctx, issueB.ID, "until_regression"); err != nil {
 		t.Fatalf("mute: %v", err)
 	}
-	pe := worker.ProcessedEvent{
-		Event: event.Event{
-			ObservedAt: time.Now().UTC(),
-			ReceivedAt: time.Now().UTC().Add(time.Second),
-			Severity:   "ERROR",
-			Message:    "will regress error",
-			Exception:  event.Exception{Type: "TestError", Message: "will regress error"},
-		},
-		Fingerprint:         "fp-regress-b",
-		FingerprintMaterial: "TestError: will regress error",
+	regressEvt := event.Event{
+		ObservedAt: time.Now().UTC(),
+		ReceivedAt: time.Now().UTC().Add(time.Second),
+		Severity:   "ERROR",
+		Message:    "will regress error",
+		Exception:  event.Exception{Type: "TestError", Message: "will regress error"},
 	}
-	regressedIssue, _, _, regressed, err := store.PersistProcessedEvent(ctx, pe)
+	regressedIssue, _, _, regressed, err := store.PersistProcessedEvent(ctx, worker.ProcessedEvent{
+		Event:               regressEvt,
+		Fingerprint:         fpB,
+		FingerprintMaterial: snapB.Material,
+	})
 	if err != nil {
 		t.Fatalf("persist regression: %v", err)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
+	"github.com/wiebe-xyz/bugbarn/internal/mutqueue"
 	alertsvc "github.com/wiebe-xyz/bugbarn/internal/service/alerts"
 	analyticssvc "github.com/wiebe-xyz/bugbarn/internal/service/analytics"
 	issuesvc "github.com/wiebe-xyz/bugbarn/internal/service/issues"
@@ -54,12 +55,19 @@ type Server struct {
 	loginLimiter    sync.Map // map[string]*loginAttempt
 	writeForwarder  *WriteForwarder
 	ingestSpool     *SpoolForwarder
+	mutQueue        *mutqueue.Queue
 	dbPath          string
 
 	digestConfig    *digest.Config
 	digestStore     digest.Store
 
 	oidc *auth.OIDCClient
+}
+
+// SetMutQueue wires the mutation queue so that resolve/reopen/mute/unmute
+// handlers enqueue writes instead of hitting SQLite synchronously.
+func (s *Server) SetMutQueue(q *mutqueue.Queue) {
+	s.mutQueue = q
 }
 
 // SetOIDCClient wires the optional iambarn OIDC login adapter. When set, the

--- a/internal/mutqueue/mutqueue.go
+++ b/internal/mutqueue/mutqueue.go
@@ -1,0 +1,173 @@
+// Package mutqueue provides a durable NDJSON queue for admin mutations
+// (resolve, reopen, mute, unmute). It decouples HTTP handlers from SQLite
+// writes: handlers append a record and return 202 immediately; the background
+// worker drains and applies the records at its own pace.
+package mutqueue
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	activeFile     = "mutations.ndjson"
+	processingFile = "mutations.processing.ndjson"
+)
+
+// Op is the mutation operation type.
+type Op string
+
+const (
+	OpResolve Op = "resolve"
+	OpReopen  Op = "reopen"
+	OpMute    Op = "mute"
+	OpUnmute  Op = "unmute"
+)
+
+// Record is a single queued mutation.
+type Record struct {
+	IssueID  string    `json:"issue_id"`
+	Op       Op        `json:"op"`
+	MuteMode string    `json:"mute_mode,omitempty"`
+	QueuedAt time.Time `json:"queued_at"`
+}
+
+// Queue is a durable append-only queue stored as NDJSON on disk.
+// Use New to open one; call Drain on the same instance so file rotation
+// is coordinated under the internal mutex.
+type Queue struct {
+	mu   sync.Mutex
+	dir  string
+	path string
+	file *os.File
+}
+
+// New opens (or creates) a mutation queue in dir.
+func New(dir string) (*Queue, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, activeFile)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &Queue{dir: dir, path: path, file: f}, nil
+}
+
+// Append durably appends a mutation record to the queue.
+func (q *Queue) Append(r Record) error {
+	if r.QueuedAt.IsZero() {
+		r.QueuedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("mutqueue: marshal: %w", err)
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, err := q.file.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("mutqueue: write: %w", err)
+	}
+	return q.file.Sync()
+}
+
+// Drain atomically claims all pending records and calls apply for each one.
+// File rotation (active → processing) is done under the lock so in-flight
+// Append calls always land on the correct file. Returns nil when the queue
+// was empty or all records were applied successfully. On apply failure the
+// processing file is left on disk and retried on the next Drain call.
+func (q *Queue) Drain(apply func(Record) error) error {
+	// Recover any leftover processing file from a previous crashed drain first.
+	procPath := filepath.Join(q.dir, processingFile)
+	if err := drainFile(procPath, apply); err != nil {
+		return err
+	}
+
+	// Under the lock: rename active → processing and open a fresh active file.
+	// Appends during this window are queued behind the mutex.
+	q.mu.Lock()
+	renameErr := os.Rename(q.path, procPath)
+	if renameErr == nil {
+		// Open a new active file before releasing the lock so appenders never see
+		// a missing file.
+		newFile, openErr := os.OpenFile(q.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			q.mu.Unlock()
+			return fmt.Errorf("mutqueue: reopen: %w", openErr)
+		}
+		oldFile := q.file
+		q.file = newFile
+		q.mu.Unlock()
+		_ = oldFile.Close()
+	} else {
+		q.mu.Unlock()
+		if errors.Is(renameErr, os.ErrNotExist) {
+			return nil // nothing queued
+		}
+		return fmt.Errorf("mutqueue: claim: %w", renameErr)
+	}
+
+	return drainFile(procPath, apply)
+}
+
+// Close closes the underlying file.
+func (q *Queue) Close() error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.file == nil {
+		return nil
+	}
+	return q.file.Close()
+}
+
+// drainFile reads records from path, calls apply for each, and deletes the
+// file on success. On failure the file is left for the next Drain call.
+func drainFile(path string, apply func(Record) error) error {
+	records, err := readRecords(path)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		_ = os.Remove(path)
+		return nil
+	}
+	for _, r := range records {
+		if err := apply(r); err != nil {
+			return fmt.Errorf("mutqueue: apply %s %s: %w", r.Op, r.IssueID, err)
+		}
+	}
+	return os.Remove(path)
+}
+
+func readRecords(path string) ([]Record, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("mutqueue: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var records []Record
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r Record
+		if err := json.Unmarshal(line, &r); err != nil {
+			return nil, fmt.Errorf("mutqueue: parse: %w", err)
+		}
+		records = append(records, r)
+	}
+	return records, sc.Err()
+}

--- a/internal/mutqueue/mutqueue_test.go
+++ b/internal/mutqueue/mutqueue_test.go
@@ -1,0 +1,159 @@
+package mutqueue_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/mutqueue"
+)
+
+func TestAppendAndDrain(t *testing.T) {
+	dir := t.TempDir()
+
+	q, err := mutqueue.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Close()
+
+	records := []mutqueue.Record{
+		{Op: mutqueue.OpResolve, IssueID: "PROJ-1"},
+		{Op: mutqueue.OpReopen, IssueID: "PROJ-2"},
+		{Op: mutqueue.OpMute, IssueID: "PROJ-3", MuteMode: "forever"},
+		{Op: mutqueue.OpUnmute, IssueID: "PROJ-4"},
+	}
+	for _, r := range records {
+		if err := q.Append(r); err != nil {
+			t.Fatalf("append %s: %v", r.IssueID, err)
+		}
+	}
+
+	var got []mutqueue.Record
+	if err := q.Drain(func(r mutqueue.Record) error {
+		got = append(got, r)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != len(records) {
+		t.Fatalf("got %d records, want %d", len(got), len(records))
+	}
+	for i, want := range records {
+		if got[i].Op != want.Op || got[i].IssueID != want.IssueID || got[i].MuteMode != want.MuteMode {
+			t.Errorf("record %d: got %+v, want %+v", i, got[i], want)
+		}
+	}
+}
+
+func TestDrainEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	q, err := mutqueue.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Close()
+
+	if err := q.Drain(func(mutqueue.Record) error { return nil }); err != nil {
+		t.Fatalf("drain on empty queue: %v", err)
+	}
+}
+
+func TestDrainRetainsFileOnApplyError(t *testing.T) {
+	dir := t.TempDir()
+
+	q, err := mutqueue.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Close()
+
+	if err := q.Append(mutqueue.Record{Op: mutqueue.OpResolve, IssueID: "PROJ-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	applyErr := errors.New("db locked")
+	if err := q.Drain(func(r mutqueue.Record) error {
+		return applyErr
+	}); err == nil {
+		t.Fatal("expected error from Drain, got nil")
+	}
+
+	// The processing file should still be present so the next Drain retries.
+	procPath := filepath.Join(dir, "mutations.processing.ndjson")
+	if _, err := filepath.Glob(procPath); err != nil {
+		t.Fatalf("processing file stat: %v", err)
+	}
+
+	var retried []mutqueue.Record
+	if err := q.Drain(func(r mutqueue.Record) error {
+		retried = append(retried, r)
+		return nil
+	}); err != nil {
+		t.Fatalf("retry drain: %v", err)
+	}
+	if len(retried) != 1 || retried[0].IssueID != "PROJ-1" {
+		t.Fatalf("retry got %+v, want [{PROJ-1}]", retried)
+	}
+}
+
+func TestAppendAfterDrain(t *testing.T) {
+	dir := t.TempDir()
+
+	q, err := mutqueue.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Close()
+
+	if err := q.Append(mutqueue.Record{Op: mutqueue.OpResolve, IssueID: "A"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Drain(func(mutqueue.Record) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append to the fresh file opened after drain.
+	if err := q.Append(mutqueue.Record{Op: mutqueue.OpReopen, IssueID: "B"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got []mutqueue.Record
+	if err := q.Drain(func(r mutqueue.Record) error {
+		got = append(got, r)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].IssueID != "B" {
+		t.Fatalf("got %+v, want [{IssueID:B}]", got)
+	}
+}
+
+func TestQueuedAtIsSet(t *testing.T) {
+	dir := t.TempDir()
+
+	q, err := mutqueue.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer q.Close()
+
+	if err := q.Append(mutqueue.Record{Op: mutqueue.OpResolve, IssueID: "X"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got mutqueue.Record
+	if err := q.Drain(func(r mutqueue.Record) error {
+		got = r
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.QueuedAt.IsZero() {
+		t.Error("QueuedAt was not set")
+	}
+}


### PR DESCRIPTION
## What

Handlers for resolve, reopen, mute, and unmute now race the direct SQLite write against a 5-second deadline. If the write completes in time → 200 OK with the result. If the deadline fires → mutation is appended to a durable NDJSON spool and the request returns 202 Accepted. The background worker drains the spool each tick.

This is the \"race two promises\" pattern: normal operation is unchanged (fast 200), contention gracefully degrades to async (202).

## Why

Resolve/mute calls from `bb` were timing out against production due to SQLite write contention on the single write connection. The original approach always-queued, which loses the synchronous response even when the DB is healthy. This approach preserves the fast path and only falls back under load.

## Design

- `tryMutate` helper races `fn(ctx)` against a 5-second `context.WithTimeout`. On timeout, appends to the `mutqueue` spool and returns 202. The timed-out goroutine exits cleanly once the cancelled context aborts the DB call.
- `internal/mutqueue`: durable NDJSON append-only spool; drain via atomic `os.Rename`; leftover `.processing` file is retried on next tick.
- No handler changes when DB is healthy — response is identical to before.
- Fixes pre-existing flaky test `TestListIssuesRegressedFirst` (race with `migrateFingerprints`).

## Test plan

- [ ] `go test ./...` green
- [ ] CI green
- [ ] After deploy: `bb resolve` returns 200 when DB is not under write load; falls back to 202 under contention