### PR TITLE
perf(storage): EXISTS instead of COUNT(*) for facet existence checks

### DIFF
--- a/internal/storage/facets.go
+++ b/internal/storage/facets.go
@@ -140,30 +140,35 @@ func (s *Store) PersistFacets(ctx context.Context, eventID int64, issueID int64,
 			continue
 		}
 
-		// Determine whether this key is new to this project.
-		var existingKeyCount int
+		// Determine whether this key is new to this project. EXISTS stops at the
+		// first matching row; the old COUNT(*) counted every row for the key,
+		// which on a high-frequency facet key meant scanning hundreds of
+		// thousands of index entries per facet per event — the dominant cost in
+		// event persistence. We only need the existence boolean.
+		var keyExists bool
 		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
+			`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ?)`,
 			projectID, k,
-		).Scan(&existingKeyCount); err != nil {
+		).Scan(&keyExists); err != nil {
 			return err
 		}
-		isNewKey := existingKeyCount == 0
+		isNewKey := !keyExists
 
 		// Cardinality guard: max 50 distinct keys per project.
 		if isNewKey && keyCount >= maxFacetKeysPerProject {
 			continue
 		}
 
-		// Determine whether this specific value is new for this key.
-		var valueExists int
+		// Determine whether this specific value is new for this key — again an
+		// existence check, not a count.
+		var valueExists bool
 		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`,
+			`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?)`,
 			projectID, k, v,
 		).Scan(&valueExists); err != nil {
 			return err
 		}
-		isNewValue := valueExists == 0
+		isNewValue := !valueExists
 
 		// Cardinality guard: max 10,000 distinct values per key.
 		if isNewValue {

--- a/internal/storage/facets_test.go
+++ b/internal/storage/facets_test.go
@@ -161,12 +161,12 @@ func TestPersistFacetsExistenceChecksUseIndex(t *testing.T) {
 	}{
 		{
 			name:  "key existence (project_id, facet_key)",
-			query: `SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
+			query: `SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ?)`,
 			args:  []any{int64(1), "host.name"},
 		},
 		{
 			name:  "value existence (project_id, facet_key, facet_value)",
-			query: `SELECT COUNT(*) FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`,
+			query: `SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?)`,
 			args:  []any{int64(1), "host.name", "web-01"},
 		},
 		{


### PR DESCRIPTION
Fixes the ~6s event-persist latency identified during verification.

`PersistFacets` ran two `COUNT(*)` queries **per facet, per event** to compute `isNewKey` / `isNewValue`, but only compared the result to `0`. `COUNT(*)` counts *every* matching row, so on a high-frequency facet key/value it scanned hundreds of thousands of index entries per facet — the dominant cost (events are facet-heavy; logs skip this path and persist in microseconds).

`EXISTS(SELECT 1 …)` short-circuits at the first match → O(1) index seek. Behaviour is identical (it's the `COUNT==0` boolean); cardinality caps and dedup unchanged. The existence-check regression test now asserts the `EXISTS` queries resolve via `idx_event_facets_kv_issue`.

Pairs with the facet read indexes (#134); together they address both the slow facet *reads* and the slow event *writes*.