### PR TITLE
fix(k8s): set LITESTREAM_ENDPOINT on testing and staging

### DIFF
--- a/deploy/k8s/staging/writer-deployment.yaml
+++ b/deploy/k8s/staging/writer-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: "104857600"
             - name: BUGBARN_SESSION_TTL_SECONDS
               value: "86400"
+            - name: LITESTREAM_ENDPOINT
+              value: https://s3.wiebe.xyz
             - name: LITESTREAM_REPLICA_PATH
               value: staging/bugbarn.db
             - name: BUGBARN_API_KEY

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: "104857600"
             - name: BUGBARN_SESSION_TTL_SECONDS
               value: "86400"
+            - name: LITESTREAM_ENDPOINT
+              value: https://s3.wiebe.xyz
             - name: LITESTREAM_REPLICA_PATH
               value: testing/bugbarn.db
             - name: BUGBARN_API_KEY


### PR DESCRIPTION
## Summary

The Litestream image config replicates to `${LITESTREAM_ENDPOINT}` (since commit 27cf862, "route replication through internal MinIO service"), but only `production/writer-deployment.yaml` actually sets that env. **testing** and **staging** left it empty, so Litestream defaulted to **real AWS S3**, where the `bugbarn-litestream` access key does not exist → `InvalidAccessKeyId`. This crash-looped the testing pod and was the cause of the failed `Build and Deploy Testing` rollout for v0.236.86.

## Fix
Add `LITESTREAM_ENDPOINT: https://s3.wiebe.xyz` to both, matching production.

Testing was already patched live to recover it; this tracks the fix in the repo so it survives redeploys (and staging won't break on its next image update).