### PR TITLE
ci: shared cross-machine Go build cache via BuildKit + GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,32 +32,46 @@ jobs:
           . .ci-venv/bin/activate
           make spec-check
 
-  # One leg per Go module so the app and the SDK build/vet/test concurrently on
-  # separate runners. fail-fast cancels the siblings the moment one leg fails.
+  # Go build/vet/test runs inside BuildKit so the compile cache is shared across
+  # both build machines via a registry (GHCR) cache. The `deps` stage pre-compiles
+  # the heavy dependency closure (modernc/sqlite -> libc) into a go.sum-keyed
+  # layer; mode=max exports it, so whichever runner picks up the job starts warm
+  # instead of recompiling SQLite cold (~10 min before). Native arm64 — no QEMU.
   go:
-    strategy:
-      fail-fast: true
-      matrix:
-        module:
-          - "."
-          - "sdks/go"
     runs-on: [self-hosted, build]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      HOME: /Users/wiebe
+      PATH: /Users/wiebe/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.x'
-          cache: false
-      - name: Go build, vet, test (${{ matrix.module }})
-        working-directory: ${{ matrix.module }}
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: GHCR auth
         shell: bash
         run: |
           set -euo pipefail
-          # build first so a compile error fails fast before the longer test run.
-          go build ./...
-          go vet ./...
-          go test ./...
+          DOCKER_CONFIG_DIR="${RUNNER_TEMP}/docker-config-${GITHUB_RUN_ID}"
+          mkdir -p "$DOCKER_CONFIG_DIR"
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' \
+            "$(printf '%s:%s' '${{ github.actor }}' '${{ secrets.GITHUB_TOKEN }}' | base64)" \
+            > "$DOCKER_CONFIG_DIR/config.json"
+          echo "DOCKER_CONFIG=$DOCKER_CONFIG_DIR" >> "$GITHUB_ENV"
+      - name: Go build, vet, test (registry-cached via BuildKit)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CACHE_REF="ghcr.io/webwiebe/bugbarn/buildcache"
+          docker buildx build \
+            --platform linux/arm64 \
+            --target test \
+            -f deploy/docker/service.Dockerfile \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            --cache-to "type=registry,ref=${CACHE_REF},mode=max" \
+            --output type=cacheonly \
+            .
 
   # One leg per Node package (dashboard, marketing site, TS SDK) so they install
   # and build in parallel instead of serially.

--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.26-alpine AS build
 
 WORKDIR /src
@@ -9,6 +10,37 @@ COPY internal ./internal
 COPY sdks/go ./sdks/go
 
 RUN go build -o /out/bugbarn ./cmd/bugbarn
+
+# --- CI-only stages (not part of the deploy image; the final runtime stage
+# below depends only on `build`, so a plain `docker build` skips these). ---
+#
+# deps: download modules and pre-compile the heavy third-party dependency
+# closure into the Go build cache. modernc.org/sqlite (-> modernc/libc, a
+# transpiled-from-C SQLite) dominates compile time. This work lands in a layer
+# keyed only on go.{mod,sum}, so `--cache-to/--cache-from type=registry` shares
+# it across every build runner via GHCR — whichever machine picks up the job
+# starts from a warm cache instead of recompiling SQLite from scratch.
+FROM golang:1.26-alpine AS deps
+WORKDIR /src
+COPY go.mod go.sum ./
+COPY sdks/go/go.mod sdks/go/go.sum ./sdks/go/
+RUN go mod download
+RUN go build std && \
+    go build \
+      modernc.org/sqlite \
+      github.com/XSAM/otelsql \
+      go.opentelemetry.io/otel/sdk/trace \
+      go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp \
+      github.com/redis/go-redis/v9 \
+      github.com/pressly/goose/v3
+
+# test: vet + test + build for both modules on top of the warm deps cache, so a
+# source change only recompiles app packages. The RUN fails the build on any
+# test/vet/build failure, which fails CI.
+FROM deps AS test
+COPY . .
+RUN go vet ./... && go test ./... && go build ./... && \
+    (cd sdks/go && go vet ./... && go test ./... && go build ./...)
 
 FROM alpine:3.20 AS litestream
 ARG LITESTREAM_VERSION=0.3.13


### PR DESCRIPTION
## Why

The `go` CI job took ~10 min. Measured breakdown showed it's **not** the tests — the whole suite runs in **~8s** (`internal/storage` real-SQLite tests are the heaviest at ~4s; there's no e2e monster). The cost is **cold compilation**: `modernc.org/sqlite` → `modernc/libc` (transpiled-from-C SQLite, ~1.5M LOC of generated Go) recompiled from scratch every run, because the per-machine Go build cache is a coin flip across the two build hosts (laptop + mac-mini).

CI step timing confirmed it: `go build+vet+test` = **520s**, 0 module downloads, setup-go on `cache: false`.

## What

Run Go checks inside **BuildKit** so the compile cache is **shared across both machines via a GHCR registry cache**:

- `deploy/docker/service.Dockerfile` gains:
  - a **`deps`** stage — `go mod download` + pre-compile the heavy dependency closure into a layer **keyed only on `go.{mod,sum}`** (so it's reused until deps change), and
  - a **`test`** stage — `vet`/`test`/`build` for both the root module and `sdks/go` on top of the warm cache.
  - These sit **before** the runtime stage, so a plain deploy `docker build` (no `--target`) skips them — **deploy image build is unchanged**.
- The CI `go` job runs `docker buildx build --target test` with `--cache-to/--cache-from type=registry,ref=ghcr.io/webwiebe/bugbarn/buildcache,mode=max`, native `linux/arm64` (no QEMU), `--output type=cacheonly`. Whichever runner grabs the job **restores the warm `deps` layer from GHCR** instead of recompiling SQLite cold.

Replaces the native per-module matrix (`.` + `sdks/go` now both run in the container).

## Effect

- First run on either machine: cold, then pushes the cache to GHCR.
- Subsequent runs on **either** machine: pull the warm deps layer → only app packages recompile (seconds) + ~8–15s tests. Expected `go` job: **~10 min → well under a minute** on warm runs.
- Generic: the same pattern drops into any of the other Go repos on these runners.

## Validation

`docker buildx build --target test --output type=cacheonly .` locally: builds and the **full suite (both modules) passes in-container** (~54s cold on arm64, no QEMU).

Note: this PR runs under the new `go` job, so its own `go` check exercises the BuildKit path (first run primes the GHCR cache).