### PR TITLE
perf(storage): index event_facets for facet read/filter paths

### DIFF
--- a/internal/storage/facets_test.go
+++ b/internal/storage/facets_test.go
@@ -196,6 +196,61 @@ func TestPersistFacetsExistenceChecksUseIndex(t *testing.T) {
 	}
 }
 
+// TestFacetReadQueriesUseIndexes guards the facet read/filter paths (migration
+// 00005). The cross-project ("all projects") variants filter on facet_key with
+// no project_id; before the facet-leading index they full-scanned event_facets.
+// The project-scoped facet→issue filter needs issue_id in the index to avoid a
+// per-row table lookup.
+func TestFacetReadQueriesUseIndexes(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cases := []struct {
+		name      string
+		query     string
+		args      []any
+		wantIndex string
+	}{
+		{
+			name:      "cross-project distinct facet keys",
+			query:     `SELECT DISTINCT facet_key FROM event_facets ORDER BY facet_key ASC`,
+			wantIndex: "idx_event_facets_facet",
+		},
+		{
+			name:      "cross-project distinct facet values for a key",
+			query:     `SELECT DISTINCT facet_value FROM event_facets WHERE facet_key = ? ORDER BY facet_value ASC`,
+			args:      []any{"host.name"},
+			wantIndex: "idx_event_facets_facet",
+		},
+		{
+			name:      "cross-project issue filter by facet",
+			query:     `SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`,
+			args:      []any{"host.name", "web-01"},
+			wantIndex: "idx_event_facets_facet",
+		},
+		{
+			name:      "project-scoped issue filter by facet (covering)",
+			query:     `SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`,
+			args:      []any{int64(1), "host.name", "web-01"},
+			wantIndex: "idx_event_facets_kv_issue",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := queryPlan(t, store, "EXPLAIN QUERY PLAN "+tc.query, tc.args...)
+			if !strings.Contains(plan, tc.wantIndex) {
+				t.Fatalf("query does not use %s (likely a full table scan).\nquery: %s\nplan:  %s", tc.wantIndex, tc.query, plan)
+			}
+		})
+	}
+}
+
 // queryPlan runs an EXPLAIN QUERY PLAN statement on the read pool and returns
 // the concatenated detail of every step.
 func queryPlan(t *testing.T, store *Store, explain string, args ...any) string {

--- a/internal/storage/migrations/00005_event_facets_read_indexes.sql
+++ b/internal/storage/migrations/00005_event_facets_read_indexes.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- Facet read/filter paths beyond the PersistFacets existence checks were
+-- under-indexed:
+--
+--   * issues.go ListIssuesFilteredByFacets, project-scoped:
+--       SELECT DISTINCT issue_id ... WHERE project_id=? AND facet_key=? AND facet_value=?
+--     idx_event_facets_kv covered the WHERE but not issue_id, so each matching
+--     row needed a table lookup. Widen it to a covering index (issue_id last).
+--     The new index is a superset of idx_event_facets_kv, which is therefore
+--     redundant and dropped — keeping the per-insert index count flat.
+--
+--   * The cross-project ("all projects") variants filter on facet_key /
+--     facet_value with no project_id (ListFacetKeys, ListFacetValues, and the
+--     facet issue filter). Every existing index leads with project_id, so those
+--     queries full-scanned event_facets. Add a facet-leading index to serve them.
+DROP INDEX IF EXISTS idx_event_facets_kv;
+CREATE INDEX IF NOT EXISTS idx_event_facets_kv_issue
+  ON event_facets(project_id, facet_key, facet_value, issue_id);
+CREATE INDEX IF NOT EXISTS idx_event_facets_facet
+  ON event_facets(facet_key, facet_value, issue_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_event_facets_facet;
+DROP INDEX IF EXISTS idx_event_facets_kv_issue;
+CREATE INDEX IF NOT EXISTS idx_event_facets_kv ON event_facets(project_id, facet_key, facet_value);


### PR DESCRIPTION
Adds two indexes for facet access patterns that were under-indexed:

- **`idx_event_facets_kv_issue`** `(project_id, facet_key, facet_value, issue_id)` — makes the project-scoped facet→issue filter (`ListIssuesFilteredByFacets`) a **covering** scan instead of index-seek + per-row table read. Supersedes `idx_event_facets_kv`, which is dropped so the per-insert index count stays flat.
- **`idx_event_facets_facet`** `(facet_key, facet_value, issue_id)` — serves the **cross-project** (all-projects) facet queries (`ListFacetKeys`, `ListFacetValues`, and the cross-project issue facet filter), which led with `facet_key` and had no usable index, so they full-scanned `event_facets` (now 1.86M rows).

Regression test (`TestFacetReadQueriesUseIndexes`) asserts both paths resolve via the new indexes; the existing existence-check test still passes against the widened index.

**Scope note:** these accelerate facet **read/filter** queries. They do *not* fix the ~6s event **write** latency (the per-facet `COUNT(*)` existence checks count all matching rows) — that needs a `COUNT`→`EXISTS` change, a separate follow-up.