### PR TITLE
fix(ingest): setup-key projects work on read-only readers; hold ingest until approval

### DIFF
--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -164,6 +164,14 @@ func run() error {
 	// producers are switched to Redis (phase 3) and it is retired (phase 5).
 	// The shared write mutex (nil for now) is wired when retention and the WAL
 	// checkpoint move under it in a later phase.
+	// The persist pipeline and held-events replayer are shared between the Redis
+	// consumer (live ingest) and the project-approval path (backlog drain), so
+	// build them once. The replayer works without Redis — approving a pending
+	// project drains its backlog even if no consumer is running.
+	eventProc := ingestproc.NewProcessor(store, eventPub, logger, cfg.AutoApproveProjects)
+	logService := logsvc.New(store, logger)
+	heldReplayer := ingestproc.NewReplayer(store, eventProc, logService, logger)
+
 	if cfg.RedisQueueURL != "" {
 		bgWg.Add(1)
 		go func() {
@@ -174,7 +182,7 @@ func run() error {
 				return
 			}
 			defer writeQueue.Close()
-			consumer := ingestproc.NewConsumer(writeQueue, ingestproc.NewProcessor(store, eventPub, logger), logsvc.New(store, logger), nil, logger)
+			consumer := ingestproc.NewConsumer(writeQueue, eventProc, logService, nil, logger)
 			logger.Info("redis write-queue consumer started", "url", cfg.RedisQueueURL)
 			consumer.Run(ctx)
 		}()
@@ -204,6 +212,7 @@ func run() error {
 	apiServer.SetDBPath(cfg.DBPath)
 	apiServer.SetWorkerStatus(workerStatus)
 	apiServer.SetAutoApproveProjects(cfg.AutoApproveProjects)
+	apiServer.SetHeldReplayer(heldReplayer)
 	apiServer.SetFunnelBarnConfig(cfg.FunnelBarnEndpoint, cfg.FunnelBarnAPIKey)
 	if selfReporting {
 		apiServer.SetSelfReportingConfig(cfg.SelfAPIKey, cfg.SelfProject)
@@ -518,30 +527,24 @@ func newAPIAuthorizer(cfg config.Config, store *storage.Store) (*auth.Authorizer
 	}
 	base = base.WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
 	if cfg.SessionSecret != "" {
-		base = base.WithSetupKeyVerifier(newSetupKeyVerifier(cfg.SessionSecret, store, cfg.AutoApproveProjects))
+		base = base.WithSetupKeyVerifier(newSetupKeyVerifier(cfg.SessionSecret))
 	}
 	return base, nil
 }
 
-func newSetupKeyVerifier(secret string, store *storage.Store, autoApprove bool) auth.SetupKeyVerifier {
-	return func(ctx context.Context, rawKey, projectSlug string) (int64, bool) {
+// newSetupKeyVerifier returns a verifier that authorizes a setup key purely by
+// its HMAC — it performs no database writes, so it is safe on the read-only
+// reader pods that serve public ingest (CQRS split). The project is created
+// (pending, awaiting approval) lazily on the writer when the forwarded event is
+// consumed; see ingestproc.Processor.EnsureProjectForIngest. ProjectID is 0
+// because the reader resolves projects by slug downstream, not at auth time.
+func newSetupKeyVerifier(secret string) auth.SetupKeyVerifier {
+	return func(_ context.Context, rawKey, projectSlug string) (int64, bool) {
 		expected := setupKey(secret, projectSlug)
 		if expected == "" || subtle.ConstantTimeCompare([]byte(rawKey), []byte(expected)) != 1 {
 			return 0, false
 		}
-		var proj storage.Project
-		var err error
-		if autoApprove {
-			proj, err = store.EnsureProject(ctx, projectSlug)
-		} else {
-			proj, err = store.EnsureProjectPending(ctx, projectSlug)
-		}
-		if err != nil {
-			return 0, false
-		}
-		keySHA := sha256Hex(rawKey)
-		_ = store.EnsureSetupAPIKey(ctx, projectSlug+"-setup", proj.ID, keySHA)
-		return proj.ID, true
+		return 0, true
 	}
 }
 
@@ -552,11 +555,6 @@ func setupKey(secret, slug string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte("setup:" + slug))
 	return hex.EncodeToString(mac.Sum(nil))[:40]
-}
-
-func sha256Hex(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:])
 }
 
 // runWorkerOnce replays queued records into the persistent store for local maintenance.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -148,6 +148,14 @@ func (s *Server) SetWriteForwarder(f *WriteForwarder) {
 	s.writeForwarder = f
 }
 
+// SetHeldReplayer wires the held-events replayer into the projects service so
+// approving a pending project drains its backlog. Writer-only.
+func (s *Server) SetHeldReplayer(r projectsvc.HeldReplayer) {
+	if s.projects != nil {
+		s.projects.SetHeldReplayer(r)
+	}
+}
+
 // SetIngestSpool wires a spool-backed forwarder for fire-and-forget ingest
 // endpoints (events, logs, analytics). When set, those endpoints append to
 // the on-disk spool and return 202 instead of forwarding synchronously, so

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -35,9 +35,10 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 
 	proj, err := s.projects.BySlug(r.Context(), slug)
 	if err != nil {
-		// Project doesn't exist yet or we're on a read-only replica.
-		// That's fine — the key is deterministic and the project + API key
-		// will be created lazily on the writer when the first event arrives.
+		// Project doesn't exist yet (e.g. on a read-only reader serving public
+		// ingest). That's fine — the key is deterministic and the project is
+		// created lazily, pending admin approval, on the writer when the first
+		// event arrives.
 		proj.Slug = slug
 		proj.Status = "new"
 	}
@@ -58,14 +59,14 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pendingNote := ""
-	if status == "pending" {
+	if status == "pending" || status == "new" {
 		pendingNote = fmt.Sprintf(`
 ## Pending admin approval
 
-This project was just created and is pending approval at:
+New projects are created pending approval. Send events now — they are accepted
+(HTTP 202) and queued. They are ingested into the dashboard once an admin
+approves the project at:
   %s
-
-Events are accepted immediately. The admin will review and approve.
 `, endpoint)
 	}
 

--- a/internal/ingestproc/consumer.go
+++ b/internal/ingestproc/consumer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/logparse"
 	"github.com/wiebe-xyz/bugbarn/internal/queue"
 	"github.com/wiebe-xyz/bugbarn/internal/spool"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
 // LogInserter persists parsed log entries. Satisfied by *service/logs.Service.
@@ -172,6 +173,8 @@ func (c *Consumer) persistEvent(ctx context.Context, item queue.Item) string {
 		switch res.Outcome {
 		case OutcomeSuccess:
 			return "success"
+		case OutcomeHeld:
+			return "held"
 		case OutcomeParseError:
 			c.logger.Error("drop unparseable event", "ingest_id", item.IngestID, "error", res.Err)
 			return "parse_error"
@@ -208,11 +211,29 @@ func (c *Consumer) persistLog(ctx context.Context, item queue.Item) string {
 		c.logger.Error("decode log body", "project", item.ProjectSlug, "error", err)
 		return "decode_error"
 	}
-	projectID := c.proc.ResolveProjectID(ctx, item.ProjectSlug)
-	if projectID == 0 {
+	proj, ok := c.proc.EnsureProjectForIngest(ctx, item.ProjectSlug)
+	if !ok {
 		c.logger.Warn("dropping log item: unresolved project", "project", item.ProjectSlug)
 		return "dropped"
 	}
+	// Project pending admin approval: park the raw log payload for replay on
+	// approval instead of inserting it.
+	if proj.Status == "pending" {
+		held := storage.HeldRecord{
+			ProjectID:   proj.ID,
+			Slug:        item.ProjectSlug,
+			Kind:        storage.HeldKindLog,
+			IngestID:    item.IngestID,
+			ReceivedAt:  item.ReceivedAt,
+			ContentType: item.ContentType,
+			BodyBase64:  item.BodyBase64,
+		}
+		if err := c.proc.Hold(ctx, held); err != nil {
+			return "held_error"
+		}
+		return "held"
+	}
+	projectID := proj.ID
 	entries := logparse.ParseBody(body, item.ContentType, projectID)
 	if len(entries) == 0 {
 		return "empty"

--- a/internal/ingestproc/held_test.go
+++ b/internal/ingestproc/held_test.go
@@ -1,0 +1,194 @@
+package ingestproc
+
+import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/wiebe-xyz/bugbarn/internal/domainevents"
+	"github.com/wiebe-xyz/bugbarn/internal/queue"
+	"github.com/wiebe-xyz/bugbarn/internal/service"
+	logsvc "github.com/wiebe-xyz/bugbarn/internal/service/logs"
+	"github.com/wiebe-xyz/bugbarn/internal/spool"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+// pendingProcessor builds a processor with autoApprove=false so brand-new
+// projects are created pending and their ingest is held.
+func pendingProcessor(t *testing.T) (*Processor, *storage.Store) {
+	t.Helper()
+	store, err := storage.Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	pub := service.NewEventPublisher(&domainevents.Bus{})
+	return NewProcessor(store, pub, nil, false), store
+}
+
+func TestPersistRecordHeldForPendingProject(t *testing.T) {
+	t.Parallel()
+	proc, store := pendingProcessor(t)
+	ctx := context.Background()
+
+	res := proc.PersistRecord(ctx, spool.Record{
+		IngestID:    "ing-1",
+		ReceivedAt:  time.Now().UTC(),
+		BodyBase64:  eventBody(t),
+		ProjectSlug: "pending-svc",
+	})
+	if res.Outcome != OutcomeHeld {
+		t.Fatalf("outcome = %v, want OutcomeHeld (err=%v)", res.Outcome, res.Err)
+	}
+
+	proj, err := store.ProjectBySlug(ctx, "pending-svc")
+	if err != nil {
+		t.Fatalf("project by slug: %v", err)
+	}
+	if proj.Status != "pending" {
+		t.Errorf("project status = %q, want pending", proj.Status)
+	}
+	n, err := store.CountHeldByProject(ctx, proj.ID)
+	if err != nil {
+		t.Fatalf("count held: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("held count = %d, want 1", n)
+	}
+	issues, err := store.ListIssues(storage.WithProjectID(ctx, proj.ID))
+	if err != nil {
+		t.Fatalf("list issues: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("got %d issues, want 0 (held, not persisted)", len(issues))
+	}
+}
+
+func TestReplayHeldEventsOnApproval(t *testing.T) {
+	t.Parallel()
+	proc, store := pendingProcessor(t)
+	ctx := context.Background()
+
+	// Two events arrive while pending → both held.
+	for i := 0; i < 2; i++ {
+		res := proc.PersistRecord(ctx, spool.Record{
+			IngestID:    "ing",
+			ReceivedAt:  time.Now().UTC(),
+			BodyBase64:  eventBody(t),
+			ProjectSlug: "pending-svc",
+		})
+		if res.Outcome != OutcomeHeld {
+			t.Fatalf("event %d outcome = %v, want OutcomeHeld", i, res.Outcome)
+		}
+	}
+	proj, err := store.ProjectBySlug(ctx, "pending-svc")
+	if err != nil {
+		t.Fatalf("project by slug: %v", err)
+	}
+
+	// Approve and drain.
+	if err := store.ApproveProject(ctx, "pending-svc"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	replayer := NewReplayer(store, proc, logsvc.New(store, nil), nil)
+	got, err := replayer.ReplayHeld(ctx, proj.ID)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if got != 2 {
+		t.Errorf("replayed = %d, want 2", got)
+	}
+
+	n, _ := store.CountHeldByProject(ctx, proj.ID)
+	if n != 0 {
+		t.Errorf("held count after replay = %d, want 0", n)
+	}
+	// Both events share a fingerprint → one issue, two events on it.
+	issues, err := store.ListIssues(storage.WithProjectID(ctx, proj.ID))
+	if err != nil {
+		t.Fatalf("list issues: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("got %d issues, want 1", len(issues))
+	}
+	if issues[0].EventCount != 2 {
+		t.Errorf("issue event count = %d, want 2", issues[0].EventCount)
+	}
+}
+
+func TestConsumerHoldsAndReplaysLog(t *testing.T) {
+	t.Parallel()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	q, err := queue.NewRedisQueue("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+	t.Cleanup(func() { q.Close() })
+
+	proc, store := pendingProcessor(t)
+	logs := logsvc.New(store, nil)
+	var mu sync.Mutex
+	c := NewConsumer(q, proc, logs, &mu, nil)
+
+	ctx := context.Background()
+	logBody := []byte(`{"logs":[{"level":"error","msg":"boom","reqId":"abc"}]}`)
+	if err := q.Publish(ctx, []queue.Item{{
+		Kind:        queue.KindLog,
+		ReceivedAt:  time.Now().UTC(),
+		ContentType: "application/json",
+		ProjectSlug: "pending-svc",
+		BodyBase64:  base64.StdEncoding.EncodeToString(logBody),
+	}}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	go c.Run(runCtx)
+
+	// Wait for the queue to drain into held_events (not log_entries).
+	var proj storage.Project
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		n, _ := q.Len(ctx)
+		if p, err := store.ProjectBySlug(ctx, "pending-svc"); err == nil {
+			proj = p
+			held, _ := store.CountHeldByProject(ctx, proj.ID)
+			if n == 0 && held == 1 {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("consumer did not hold log: queue_len=%d", n)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+
+	// No log entries persisted while pending.
+	entries, _ := store.ListLogEntries(ctx, proj.ID, 0, "", 50, 0)
+	if len(entries) != 0 {
+		t.Errorf("got %d log entries while pending, want 0", len(entries))
+	}
+
+	// Approve → replay → log is ingested.
+	if err := store.ApproveProject(ctx, "pending-svc"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	replayer := NewReplayer(store, proc, logs, nil)
+	if _, err := replayer.ReplayHeld(ctx, proj.ID); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	entries, _ = store.ListLogEntries(ctx, proj.ID, 0, "", 50, 0)
+	if len(entries) != 1 {
+		t.Errorf("got %d log entries after approval, want 1", len(entries))
+	}
+}

--- a/internal/ingestproc/ingestproc_test.go
+++ b/internal/ingestproc/ingestproc_test.go
@@ -29,7 +29,9 @@ func newProcessor(t *testing.T) (*Processor, *storage.Store) {
 	}
 	t.Cleanup(func() { store.Close() })
 	pub := service.NewEventPublisher(&domainevents.Bus{})
-	return NewProcessor(store, pub, nil), store
+	// autoApprove=true: brand-new projects are created active so these tests
+	// exercise the persist path. The pending/hold path is covered in held_test.go.
+	return NewProcessor(store, pub, nil, true), store
 }
 
 func eventBody(t *testing.T) string {

--- a/internal/ingestproc/processor.go
+++ b/internal/ingestproc/processor.go
@@ -29,6 +29,9 @@ const (
 	OutcomeTransient
 	// OutcomePersistError: a non-retryable persist failure — dead-letter.
 	OutcomePersistError
+	// OutcomeHeld: the project is pending approval, so the raw payload was parked
+	// in held_events instead of persisted. It will be replayed on approval.
+	OutcomeHeld
 )
 
 // Result reports the outcome of PersistRecord.
@@ -48,14 +51,20 @@ type Processor struct {
 	store     *storage.Store
 	publisher *service.EventPublisher
 	logger    *slog.Logger
+	// autoApprove controls how a not-yet-existing project is created on first
+	// ingest: active (true) or pending admin approval (false). When pending, the
+	// payload is held instead of persisted.
+	autoApprove bool
 }
 
 // NewProcessor wires the pipeline against a writer store and event publisher.
-func NewProcessor(store *storage.Store, publisher *service.EventPublisher, logger *slog.Logger) *Processor {
+// When autoApprove is false, brand-new projects are created pending and their
+// ingest is held until approved.
+func NewProcessor(store *storage.Store, publisher *service.EventPublisher, logger *slog.Logger, autoApprove bool) *Processor {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Processor{store: store, publisher: publisher, logger: logger.With("component", "ingestproc")}
+	return &Processor{store: store, publisher: publisher, logger: logger.With("component", "ingestproc"), autoApprove: autoApprove}
 }
 
 // PersistRecord parses and persists a single ingest record. Mirrors the inline
@@ -70,10 +79,25 @@ func (p *Processor) PersistRecord(ctx context.Context, record spool.Record) Resu
 	// non-fatal: we fall through with no project context (default project).
 	persistCtx := ctx
 	if record.ProjectSlug != "" {
-		if proj, perr := p.store.EnsureProject(ctx, record.ProjectSlug); perr == nil {
+		if proj, ok := p.EnsureProjectForIngest(ctx, record.ProjectSlug); ok {
+			// Project pending admin approval: park the raw payload and stop. It
+			// replays through this same path once the project is approved.
+			if proj.Status == "pending" {
+				held := storage.HeldRecord{
+					ProjectID:   proj.ID,
+					Slug:        record.ProjectSlug,
+					Kind:        storage.HeldKindEvent,
+					IngestID:    record.IngestID,
+					ReceivedAt:  record.ReceivedAt,
+					ContentType: record.ContentType,
+					BodyBase64:  record.BodyBase64,
+				}
+				if herr := p.Hold(ctx, held); herr != nil {
+					return Result{Outcome: OutcomeTransient, Err: herr}
+				}
+				return Result{Outcome: OutcomeHeld, ProjectID: proj.ID}
+			}
 			persistCtx = storage.WithProjectID(ctx, proj.ID)
-		} else {
-			p.logger.Error("ensure project", "project_slug", record.ProjectSlug, "error", perr)
 		}
 	}
 
@@ -103,19 +127,38 @@ func (p *Processor) PersistRecord(ctx context.Context, record spool.Record) Resu
 	}
 }
 
-// ResolveProjectID ensures the project for slug exists and returns its ID, or 0
-// if slug is empty or the project cannot be resolved. Used by the log path,
-// which needs a project ID before parsing entries.
-func (p *Processor) ResolveProjectID(ctx context.Context, slug string) int64 {
+// EnsureProjectForIngest resolves (creating if needed) the project for slug,
+// returning the project and ok=false when slug is empty or the project cannot be
+// resolved. A brand-new project is created pending (or active when autoApprove is
+// set). Callers must check proj.Status == "pending" and hold the payload rather
+// than persist it.
+func (p *Processor) EnsureProjectForIngest(ctx context.Context, slug string) (storage.Project, bool) {
 	if slug == "" {
-		return 0
+		return storage.Project{}, false
 	}
-	proj, err := p.store.EnsureProject(ctx, slug)
+	var proj storage.Project
+	var err error
+	if p.autoApprove {
+		proj, err = p.store.EnsureProject(ctx, slug)
+	} else {
+		proj, err = p.store.EnsureProjectPending(ctx, slug)
+	}
 	if err != nil {
 		p.logger.Error("ensure project", "project_slug", slug, "error", err)
-		return 0
+		return storage.Project{}, false
 	}
-	return proj.ID
+	return proj, true
+}
+
+// Hold parks a raw ingest payload for a project pending admin approval. The
+// error is logged here (services are the log boundary) and returned so the
+// caller can retry.
+func (p *Processor) Hold(ctx context.Context, h storage.HeldRecord) error {
+	if err := p.store.HoldEvent(ctx, h); err != nil {
+		p.logger.Error("hold ingest for pending project", "project_id", h.ProjectID, "kind", h.Kind, "error", err)
+		return err
+	}
+	return nil
 }
 
 // isTransientPersistError mirrors cmd/bugbarn.isTransientPersistError: a locked

--- a/internal/ingestproc/replayer.go
+++ b/internal/ingestproc/replayer.go
@@ -1,0 +1,114 @@
+package ingestproc
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+
+	"github.com/wiebe-xyz/bugbarn/internal/logparse"
+	"github.com/wiebe-xyz/bugbarn/internal/spool"
+	"github.com/wiebe-xyz/bugbarn/internal/storage"
+)
+
+// replayBatchSize bounds how many held records are read per round so a large
+// backlog drains in steady chunks rather than one huge query.
+const replayBatchSize = 500
+
+// Replayer drains a project's held-events backlog through the normal persist
+// pipeline. It runs on the writer when a pending project is approved. Each
+// record is deleted only after it persists, so an interrupted drain is safe to
+// resume — replay is at-least-once and PersistProcessedEvent is idempotent on
+// fingerprint.
+type Replayer struct {
+	store  *storage.Store
+	proc   *Processor
+	logs   LogInserter
+	logger *slog.Logger
+}
+
+// NewReplayer wires a replayer against the writer store, persist pipeline, and
+// log inserter (logs may be nil; held log records are then skipped).
+func NewReplayer(store *storage.Store, proc *Processor, logs LogInserter, logger *slog.Logger) *Replayer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Replayer{store: store, proc: proc, logs: logs, logger: logger.With("component", "held-replayer")}
+}
+
+// ReplayHeld persists and clears every held record for a project, returning how
+// many were replayed. The project must already be active so records are not
+// re-held. It stops and returns the error on the first transient failure, having
+// already cleared the records it persisted, so a retry resumes from the rest.
+func (r *Replayer) ReplayHeld(ctx context.Context, projectID int64) (int, error) {
+	total := 0
+	for {
+		if ctx.Err() != nil {
+			return total, ctx.Err()
+		}
+		recs, err := r.store.ListHeldByProject(ctx, projectID, replayBatchSize)
+		if err != nil {
+			return total, fmt.Errorf("list held events: %w", err)
+		}
+		if len(recs) == 0 {
+			if total > 0 {
+				r.logger.Info("drained held events for approved project", "project_id", projectID, "replayed", total)
+			}
+			return total, nil
+		}
+		for _, rec := range recs {
+			if err := r.replayOne(ctx, rec); err != nil {
+				r.logger.Error("replay held record", "id", rec.ID, "project_id", projectID, "kind", rec.Kind, "error", err)
+				return total, err
+			}
+			if err := r.store.DeleteHeldEvent(ctx, rec.ID); err != nil {
+				return total, fmt.Errorf("delete held event: %w", err)
+			}
+			total++
+		}
+	}
+}
+
+// replayOne persists a single held record. A permanent failure (unparseable
+// payload) is logged and dropped so it never blocks the drain; a transient
+// failure is returned so the caller keeps the record for a later retry.
+func (r *Replayer) replayOne(ctx context.Context, rec storage.HeldRecord) error {
+	switch rec.Kind {
+	case storage.HeldKindEvent:
+		record := spool.Record{
+			IngestID:    rec.IngestID,
+			ReceivedAt:  rec.ReceivedAt,
+			ContentType: rec.ContentType,
+			BodyBase64:  rec.BodyBase64,
+			ProjectSlug: rec.Slug,
+		}
+		res := r.proc.PersistRecord(ctx, record)
+		switch res.Outcome {
+		case OutcomeSuccess, OutcomeHeld:
+			return nil
+		case OutcomeParseError:
+			r.logger.Error("drop unparseable held event", "id", rec.ID, "error", res.Err)
+			return nil
+		default:
+			return res.Err
+		}
+	case storage.HeldKindLog:
+		if r.logs == nil {
+			r.logger.Warn("skipping held log: no log inserter", "id", rec.ID)
+			return nil
+		}
+		body, err := base64.StdEncoding.DecodeString(rec.BodyBase64)
+		if err != nil {
+			r.logger.Error("drop undecodable held log", "id", rec.ID, "error", err)
+			return nil
+		}
+		entries := logparse.ParseBody(body, rec.ContentType, rec.ProjectID)
+		if len(entries) == 0 {
+			return nil
+		}
+		return r.logs.Insert(ctx, entries)
+	default:
+		r.logger.Warn("dropping held record of unknown kind", "id", rec.ID, "kind", rec.Kind)
+		return nil
+	}
+}

--- a/internal/service/projects/service.go
+++ b/internal/service/projects/service.go
@@ -56,9 +56,17 @@ type Repository interface {
 	UpdateSettings(context.Context, map[string]string) error
 }
 
+// HeldReplayer drains the held-events backlog accumulated while a project was
+// pending, persisting it through the normal ingest pipeline. It is satisfied by
+// *ingestproc.Replayer and wired only on the writer.
+type HeldReplayer interface {
+	ReplayHeld(ctx context.Context, projectID int64) (int, error)
+}
+
 type Service struct {
-	repo   Repository
-	logger *slog.Logger
+	repo     Repository
+	logger   *slog.Logger
+	replayer HeldReplayer
 }
 
 func New(repo Repository, logger *slog.Logger) *Service {
@@ -66,6 +74,13 @@ func New(repo Repository, logger *slog.Logger) *Service {
 		logger = slog.Default()
 	}
 	return &Service{repo: repo, logger: logger.With("service", "projects")}
+}
+
+// SetHeldReplayer wires the held-events replayer used to drain a project's
+// backlog on approval. Called on the writer; left nil on readers (which forward
+// approvals to the writer).
+func (s *Service) SetHeldReplayer(r HeldReplayer) {
+	s.replayer = r
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Project, error) {
@@ -143,6 +158,26 @@ func (s *Service) Approve(ctx context.Context, slug string) error {
 		return err
 	}
 	s.logger.InfoContext(ctx, "project approved", "slug", slug)
+
+	// Drain any ingest that arrived while the project was pending. The status is
+	// now active, so replayed records persist instead of being re-held. A drain
+	// failure is logged but does not fail the approval — the backlog remains and
+	// is retried on the next approval call.
+	if s.replayer != nil {
+		proj, err := s.repo.ProjectBySlug(ctx, slug)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "approve: lookup project for replay", "slug", slug, "error", err)
+			return nil
+		}
+		n, err := s.replayer.ReplayHeld(ctx, proj.ID)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "approve: replay held events", "slug", slug, "replayed", n, "error", err)
+			return nil
+		}
+		if n > 0 {
+			s.logger.InfoContext(ctx, "replayed held events on approval", "slug", slug, "count", n)
+		}
+	}
 	return nil
 }
 

--- a/internal/service/projects/service_test.go
+++ b/internal/service/projects/service_test.go
@@ -216,3 +216,56 @@ func TestApprove_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+type fakeReplayer struct {
+	gotProjectID int64
+	calls        int
+	err          error
+}
+
+func (f *fakeReplayer) ReplayHeld(_ context.Context, projectID int64) (int, error) {
+	f.calls++
+	f.gotProjectID = projectID
+	return 0, f.err
+}
+
+func TestApprove_DrainsHeldBacklog(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{projects: map[string]domain.Project{
+		"svc": {ID: 42, Slug: "svc", Status: "pending"},
+	}}
+	rep := &fakeReplayer{}
+	svc := New(repo, nil)
+	svc.SetHeldReplayer(rep)
+
+	if err := svc.Approve(context.Background(), "svc"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if rep.calls != 1 {
+		t.Fatalf("replayer calls = %d, want 1", rep.calls)
+	}
+	if rep.gotProjectID != 42 {
+		t.Errorf("replayed project id = %d, want 42", rep.gotProjectID)
+	}
+}
+
+func TestApprove_ReplayFailureDoesNotFailApproval(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeRepo{projects: map[string]domain.Project{
+		"svc": {ID: 7, Slug: "svc", Status: "pending"},
+	}}
+	rep := &fakeReplayer{err: errors.New("boom")}
+	svc := New(repo, nil)
+	svc.SetHeldReplayer(rep)
+
+	// Approval succeeds even though the drain fails; the backlog is retried on a
+	// later approval call.
+	if err := svc.Approve(context.Background(), "svc"); err != nil {
+		t.Fatalf("approve should not fail on replay error, got %v", err)
+	}
+	if rep.calls != 1 {
+		t.Errorf("replayer calls = %d, want 1", rep.calls)
+	}
+}

--- a/internal/storage/held_events.go
+++ b/internal/storage/held_events.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Held-event kinds mirror the queue item kinds; kept as storage constants so the
+// persist pipeline does not need to import the queue package.
+const (
+	HeldKindEvent = "event"
+	HeldKindLog   = "log"
+)
+
+// HeldRecord is a raw ingest payload parked for a project that is pending admin
+// approval. BodyBase64 is the exact payload received, so replay after approval
+// is identical to live ingest.
+type HeldRecord struct {
+	ID          int64
+	ProjectID   int64
+	Slug        string
+	Kind        string
+	IngestID    string
+	ReceivedAt  time.Time
+	ContentType string
+	BodyBase64  string
+	CreatedAt   time.Time
+}
+
+// HoldEvent parks a raw ingest payload for a pending project. It is a write and
+// fails on a read-only store (readers never hold — they forward to the writer).
+func (s *Store) HoldEvent(ctx context.Context, h HeldRecord) error {
+	if s == nil || s.db == nil {
+		return errors.New("storage is read-only")
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO held_events (project_id, slug, kind, ingest_id, received_at, content_type, body_base64, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		h.ProjectID, h.Slug, h.Kind, h.IngestID,
+		formatTime(h.ReceivedAt), h.ContentType, h.BodyBase64, formatTime(time.Now().UTC()),
+	)
+	if err != nil {
+		return wrapErr(err, "hold event")
+	}
+	return nil
+}
+
+// ListHeldByProject returns up to limit held records for a project, oldest
+// first, so the backlog replays in arrival order.
+func (s *Store) ListHeldByProject(ctx context.Context, projectID int64, limit int) ([]HeldRecord, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.readDB().QueryContext(ctx, `
+SELECT id, project_id, slug, kind, ingest_id, received_at, content_type, body_base64, created_at
+FROM held_events WHERE project_id = ? ORDER BY id ASC LIMIT ?`, projectID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var held []HeldRecord
+	for rows.Next() {
+		var h HeldRecord
+		var receivedAt, createdAt string
+		if err := rows.Scan(&h.ID, &h.ProjectID, &h.Slug, &h.Kind, &h.IngestID, &receivedAt, &h.ContentType, &h.BodyBase64, &createdAt); err != nil {
+			return nil, err
+		}
+		h.ReceivedAt, _ = parseTime(receivedAt)
+		h.CreatedAt, _ = parseTime(createdAt)
+		held = append(held, h)
+	}
+	return held, rows.Err()
+}
+
+// DeleteHeldEvent removes a single held record once it has been replayed.
+func (s *Store) DeleteHeldEvent(ctx context.Context, id int64) error {
+	if s == nil || s.db == nil {
+		return errors.New("storage is read-only")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM held_events WHERE id = ?`, id)
+	return err
+}
+
+// CountHeldByProject returns how many records are currently held for a project.
+func (s *Store) CountHeldByProject(ctx context.Context, projectID int64) (int, error) {
+	var n int
+	err := s.readDB().QueryRowContext(ctx, `SELECT COUNT(*) FROM held_events WHERE project_id = ?`, projectID).Scan(&n)
+	return n, err
+}

--- a/internal/storage/held_events_test.go
+++ b/internal/storage/held_events_test.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHeldEventsCRUD(t *testing.T) {
+	t.Parallel()
+	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	ctx := context.Background()
+
+	proj, err := store.CreateProjectPending(ctx, "svc")
+	if err != nil {
+		t.Fatalf("create pending: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := store.HoldEvent(ctx, HeldRecord{
+			ProjectID:   proj.ID,
+			Slug:        "svc",
+			Kind:        HeldKindEvent,
+			IngestID:    "ing",
+			ReceivedAt:  time.Now().UTC(),
+			ContentType: "application/json",
+			BodyBase64:  "eyJ4IjoxfQ==",
+		}); err != nil {
+			t.Fatalf("hold %d: %v", i, err)
+		}
+	}
+
+	n, err := store.CountHeldByProject(ctx, proj.ID)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("count = %d, want 3", n)
+	}
+
+	held, err := store.ListHeldByProject(ctx, proj.ID, 2)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(held) != 2 {
+		t.Fatalf("list returned %d, want 2 (limit honored)", len(held))
+	}
+	// Oldest first.
+	if held[0].ID > held[1].ID {
+		t.Errorf("not ordered oldest-first: %d then %d", held[0].ID, held[1].ID)
+	}
+	if held[0].Kind != HeldKindEvent || held[0].BodyBase64 != "eyJ4IjoxfQ==" {
+		t.Errorf("unexpected held record: %+v", held[0])
+	}
+
+	if err := store.DeleteHeldEvent(ctx, held[0].ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	n, _ = store.CountHeldByProject(ctx, proj.ID)
+	if n != 2 {
+		t.Errorf("count after delete = %d, want 2", n)
+	}
+}
+
+func TestHoldEventFailsOnReadOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "bugbarn.db")
+	// Create and migrate the DB first.
+	rw, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open rw: %v", err)
+	}
+	rw.Close()
+
+	ro, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open ro: %v", err)
+	}
+	t.Cleanup(func() { ro.Close() })
+
+	err = ro.HoldEvent(context.Background(), HeldRecord{ProjectID: 1, Slug: "x", Kind: HeldKindEvent, ReceivedAt: time.Now().UTC(), BodyBase64: "e30="})
+	if err == nil {
+		t.Fatal("expected HoldEvent to fail on read-only store")
+	}
+}

--- a/internal/storage/migrations/00006_held_events.sql
+++ b/internal/storage/migrations/00006_held_events.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Events and logs ingested for a project that is still pending admin approval are
+-- parked here instead of being persisted as issues. On approval the project's
+-- backlog is drained through the normal persist pipeline and these rows deleted.
+-- body_base64 holds the raw ingest payload so replay is byte-for-byte identical
+-- to live ingest.
+CREATE TABLE IF NOT EXISTS held_events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id   INTEGER NOT NULL,
+  slug         TEXT    NOT NULL,
+  kind         TEXT    NOT NULL,
+  ingest_id    TEXT    NOT NULL DEFAULT '',
+  received_at  TEXT    NOT NULL,
+  content_type TEXT    NOT NULL DEFAULT '',
+  body_base64  TEXT    NOT NULL,
+  created_at   TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_held_events_project ON held_events(project_id, id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_held_events_project;
+DROP TABLE IF EXISTS held_events;


### PR DESCRIPTION
## Problem

Setup keys always returned **401** in production, so calling `/api/v1/setup/{slug}` never produced a project. Public ingest is served only by the **read-only reader** pods, but the setup-key verifier ran inline during auth and tried to create the project (`EnsureProjectPending` → INSERT), which fails on the `mode=ro` store → key rejected → no project ever created. The write error was also swallowed, so it never surfaced in our own dashboard.

## Fix — match the CQRS flow

- **Reader validates, never writes**: the setup-key verifier is now HMAC-only (no DB access), safe on read-only readers. The event forwards to the queue.
- **Writer creates the client on consume**: `ingestproc.Processor.EnsureProjectForIngest` creates the project **pending** (or active when `BUGBARN_AUTO_APPROVE_PROJECTS=true`).
- **Hold while pending, replay on approval**: events and logs for a pending project are parked in a new `held_events` table (raw payload) instead of being persisted. On admin approval, `projects.Service.Approve` flips status and drains the backlog through the normal persist pipeline via `ingestproc.Replayer`, then clears it. Nothing sent during the pending window is lost.
- Setup page copy clarifies pending-on-first-event + approval gate.

## Scope notes

- Events **and** logs are held; releases create the pending project but persist normally.
- The legacy non-redis inline worker path is left as create-active (prod uses the redis/ingestproc path, which is fully covered).
- No k8s changes: `BUGBARN_AUTO_APPROVE_PROJECTS` is unset (→ pending) and `SESSION_SECRET` is present.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` (26 packages, 0 failures), `make spec-check` all green. New tests: hold-on-pending, replay-on-approval (events + logs), `held_events` CRUD, read-only Hold failure, approve-drains-backlog wiring.