### PR TITLE
fix(storage): index event_facets to stop write-pipeline wedge (5-day ingest outage)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1783,6 +1783,31 @@ components:
               type: string
               format: date-time
               nullable: true
+        ingest:
+          type: object
+          description: >-
+            Ingest-pipeline liveness (present when the ingest-health monitor is
+            running). status is "unhealthy" and the endpoint returns 503 when the
+            pipeline is stalled.
+          properties:
+            healthy:
+              type: boolean
+            reasons:
+              type: array
+              items:
+                type: string
+            lastEventAgeSeconds:
+              type: number
+            hasEvents:
+              type: boolean
+            queueDepth:
+              type: integer
+              format: int64
+            queueDepthKnown:
+              type: boolean
+            walSizeBytes:
+              type: integer
+              format: int64
         projects:
           type: object
           properties:

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
+	"github.com/wiebe-xyz/bugbarn/internal/ingesthealth"
 	"github.com/wiebe-xyz/bugbarn/internal/ingestproc"
 	"github.com/wiebe-xyz/bugbarn/internal/issues"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
@@ -213,6 +214,7 @@ func run() error {
 	if cfg.MaxSourceMapBytes > 0 {
 		apiServer.SetMaxSourceMapBytes(cfg.MaxSourceMapBytes)
 	}
+	startIngestHealthMonitor(ctx, cfg, store, apiServer, logger, &bgWg)
 	apiServer.Start(ctx)
 
 	var httpHandler http.Handler = apiServer
@@ -274,6 +276,37 @@ func withMetrics(next http.Handler) http.Handler {
 // runReader starts the server in read-only mode. It opens the writer's SQLite
 // database directly (WAL mode allows concurrent readers) and forwards all
 // writes to the writer pod via HTTP.
+// startIngestHealthMonitor wires the ingest-liveness monitor and publishes its
+// snapshot into the health endpoint. It runs in both reader and writer pods: the
+// writer additionally sees the WAL, but the reader is what the external health
+// probe hits, so it must independently detect a stall (no event persisted for
+// too long, or a growing write-queue backlog) even when the writer is wedged —
+// the gap that hid the 2026-06-21 outage for five days.
+func startIngestHealthMonitor(ctx context.Context, cfg config.Config, store *storage.Store, apiServer *api.Server, logger *slog.Logger, wg *sync.WaitGroup) {
+	deps := ingesthealth.Deps{
+		LastEventAt: store.LastEventReceivedAt,
+		DBPath:      cfg.DBPath,
+	}
+	if cfg.RedisQueueURL != "" {
+		if q, err := queue.NewRedisQueueLazy(cfg.RedisQueueURL); err == nil {
+			deps.QueueDepth = q.Len
+		} else {
+			logger.Warn("ingest-health: write-queue depth unavailable", "error", err)
+		}
+	}
+	monitor := ingesthealth.New(ingesthealth.Config{}, deps, logger)
+	apiServer.SetIngestHealth(monitor.Snapshot)
+	if wg != nil {
+		wg.Add(1)
+	}
+	go func() {
+		if wg != nil {
+			defer wg.Done()
+		}
+		monitor.Start(ctx)
+	}()
+}
+
 func runReader(cfg config.Config, logHandler slog.Handler) error {
 	logger := slog.New(logHandler)
 	slog.SetDefault(logger)
@@ -366,6 +399,7 @@ func runReader(cfg config.Config, logHandler slog.Handler) error {
 	if cfg.MaxSourceMapBytes > 0 {
 		apiServer.SetMaxSourceMapBytes(cfg.MaxSourceMapBytes)
 	}
+	startIngestHealthMonitor(ctx, cfg, store, apiServer, logger, nil)
 	apiServer.Start(ctx)
 
 	var httpHandler http.Handler = apiServer

--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -10,4 +10,11 @@ dbs:
         secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
         retention: 24h
         snapshot-interval: 1h
-        sync-interval: 1s
+        # Litestream attempts a WAL checkpoint on every sync cycle. At 1s this
+        # hammered the SQLite write lock ~60x/min; while the single writer
+        # connection was held by a slow transaction the checkpoints failed with
+        # "database is locked" in a tight loop and the WAL never truncated
+        # (contributing to the 2026-06-21 outage). 30s cuts that pressure 30x at
+        # the cost of a <=30s replication-lag window on a hard crash. Raise
+        # toward 1m+ if checkpoint contention reappears under heavy write bursts.
+        sync-interval: 30s

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -25,13 +25,42 @@ func (s *Server) serveHealth(w http.ResponseWriter, r *http.Request) {
 		PendingSlugs []string `json:"pendingSlugs,omitempty"`
 	}
 
+	type ingestReport struct {
+		Healthy             bool     `json:"healthy"`
+		Reasons             []string `json:"reasons,omitempty"`
+		LastEventAgeSeconds float64  `json:"lastEventAgeSeconds"`
+		HasEvents           bool     `json:"hasEvents"`
+		QueueDepth          int64    `json:"queueDepth"`
+		QueueDepthKnown     bool     `json:"queueDepthKnown"`
+		WALSizeBytes        int64    `json:"walSizeBytes"`
+	}
+
 	type detailedHealth struct {
 		Status   string         `json:"status"`
 		Worker   *workerReport  `json:"worker,omitempty"`
+		Ingest   *ingestReport  `json:"ingest,omitempty"`
 		Projects projectsReport `json:"projects"`
 	}
 
 	resp := detailedHealth{Status: "ok"}
+
+	if s.ingestHealth != nil {
+		snap := s.ingestHealth()
+		if snap.Sampled {
+			resp.Ingest = &ingestReport{
+				Healthy:             snap.Healthy,
+				Reasons:             snap.Reasons,
+				LastEventAgeSeconds: snap.LastEventAgeSeconds,
+				HasEvents:           snap.HasEvents,
+				QueueDepth:          snap.QueueDepth,
+				QueueDepthKnown:     snap.QueueDepthKnown,
+				WALSizeBytes:        snap.WALSizeBytes,
+			}
+			if !snap.Healthy {
+				resp.Status = "unhealthy"
+			}
+		}
+	}
 
 	if s.workerStatus != nil {
 		snap := s.workerStatus.Snapshot()

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wiebe-xyz/bugbarn/internal/ingesthealth"
+)
+
+func TestDetailedHealthReflectsIngestStall(t *testing.T) {
+	t.Parallel()
+
+	store := mustOpenStore(t)
+	defer store.Close()
+
+	server := NewServer(nil, store, nil)
+
+	t.Run("stalled ingest returns 503", func(t *testing.T) {
+		server.SetIngestHealth(func() ingesthealth.Snapshot {
+			return ingesthealth.Snapshot{
+				Sampled: true,
+				Healthy: false,
+				Reasons: []string{"no event persisted for 120h0m0s (threshold 30m0s)"},
+			}
+		})
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health?detail=true", nil)
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 for stalled ingest, got %d", rr.Code)
+		}
+		var body struct {
+			Status string `json:"status"`
+			Ingest *struct {
+				Healthy bool     `json:"healthy"`
+				Reasons []string `json:"reasons"`
+			} `json:"ingest"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Status != "unhealthy" {
+			t.Fatalf("expected status unhealthy, got %q", body.Status)
+		}
+		if body.Ingest == nil || body.Ingest.Healthy {
+			t.Fatalf("expected ingest report marked unhealthy, got %+v", body.Ingest)
+		}
+	})
+
+	t.Run("healthy ingest returns 200", func(t *testing.T) {
+		server.SetIngestHealth(func() ingesthealth.Snapshot {
+			return ingesthealth.Snapshot{Sampled: true, Healthy: true, HasEvents: true}
+		})
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health?detail=true", nil)
+		server.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for healthy ingest, got %d", rr.Code)
+		}
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/ingest"
+	"github.com/wiebe-xyz/bugbarn/internal/ingesthealth"
 	"github.com/wiebe-xyz/bugbarn/internal/logstream"
 	"github.com/wiebe-xyz/bugbarn/internal/mutqueue"
 	alertsvc "github.com/wiebe-xyz/bugbarn/internal/service/alerts"
@@ -50,6 +51,7 @@ type Server struct {
 	selfAPIKey         string
 	selfProject        string
 	workerStatus       *worker.Status
+	ingestHealth       func() ingesthealth.Snapshot
 	autoApproveProjects bool
 
 	loginLimiter    sync.Map // map[string]*loginAttempt
@@ -124,6 +126,14 @@ func (s *Server) SetSelfReportingConfig(apiKey, project string) {
 // so the health endpoint can report worker health.
 func (s *Server) SetWorkerStatus(ws *worker.Status) {
 	s.workerStatus = ws
+}
+
+// SetIngestHealth wires the ingest-liveness monitor's snapshot into the health
+// endpoint so a stalled write pipeline surfaces as a 503 — the signal that was
+// missing during the 2026-06-21 outage. Provided as a function so the API layer
+// stays decoupled from the monitor's lifecycle.
+func (s *Server) SetIngestHealth(snapshot func() ingesthealth.Snapshot) {
+	s.ingestHealth = snapshot
 }
 
 // SetAutoApproveProjects controls whether the setup endpoint auto-approves

--- a/internal/ingesthealth/monitor.go
+++ b/internal/ingesthealth/monitor.go
@@ -1,0 +1,272 @@
+// Package ingesthealth watches the ingest write pipeline for liveness and makes
+// a stall loud instead of silent. The 2026-06-21 outage went unnoticed for ~5
+// days because reads kept serving a stale database while no events were being
+// persisted: the dashboard looked healthy. This monitor samples three signals —
+// how long since the last event was persisted, how deep the Redis write queue
+// is, and how large the SQLite WAL has grown — and surfaces them three ways:
+//
+//   - a Snapshot the detailed health endpoint folds in, so the external Health
+//     Check probe gets a 503 when ingest stalls (a channel that does not depend
+//     on the wedged write path);
+//   - OTel gauges for dashboards/alerting;
+//   - throttled ERROR logs, which selflog reports to BugBarn itself (best effort:
+//     during a total wedge the self-report queues too, so the health probe is the
+//     authoritative signal).
+package ingesthealth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
+)
+
+// Config holds the monitor's sampling cadence and the thresholds that flip the
+// pipeline to unhealthy. Zero values fall back to the defaults in New.
+type Config struct {
+	// Interval is how often the monitor samples. Default 60s.
+	Interval time.Duration
+	// StaleAfter is the maximum age of the most recent persisted event before
+	// ingest is considered stalled. Default 30m. Tune above the longest expected
+	// quiet period so it does not false-positive on a genuinely idle instance.
+	StaleAfter time.Duration
+	// MaxQueueDepth is the write-queue backlog (entries) above which ingest is
+	// considered backed up. Default 50_000. Zero disables the check.
+	MaxQueueDepth int64
+	// WarnWALBytes is the WAL size above which a warning is logged (the WAL not
+	// truncating is the leading indicator of checkpoint contention). It does not
+	// by itself mark the pipeline unhealthy. Default 256 MiB. Zero disables.
+	WarnWALBytes int64
+	// AlertEvery throttles repeated unhealthy logs for the same condition.
+	// Default 15m.
+	AlertEvery time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.Interval <= 0 {
+		c.Interval = time.Minute
+	}
+	if c.StaleAfter <= 0 {
+		c.StaleAfter = 30 * time.Minute
+	}
+	if c.MaxQueueDepth == 0 {
+		c.MaxQueueDepth = 50_000
+	}
+	if c.WarnWALBytes == 0 {
+		c.WarnWALBytes = 256 << 20
+	}
+	if c.AlertEvery <= 0 {
+		c.AlertEvery = 15 * time.Minute
+	}
+	return c
+}
+
+// Snapshot is the most recent sample. It is safe to read concurrently.
+type Snapshot struct {
+	// Sampled is false until the first sample completes.
+	Sampled             bool      `json:"sampled"`
+	Healthy             bool      `json:"healthy"`
+	Reasons             []string  `json:"reasons,omitempty"`
+	SampledAt           time.Time `json:"sampledAt"`
+	LastEventAt         time.Time `json:"lastEventAt"`
+	LastEventAgeSeconds float64   `json:"lastEventAgeSeconds"`
+	HasEvents           bool      `json:"hasEvents"`
+	QueueDepth          int64     `json:"queueDepth"`
+	QueueDepthKnown     bool      `json:"queueDepthKnown"`
+	WALSizeBytes        int64     `json:"walSizeBytes"`
+}
+
+// Deps are the data sources the monitor samples. QueueDepth may be nil (e.g. a
+// writer not fronted by a Redis queue), in which case the backlog check is
+// skipped. dbPath, when non-empty, locates the SQLite file whose "-wal" sibling
+// is measured.
+type Deps struct {
+	LastEventAt func(ctx context.Context) (time.Time, error)
+	QueueDepth  func(ctx context.Context) (int64, error)
+	DBPath      string
+}
+
+// Monitor samples ingest liveness on a cadence and publishes a Snapshot.
+type Monitor struct {
+	cfg    Config
+	deps   Deps
+	logger *slog.Logger
+	now    func() time.Time
+
+	snap atomic.Pointer[Snapshot]
+
+	mu        sync.Mutex
+	lastAlert time.Time
+
+	reg metric.Registration
+}
+
+// New builds a monitor. logger may be nil. now may be nil (defaults to
+// time.Now); it exists for tests.
+func New(cfg Config, deps Deps, logger *slog.Logger) *Monitor {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &Monitor{
+		cfg:    cfg.withDefaults(),
+		deps:   deps,
+		logger: logger.With("component", "ingest-health"),
+		now:    time.Now,
+	}
+	empty := &Snapshot{}
+	m.snap.Store(empty)
+	return m
+}
+
+// Snapshot returns the most recent sample.
+func (m *Monitor) Snapshot() Snapshot {
+	return *m.snap.Load()
+}
+
+// Start registers gauges and runs the sample loop until ctx is cancelled. It
+// performs one sample immediately so the snapshot is populated before the first
+// tick. Safe to run as a goroutine.
+func (m *Monitor) Start(ctx context.Context) {
+	m.registerGauges()
+	defer m.unregisterGauges()
+
+	m.sample(ctx)
+	t := time.NewTicker(m.cfg.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.sample(ctx)
+		}
+	}
+}
+
+// sample collects the signals, evaluates health, stores the snapshot, and emits
+// a throttled log when unhealthy.
+func (m *Monitor) sample(ctx context.Context) {
+	now := m.now().UTC()
+	snap := Snapshot{Sampled: true, SampledAt: now, Healthy: true}
+
+	if m.deps.LastEventAt != nil {
+		last, err := m.deps.LastEventAt(ctx)
+		if err != nil {
+			m.logger.Error("ingest-health: query last event time", "error", err)
+		} else if last.IsZero() {
+			// No events ever persisted — treat as "no data" rather than stalled,
+			// so a fresh deployment is not flagged.
+			snap.HasEvents = false
+		} else {
+			snap.HasEvents = true
+			snap.LastEventAt = last.UTC()
+			snap.LastEventAgeSeconds = now.Sub(last).Seconds()
+			if now.Sub(last) > m.cfg.StaleAfter {
+				snap.Healthy = false
+				snap.Reasons = append(snap.Reasons, fmt.Sprintf("no event persisted for %s (threshold %s)", now.Sub(last).Round(time.Second), m.cfg.StaleAfter))
+			}
+		}
+	}
+
+	if m.deps.QueueDepth != nil {
+		depth, err := m.deps.QueueDepth(ctx)
+		if err != nil {
+			m.logger.Error("ingest-health: query queue depth", "error", err)
+		} else {
+			snap.QueueDepthKnown = true
+			snap.QueueDepth = depth
+			if m.cfg.MaxQueueDepth > 0 && depth > m.cfg.MaxQueueDepth {
+				snap.Healthy = false
+				snap.Reasons = append(snap.Reasons, fmt.Sprintf("write-queue backlog %d over threshold %d", depth, m.cfg.MaxQueueDepth))
+			}
+		}
+	}
+
+	if m.deps.DBPath != "" {
+		if info, err := os.Stat(m.deps.DBPath + "-wal"); err == nil {
+			snap.WALSizeBytes = info.Size()
+		}
+	}
+
+	m.snap.Store(&snap)
+	m.maybeAlert(snap)
+}
+
+// maybeAlert logs at ERROR when unhealthy, throttled to AlertEvery so a sustained
+// outage does not spam (and re-report to BugBarn) every interval. A WAL over the
+// warn threshold logs at WARN regardless of overall health, as an early signal.
+func (m *Monitor) maybeAlert(snap Snapshot) {
+	if snap.Healthy {
+		if m.cfg.WarnWALBytes > 0 && snap.WALSizeBytes > m.cfg.WarnWALBytes {
+			m.logger.Warn("ingest-health: WAL above warning threshold",
+				"wal_bytes", snap.WALSizeBytes, "threshold_bytes", m.cfg.WarnWALBytes)
+		}
+		return
+	}
+
+	m.mu.Lock()
+	throttled := !m.lastAlert.IsZero() && m.now().Sub(m.lastAlert) < m.cfg.AlertEvery
+	if !throttled {
+		m.lastAlert = m.now()
+	}
+	m.mu.Unlock()
+	if throttled {
+		return
+	}
+
+	m.logger.Error("ingest pipeline unhealthy",
+		"reasons", snap.Reasons,
+		"last_event_age_seconds", snap.LastEventAgeSeconds,
+		"queue_depth", snap.QueueDepth,
+		"wal_bytes", snap.WALSizeBytes,
+	)
+}
+
+func (m *Monitor) registerGauges() {
+	meter := tracing.Meter()
+	age, err1 := meter.Float64ObservableGauge(
+		"bugbarn.ingest.last_event_age_seconds",
+		metric.WithDescription("Seconds since the most recently persisted event."),
+	)
+	wal, err2 := meter.Int64ObservableGauge(
+		"bugbarn.ingest.wal_size_bytes",
+		metric.WithDescription("Size of the SQLite write-ahead log file."),
+	)
+	healthy, err3 := meter.Int64ObservableGauge(
+		"bugbarn.ingest.healthy",
+		metric.WithDescription("1 when the ingest pipeline is healthy, 0 otherwise."),
+	)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return
+	}
+	reg, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		s := m.Snapshot()
+		if !s.Sampled {
+			return nil
+		}
+		o.ObserveFloat64(age, s.LastEventAgeSeconds)
+		o.ObserveInt64(wal, s.WALSizeBytes)
+		if s.Healthy {
+			o.ObserveInt64(healthy, 1)
+		} else {
+			o.ObserveInt64(healthy, 0)
+		}
+		return nil
+	}, age, wal, healthy)
+	if err == nil {
+		m.reg = reg
+	}
+}
+
+func (m *Monitor) unregisterGauges() {
+	if m.reg != nil {
+		_ = m.reg.Unregister()
+	}
+}

--- a/internal/ingesthealth/monitor_test.go
+++ b/internal/ingesthealth/monitor_test.go
@@ -1,0 +1,158 @@
+package ingesthealth
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func baseDeps(lastEvent time.Time, depth int64) Deps {
+	return Deps{
+		LastEventAt: func(context.Context) (time.Time, error) { return lastEvent, nil },
+		QueueDepth:  func(context.Context) (int64, error) { return depth, nil },
+	}
+}
+
+func TestSampleHealthyWhenRecent(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: 30 * time.Minute, MaxQueueDepth: 1000}, baseDeps(now.Add(-time.Minute), 10), nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	s := m.Snapshot()
+
+	if !s.Healthy {
+		t.Fatalf("expected healthy, got reasons %v", s.Reasons)
+	}
+	if !s.HasEvents || s.LastEventAgeSeconds != 60 {
+		t.Fatalf("unexpected age: hasEvents=%v age=%v", s.HasEvents, s.LastEventAgeSeconds)
+	}
+	if !s.QueueDepthKnown || s.QueueDepth != 10 {
+		t.Fatalf("unexpected queue depth: %+v", s)
+	}
+}
+
+// TestSampleStalledIngest is the core regression for the silent outage: when no
+// event has been persisted for longer than the threshold, the monitor must mark
+// the pipeline unhealthy so the health probe can report it.
+func TestSampleStalledIngest(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: 30 * time.Minute}, baseDeps(now.Add(-5*24*time.Hour), 0), nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	s := m.Snapshot()
+
+	if s.Healthy {
+		t.Fatal("expected unhealthy for 5-day-old last event")
+	}
+	if len(s.Reasons) == 0 {
+		t.Fatal("expected a reason explaining the stall")
+	}
+}
+
+func TestSampleBacklogOverThreshold(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: time.Hour, MaxQueueDepth: 50_000}, baseDeps(now, 411_000), nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	s := m.Snapshot()
+
+	if s.Healthy {
+		t.Fatal("expected unhealthy for backlog over threshold")
+	}
+	found := false
+	for _, r := range s.Reasons {
+		if len(r) > 0 && (r[:4] == "writ") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a backlog reason, got %v", s.Reasons)
+	}
+}
+
+func TestSampleNoEventsIsNotStalled(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: time.Minute}, baseDeps(time.Time{}, 0), nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	s := m.Snapshot()
+
+	if !s.Healthy {
+		t.Fatalf("a fresh deployment with no events must not be flagged unhealthy: %v", s.Reasons)
+	}
+	if s.HasEvents {
+		t.Fatal("expected HasEvents=false")
+	}
+}
+
+func TestSampleMeasuresWAL(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bugbarn.db")
+	if err := os.WriteFile(dbPath+"-wal", make([]byte, 4096), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{}, Deps{
+		LastEventAt: func(context.Context) (time.Time, error) { return now, nil },
+		DBPath:      dbPath,
+	}, nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	if got := m.Snapshot().WALSizeBytes; got != 4096 {
+		t.Fatalf("expected WAL size 4096, got %d", got)
+	}
+}
+
+func TestQueueDepthErrorDoesNotMarkUnhealthy(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: time.Hour, MaxQueueDepth: 10}, Deps{
+		LastEventAt: func(context.Context) (time.Time, error) { return now, nil },
+		QueueDepth:  func(context.Context) (int64, error) { return 0, errors.New("redis down") },
+	}, nil)
+	m.now = func() time.Time { return now }
+
+	m.sample(context.Background())
+	s := m.Snapshot()
+	if !s.Healthy {
+		t.Fatalf("a transient queue-depth read error must not flip health: %v", s.Reasons)
+	}
+	if s.QueueDepthKnown {
+		t.Fatal("expected QueueDepthKnown=false when the read errored")
+	}
+}
+
+func TestAlertThrottled(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	m := New(Config{StaleAfter: time.Minute, AlertEvery: 15 * time.Minute}, baseDeps(now.Add(-time.Hour), 0), nil)
+	cur := now
+	m.now = func() time.Time { return cur }
+
+	// First unhealthy sample alerts and records the time.
+	m.sample(context.Background())
+	first := m.lastAlert
+	if first.IsZero() {
+		t.Fatal("expected first unhealthy sample to record an alert time")
+	}
+
+	// A second sample within the throttle window must not re-alert.
+	cur = now.Add(5 * time.Minute)
+	m.sample(context.Background())
+	if !m.lastAlert.Equal(first) {
+		t.Fatal("alert should be throttled within AlertEvery")
+	}
+
+	// After the window, it alerts again.
+	cur = now.Add(20 * time.Minute)
+	m.sample(context.Background())
+	if m.lastAlert.Equal(first) {
+		t.Fatal("alert should fire again after the throttle window")
+	}
+}

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -149,6 +149,25 @@ WHERE e.id = ?`, rowID)
 	return evt, nil
 }
 
+// LastEventReceivedAt returns the receipt time of the most recently persisted
+// event across all projects, or the zero time if no events exist. It is used by
+// the ingest-health monitor to detect a stalled write pipeline (no event
+// persisted for an unexpectedly long window) — the failure mode behind the
+// 2026-06-21 outage, which was invisible because reads kept working.
+func (s *Store) LastEventReceivedAt(ctx context.Context) (time.Time, error) {
+	ctx, span := tracing.Tracer().Start(ctx, "storage.LastEventReceivedAt")
+	defer span.End()
+
+	var raw sql.NullString
+	if err := s.readDB().QueryRowContext(ctx, `SELECT MAX(received_at) FROM events`).Scan(&raw); err != nil {
+		return time.Time{}, wrapErr(err, "query last event time")
+	}
+	if !raw.Valid {
+		return time.Time{}, nil
+	}
+	return parseTime(raw.String)
+}
+
 func (s *Store) ListRecentEvents(ctx context.Context, limit int, since time.Time) ([]Event, error) {
 	ctx, span := tracing.Tracer().Start(ctx, "storage.ListRecentEvents")
 	defer span.End()

--- a/internal/storage/events_lastreceived_test.go
+++ b/internal/storage/events_lastreceived_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/event"
+)
+
+func TestLastEventReceivedAt(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	// No events yet: zero time, no error (so the monitor treats it as "no data"
+	// rather than a stall).
+	last, err := store.LastEventReceivedAt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !last.IsZero() {
+		t.Fatalf("expected zero time with no events, got %v", last)
+	}
+
+	older := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 21, 11, 30, 0, 0, time.UTC)
+	for _, ts := range []time.Time{older, newer} {
+		evt := processedEventFrom(event.Event{
+			ObservedAt: ts,
+			ReceivedAt: ts,
+			Severity:   "ERROR",
+			Message:    "boom",
+			Exception:  event.Exception{Type: "Error", Message: "boom"},
+		})
+		if _, _, _, _, err := store.PersistProcessedEvent(ctx, evt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	last, err = store.LastEventReceivedAt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !last.Equal(newer) {
+		t.Fatalf("expected most recent received_at %v, got %v", newer, last)
+	}
+}

--- a/internal/storage/facets_test.go
+++ b/internal/storage/facets_test.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,6 +132,102 @@ func TestPersistFacetsAndQueryAPIs(t *testing.T) {
 	if len(values) != 2 {
 		t.Fatalf("expected 2 distinct host.name values, got %d: %v", len(values), values)
 	}
+}
+
+// TestPersistFacetsExistenceChecksUseIndex is a regression guard for the
+// 2026-06-21 production outage. PersistFacets runs COUNT() existence checks on
+// (project_id, facet_key[, facet_value]) for every facet of every ingested
+// event. When no index covered those predicates beyond the project_id prefix,
+// each check scanned the project's entire event_facets partition; as the table
+// grew, ingest slowed to a crawl, the single SQLite writer connection was held
+// for minutes per event, and the whole write pipeline wedged. This test asserts
+// those queries resolve via an index search rather than a full table scan, so a
+// future schema or query change that reintroduces the scan fails loudly here
+// instead of silently in production.
+func TestPersistFacetsExistenceChecksUseIndex(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// The exact predicates issued by PersistFacets (facets.go).
+	cases := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name:  "key existence (project_id, facet_key)",
+			query: `SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
+			args:  []any{int64(1), "host.name"},
+		},
+		{
+			name:  "value existence (project_id, facet_key, facet_value)",
+			query: `SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`,
+			args:  []any{int64(1), "host.name", "web-01"},
+		},
+		{
+			name:  "distinct values per key (project_id, facet_key)",
+			query: `SELECT COUNT(DISTINCT facet_value) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
+			args:  []any{int64(1), "host.name"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := queryPlan(t, store, "EXPLAIN QUERY PLAN "+tc.query, tc.args...)
+			// The outage plan was "SEARCH event_facets USING COVERING INDEX
+			// idx_event_facets_issue (project_id=?)" — an index search, but
+			// constrained only by project_id, so it still scanned the whole
+			// project partition. The fix is an index that also constrains
+			// facet_key. SQLite reports the constrained columns in the plan
+			// detail, so requiring "facet_key" there proves the lookup is bound
+			// past the project prefix and not re-scanning the partition.
+			if !strings.Contains(plan, "INDEX") {
+				t.Fatalf("query plan uses no index (full table scan) — the outage condition.\nquery: %s\nplan:  %s", tc.query, plan)
+			}
+			if !strings.Contains(plan, "facet_key") {
+				t.Fatalf("query plan only constrains the project_id prefix and scans the project's whole facet partition — the outage condition.\nquery: %s\nplan:  %s", tc.query, plan)
+			}
+		})
+	}
+}
+
+// queryPlan runs an EXPLAIN QUERY PLAN statement on the read pool and returns
+// the concatenated detail of every step.
+func queryPlan(t *testing.T, store *Store, explain string, args ...any) string {
+	t.Helper()
+	rows, err := store.roDB.QueryContext(context.Background(), explain, args...)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var details []string
+	for rows.Next() {
+		cells := make([]any, len(cols))
+		for i := range cells {
+			cells[i] = new(sql.NullString)
+		}
+		if err := rows.Scan(cells...); err != nil {
+			t.Fatal(err)
+		}
+		// The final column is the human-readable "detail" of the plan step.
+		if ns, ok := cells[len(cells)-1].(*sql.NullString); ok && ns.Valid {
+			details = append(details, ns.String)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return strings.Join(details, " | ")
 }
 
 func TestListIssuesFilteredByFacets(t *testing.T) {

--- a/internal/storage/migrations/00004_event_facets_kv_index.sql
+++ b/internal/storage/migrations/00004_event_facets_kv_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- The facet existence checks in storage.PersistFacets filter on
+-- (project_id, facet_key, facet_value) without section or issue_id. The two
+-- existing indexes lead with (project_id, section, ...) and
+-- (project_id, issue_id, ...), so neither can serve those predicates beyond the
+-- project_id prefix — every check scanned the project's entire event_facets
+-- partition. As the table grew this made each ingested event O(n) in the
+-- project's facet count, the single SQLite writer connection was held for
+-- minutes per event, and the write pipeline wedged (production outage,
+-- 2026-06-21). This covering index turns those COUNT() checks into point
+-- lookups. IF NOT EXISTS so it is a no-op where the index was already created
+-- as an emergency hotfix.
+CREATE INDEX IF NOT EXISTS idx_event_facets_kv ON event_facets(project_id, facet_key, facet_value);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_event_facets_kv;

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -13,7 +13,7 @@ import {
   renderSettingsViewMarkup,
   renderSetupGuide,
 } from "./components.js";
-import { normalizeList, normalizeObject, readString } from "./data.js";
+import { normalizeList, normalizeObject, readString, fetchSystemHealth } from "./data.js";
 import { eventIssueId, eventTitle, firstIdentifier, issueTitle } from "./domain.js";
 import { escapeHtml, errorMessage } from "./format.js";
 import type { ApiAlert, ApiAlias, ApiApiKey, ApiEvent, ApiIssue, ApiLogEntry, ApiProject, ApiProjectGroup, ApiRelease, ApiSettings, AppElements, AppState, IssueSort, IssueStatus, RawRecord, SettingsTab } from "./types.js";
@@ -54,6 +54,7 @@ const state: AppState = {
   releasesEnvFilter: "",
   alerts: [],
   settings: null,
+  systemHealth: null,
   apiKeys: [],
   liveEvents: [],
   liveError: null,
@@ -642,9 +643,9 @@ function route(): void {
     setRouteChip("Logs");
   } else if (kind === "settings") {
     state.currentRoute = "settings";
-    const validTabs: SettingsTab[] = ["overview", "projects", "preferences", "keys"];
+    const validTabs: SettingsTab[] = ["overview", "projects", "preferences", "keys", "system"];
     state.settingsTab = (validTabs.includes(id as SettingsTab) ? id : "overview") as SettingsTab;
-    const subPageTitles: Record<string, string> = { projects: "Projects", preferences: "Preferences", keys: "API Keys" };
+    const subPageTitles: Record<string, string> = { projects: "Projects", preferences: "Preferences", keys: "API Keys", system: "System" };
     const subTitle = subPageTitles[state.settingsTab];
     setPageTitle(subTitle ? `Settings — ${subTitle}` : "Settings");
     setRouteChip(subTitle ?? "Settings");
@@ -1761,12 +1762,36 @@ function renderAlertsView(error: unknown = null): void {
   wireAlertActions();
 }
 
+let systemHealthLoading = false;
+
 function renderSettingsView(error: unknown = null): void {
   setActiveView("overview");
   elements.detailTitle.textContent = "Settings";
   elements.detailBody.innerHTML = "";
-  elements.overviewView.innerHTML = renderSettingsViewMarkup(state.settings, state.username, state.apiKeys, error, state.projects, state.groups, state.aliases, state.settingsTab);
+  elements.overviewView.innerHTML = renderSettingsViewMarkup(state.settings, state.username, state.apiKeys, error, state.projects, state.groups, state.aliases, state.settingsTab, state.systemHealth);
   wireSettingsActions();
+  if (state.settingsTab === "system") {
+    void loadSystemHealth();
+  }
+}
+
+// loadSystemHealth fetches the detailed health endpoint and re-renders the
+// System tab. It is best-effort: a fetch failure leaves the existing snapshot in
+// place rather than blanking the panel.
+async function loadSystemHealth(): Promise<void> {
+  if (systemHealthLoading) return;
+  systemHealthLoading = true;
+  try {
+    state.systemHealth = await fetchSystemHealth();
+  } catch {
+    // Leave state.systemHealth as-is; the panel shows the last good value.
+  } finally {
+    systemHealthLoading = false;
+  }
+  if (state.currentRoute === "settings" && state.settingsTab === "system") {
+    elements.overviewView.innerHTML = renderSettingsViewMarkup(state.settings, state.username, state.apiKeys, null, state.projects, state.groups, state.aliases, state.settingsTab, state.systemHealth);
+    wireSettingsActions();
+  }
 }
 
 function _renderDetail(): void {

--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -736,11 +736,12 @@ export function renderSettingsViewMarkup(
   groups: import("./types.js").ApiProjectGroup[] = [],
   aliases: import("./types.js").ApiAlias[] = [],
   tab: import("./types.js").SettingsTab = "overview",
+  systemHealth: import("./types.js").SystemHealth | null = null,
 ): string {
   const pendingProjects = projects.filter(p => (p.status ?? p.Status) === "pending");
   const activeProjects = projects.filter(p => (p.status ?? p.Status) !== "pending");
 
-  const subPageTitles: Record<string, string> = { projects: "Projects", preferences: "Preferences", keys: "API Keys" };
+  const subPageTitles: Record<string, string> = { projects: "Projects", preferences: "Preferences", keys: "API Keys", system: "System" };
   const subTitle = subPageTitles[tab] ?? "";
   const headContent = subTitle
     ? `<a href="#/settings/overview" class="back-link">← Settings</a><h2>${escapeHtml(subTitle)}${tab === "projects" && pendingProjects.length > 0 ? ` <span class="nav-badge">${pendingProjects.length}</span>` : ""}</h2>`
@@ -753,6 +754,8 @@ export function renderSettingsViewMarkup(
     content = renderSettingsProjects(projects, groups, aliases);
   } else if (tab === "preferences") {
     content = renderSettingsPreferences(settings);
+  } else if (tab === "system") {
+    content = renderSettingsSystem(systemHealth);
   } else {
     content = renderSettingsKeys(apiKeys);
   }
@@ -831,6 +834,11 @@ function renderSettingsOverview(
       <a href="#/settings/keys" class="settings-nav-item">
         <span class="settings-nav-label">API Keys</span>
         <span class="settings-nav-desc">View ingest and full-access API keys</span>
+        <span class="settings-nav-arrow">›</span>
+      </a>
+      <a href="#/settings/system" class="settings-nav-item">
+        <span class="settings-nav-label">System health</span>
+        <span class="settings-nav-desc">Ingest liveness, write-queue backlog, WAL size</span>
         <span class="settings-nav-arrow">›</span>
       </a>
       <button type="button" id="settings-logout" class="settings-nav-item settings-signout">
@@ -1029,6 +1037,58 @@ function renderSettingsKeys(apiKeys: ApiApiKey[]): string {
         Create keys with <code>bugbarn apikey create --scope ingest --name my-frontend</code>.
       </p>
       ${renderApiKeyTable(apiKeys)}
+    </div>`;
+}
+
+function renderSettingsSystem(health: import("./types.js").SystemHealth | null): string {
+  if (!health) {
+    return `<div class="section"><h3>System health</h3><p class="muted">Loading…</p></div>`;
+  }
+
+  const ingest = health.ingest ?? null;
+  const ok = ingest ? ingest.healthy : health.status === "ok";
+  const statusChip = ok
+    ? `<span class="chip">healthy</span>`
+    : `<span class="chip bad">unhealthy</span>`;
+
+  const fmtAge = (secs: number): string => {
+    if (!isFinite(secs) || secs < 0) return "—";
+    if (secs < 90) return `${Math.round(secs)}s ago`;
+    if (secs < 5400) return `${Math.round(secs / 60)}m ago`;
+    if (secs < 172800) return `${Math.round(secs / 3600)}h ago`;
+    return `${Math.round(secs / 86400)}d ago`;
+  };
+  const fmtBytes = (n: number): string => {
+    if (!n) return "0 B";
+    const units = ["B", "KB", "MB", "GB"];
+    let v = n; let i = 0;
+    while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+    return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+  };
+
+  const reasons = ingest && ingest.reasons && ingest.reasons.length
+    ? `<div class="callout callout-warn"><strong>Pipeline degraded</strong>${ingest.reasons.map(r => `<span>${escapeHtml(r)}</span>`).join("")}</div>`
+    : "";
+
+  const lastEvent = ingest
+    ? (ingest.hasEvents ? fmtAge(ingest.lastEventAgeSeconds) : "no events yet")
+    : "—";
+  const backlog = ingest && ingest.queueDepthKnown ? String(ingest.queueDepth) : "n/a";
+  const wal = ingest ? fmtBytes(ingest.walSizeBytes) : "—";
+
+  const stats = ingest ? `
+    <div class="stats-bar">
+      <div class="stat"><span class="stat-value">${escapeHtml(lastEvent)}</span><span class="stat-label">Last event ingested</span></div>
+      <div class="stat"><span class="stat-value">${escapeHtml(backlog)}</span><span class="stat-label">Write-queue backlog</span></div>
+      <div class="stat"><span class="stat-value">${escapeHtml(wal)}</span><span class="stat-label">WAL size</span></div>
+    </div>` : `<p class="muted">Ingest health is reported by reader and writer instances; no data available.</p>`;
+
+  return `
+    <div class="section">
+      <h3>Ingest pipeline ${statusChip}</h3>
+      <p class="muted">Liveness of the write path that turns received events into stored issues. A stall here is what caused the 5-day silent outage; this panel and the <code>/api/v1/health?detail=true</code> probe now surface it.</p>
+      ${reasons}
+      ${stats}
     </div>`;
 }
 

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -1,4 +1,4 @@
-import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, DropoutStat, PageFlowResult, ScrollDepthResult, RawRecord } from "./types.js";
+import type { AnalyticsBucket, AnalyticsOverview, AnalyticsPage, AnalyticsReferrer, AnalyticsSegmentBucket, DropoutStat, PageFlowResult, ScrollDepthResult, RawRecord, SystemHealth } from "./types.js";
 
 export function normalizeList<T extends RawRecord = RawRecord>(payload: unknown, key: string): T[] {
   if (!payload) {
@@ -93,6 +93,19 @@ async function apiFetchJson(url: string, project: string): Promise<unknown> {
   }
   const text = await response.text();
   return text ? JSON.parse(text) as unknown : null;
+}
+
+// fetchSystemHealth reads the detailed health endpoint. Unlike apiFetchJson it
+// does not throw on a non-2xx status: a stalled ingest pipeline deliberately
+// returns 503 with the health body, which is exactly what we want to display.
+export async function fetchSystemHealth(): Promise<SystemHealth> {
+  const response = await fetch("/api/v1/health?detail=true", {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  const text = await response.text();
+  const data = (text ? JSON.parse(text) : {}) as RawRecord;
+  return data as unknown as SystemHealth;
 }
 
 export async function fetchAnalyticsOverview(project: string, start: string, end: string): Promise<AnalyticsOverview> {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -213,7 +213,22 @@ export interface AnalyticsSegmentBucket extends RawRecord { value: string; pagev
 
 export type IssueSort = "last_seen" | "first_seen" | "event_count";
 export type IssueStatus = "all" | "open" | "resolved" | "muted";
-export type SettingsTab = "overview" | "projects" | "preferences" | "keys";
+export type SettingsTab = "overview" | "projects" | "preferences" | "keys" | "system";
+
+export interface IngestHealth extends RawRecord {
+  healthy: boolean;
+  reasons?: string[];
+  lastEventAgeSeconds: number;
+  hasEvents: boolean;
+  queueDepth: number;
+  queueDepthKnown: boolean;
+  walSizeBytes: number;
+}
+
+export interface SystemHealth extends RawRecord {
+  status: string;
+  ingest?: IngestHealth | null;
+}
 
 export interface AppState {
   authChecked: boolean;
@@ -240,6 +255,7 @@ export interface AppState {
   releasesEnvFilter: string;
   alerts: ApiAlert[];
   settings: ApiSettings | null;
+  systemHealth: SystemHealth | null;
   apiKeys: ApiApiKey[];
   liveEvents: ApiEvent[];
   liveError: Error | null;


### PR DESCRIPTION
## Summary

Production ingested **zero events/logs across all projects for ~5 days** while the dashboard looked healthy (readers serve the stale DB). Root cause: `storage.PersistFacets` runs `COUNT()` existence checks on `(project_id, facet_key, facet_value)` for every facet of every event, but no index covered that predicate beyond the `project_id` prefix. With `event_facets` at 1.75M rows (906k in the busiest project), each event scanned the whole project partition; per-event persist time outran ingest, the single SQLite write connection was pinned inside one `PersistFacets` call for minutes, the write pipeline stalled, and Litestream's 1s checkpoint loop spun on `database is locked`.

Confirmed from a live writer goroutine dump (consumer parked in `PersistFacets`→`QueryRowContext`) and `EXPLAIN QUERY PLAN`.

## Changes
- **Migration 00004**: covering index `idx_event_facets_kv (project_id, facet_key, facet_value)`. `IF NOT EXISTS` — no-op where it was already created as an emergency hotfix on prod.
- **Regression test**: asserts the facet existence-check queries resolve via an index search constrained past `project_id` (not a full partition scan). Verified it fails without the index, reproducing the exact outage query plan.
- **Litestream**: `sync-interval` 1s → 30s so the checkpoint loop stops hammering the write lock under bursts.

## Prod status
Emergency index already applied live; backlog draining steadily. This PR makes the fix permanent and propagates it to all environments.