### PR TITLE
ci: persistent buildx builder + de-flake fingerprint-migration race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # Persist a named builder across runs so the buildkit container is
+          # created once per machine and reused. Avoids the ~1-3 min per-run cost
+          # of creating a fresh docker-container builder (image pull + bootstrap),
+          # which otherwise dwarfs the ~12s cached build.
+          name: bugbarn-ci
+          cleanup: false
       - name: GHCR auth
         shell: bash
         run: |

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -100,6 +100,14 @@ func OpenReadOnly(path string) (*Store, error) {
 }
 
 func Open(path string) (*Store, error) {
+	return open(path, true)
+}
+
+// open is Open with control over the one-time background fingerprint migration.
+// Tests that set explicit fingerprints pass autoMigrate=false: the migration
+// recomputes fingerprints from event material, which would otherwise race the
+// test and clobber the explicit values it just wrote.
+func open(path string, autoMigrate bool) (*Store, error) {
 	if strings.TrimSpace(path) == "" {
 		path = defaultDBPath
 	}
@@ -133,11 +141,13 @@ func Open(path string) (*Store, error) {
 		db.Close()
 		return nil, err
 	}
-	go func() {
-		if err := store.migrateFingerprints(context.Background()); err != nil {
-			slog.Error("fingerprint migration failed", "err", err)
-		}
-	}()
+	if autoMigrate {
+		go func() {
+			if err := store.migrateFingerprints(context.Background()); err != nil {
+				slog.Error("fingerprint migration failed", "err", err)
+			}
+		}()
+	}
 	return store, nil
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -280,7 +280,10 @@ func TestConcurrentReads(t *testing.T) {
 func TestRegressedFirstOrdering(t *testing.T) {
 	t.Parallel()
 
-	store, err := Open(filepath.Join(t.TempDir(), "bugbarn.db"))
+	// open without the background fingerprint migration: this test writes
+	// explicit fingerprints, which the migration would recompute and clobber,
+	// racing the test (flaky, surfaced under slower CI).
+	store, err := open(filepath.Join(t.TempDir(), "bugbarn.db"), false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Two CI-reliability changes (on top of the #138 BuildKit cache):

## 1. Persistent buildx builder
With the GHCR registry cache, the Go `build/vet/test` step is ~12s warm — but creating a fresh `docker-container` buildx builder each run (buildkit image pull + bootstrap) measured 56–166s and dominated the job. Pin a named builder (`bugbarn-ci`, `cleanup: false`) so it's created once per machine and reused. First run per machine still pays the one-time creation; every run after is ~seconds. Target warm `go` job: **under ~40s** (vs original ~10 min).

## 2. De-flake `TestRegressedFirstOrdering`
The slower container CI surfaced a pre-existing race: `storage.Open()` runs `migrateFingerprints` in a background goroutine that recomputes issue fingerprints from event material. This test writes *explicit* fingerprints; when the migration's one-shot scan lands after those inserts it rewrites them, so the second event no longer matches the muted issue → no regression → intermittent `expected regression` failure.

Fix: internal `open(path, autoMigrate)` (`Open == open(path, true)`); the test opens with `autoMigrate=false`. **Production unchanged** — the migration is a no-op there anyway (computed == stored fingerprint). Verified 30× with `-count`.