### PR TITLE
feat(k8s): add bb.brandtrace.net ingress

### DIFF
--- a/deploy/k8s/production/ingest-ingress.yaml
+++ b/deploy/k8s/production/ingest-ingress.yaml
@@ -119,10 +119,44 @@ spec:
                 name: bugbarn
                 port:
                   name: http
+    - host: bb.brandtrace.net
+      http:
+        paths:
+          - path: /api/v1/events
+            pathType: Prefix
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
+          - path: /api/v1/logs
+            pathType: Prefix
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
+          - path: /api/v1/setup/
+            pathType: Prefix
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
+          - path: /api/v1/health
+            pathType: Exact
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
   tls:
     - hosts:
         - bb.pensioenfeest.nl
       secretName: bb-pensioenfeest-nl-tls
+    - hosts:
+        - bb.brandtrace.net
+      secretName: bb-brandtrace-net-tls
     - hosts:
         - bb.scanoo.nl
       secretName: bb-scanoo-nl-tls
@@ -174,10 +208,23 @@ spec:
                 name: bugbarn
                 port:
                   name: http
+    - host: bb.brandtrace.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bugbarn
+                port:
+                  name: http
   tls:
     - hosts:
         - bb.pensioenfeest.nl
       secretName: bb-pensioenfeest-nl-tls
+    - hosts:
+        - bb.brandtrace.net
+      secretName: bb-brandtrace-net-tls
     - hosts:
         - bb.scanoo.nl
       secretName: bb-scanoo-nl-tls


### PR DESCRIPTION
New alias tenant domain `bb.brandtrace.net`, following the existing `bb.*` pattern: ingest-only routes (`/api/v1/events`, `/logs`, `/setup/`, `/health`) on the ingest ingress, dashboard `/` on the redirect ingress, each with its own TLS secret (`bb-brandtrace-net-tls`, provisioned via Traefik ACME).

Applied to production directly (ingress-only, no pod churn); this PR tracks it in the repo so a future prod deploy stays idempotent.