### PR TITLE
fix(config): rotate BUGBARN_FUNNELBARN_API_KEY to project-scoped key

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -18,7 +18,7 @@ stringData:
     OTEL_EXPORTER_OTLP_ENDPOINT: ENC[AES256_GCM,data:7AiC+6CQZtRa+krwGOeFOIV8O2BRXy85msM=,iv:3ddSQcch6+lhm75thHDLGvFUtmWbWtAQD8eKUdjrMik=,tag:r7H+fkm/DQ1m8ev83311WQ==,type:str]
     OTEL_EXPORTER_OTLP_HEADERS: ENC[AES256_GCM,data:/HX158d4N/g2SFWWGEyTdxyXK7XkXXXUJXiGQw582GoFyZ6DUlRldtwd3WsXgk3pIU6Uk23JDtz2xYqdyw==,iv:XjM10iqBUSR6gFbSJNIB5bdhV03bhZnWIYwf46edI1Y=,tag:d/wQFPAgNzluLnHKR2tA3g==,type:str]
     BUGBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:KFPRpOEKvBG9m1K+8Cc4SqRwLPdFy6wWSS6eZQ==,iv:78fS12priD0bWT5Smho4m+rPxXA2dBBqj6t2pL9dO/4=,tag:IfpHC8E1BVrwV+6Uv28mFA==,type:str]
-    BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:XH03DWjjOUH15zBQHlfgK4k+AoCEcFTiRVeYVXI+wctXSG9mo9rZ0g==,iv:Rx5qNUssUNR0EjLNpzQSutBG1oKGorth2zkYAfuL0vY=,tag:zi4jgHfUa7uh4BYjRgIIpQ==,type:str]
+    BUGBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:MayN7efFycRP8lSIC3aw5CPy/vs8iXbgbKN8fqEEFK3ThnRj4QBqHQ==,iv:4pIMIqucI+sysaXaKpziSbxXu/6AnXfsMcvD9kshHBo=,tag:Bxd52wiTkD0Bttq3SRTPKQ==,type:str]
     BUGBARN_OIDC_ISSUER: ENC[AES256_GCM,data:PjSDy2L8Ne71CvTqVfKGALGKX8uC,iv:JR5sZjaoxFrNQ4j/5oC27kwRQ/JA2UK0vAWqy9+9o9g=,tag:Jg8MJbzcx1CQ+z4f9JPygw==,type:str]
     BUGBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:VQz5xK6Biokr/oWZg2F6axka,iv:icolDkK79V78NPWCttNfl6X4jujJM3T81jFvpsxXXBU=,tag:+rTJojKSMK1OMztI3KgoRw==,type:str]
     BUGBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:Z/uKDYBO+sUuxNt+A5Smez4BiKUG2vXJiZaIoxMpiEW5xKQjHJfwAsRi5Q==,iv:BWvZEu0uO0H68r3/ilpQKS0HmQPCAnlG8s9STdPPYOo=,tag:9Rjp2nXdcHyx8ycINT22sQ==,type:str]
@@ -38,8 +38,8 @@ sops:
             RDNNVkNKT1hQS0pteUtKOXg4ZmNwNG8KCXUZkh8kV76oS2ZdIWDbVLv1qeKUN7q5
             YTsyCudfbr/ryBV4aU2u3xLOeObBRxds1DmgWU4ZQPj8sAwN7Nbx8g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T10:46:58Z"
-    mac: ENC[AES256_GCM,data:BXgalwjO4WIf4IOSwtdPuMDiG6bWzE3De+T+nYm/RSRyL4uu4MTw+xPpK3G0QUmevOJVmJB6hy8r4pMQWXVFJ5jTIV+rxVohIa/t0Qk89EoUL7gOqEaIYu8Wsmb6OdCylHGupD4BhagBX7eXyW0AjcyoJ3Gnji7HqiPapRTp0Ig=,iv:WB1m84/5m0RyxI+CW40R8ap7h4Tb9Zzzsj9GV5XXgT0=,tag:0gdQxLawzS0wiDidyF6i0A==,type:str]
+    lastmodified: "2026-06-23T17:11:18Z"
+    mac: ENC[AES256_GCM,data:xxyXrGC8z64pCjAkE7CIhNYkkNR3iVDThDiO9aUB6G8dsNAZyyOSGdjLR0H34HK3DLTa3pZYG7qssL8I7R/FXmo5pQBanWeat+PlezvpznFlUSHUTQoq9mZ5eN14YF1co3f4hm/wp/yxwMjrvq26eFKckbVFJBEb5ToXOyjEpwc=,iv:74A/ySnZAJ3ItNNrwJsugY7kc47BNXeT1DwLBeui/qs=,tag:WpNS6N6cFovg4y45As8tBA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Problem

Session recording chunks from bugbarn.wiebe.xyz were returning `404` when posted to `funnelbarn.wiebe.xyz/api/v1/recordings/chunk`.

Root cause: `BUGBARN_FUNNELBARN_API_KEY` was set to a key whose associated funnelbarn project was deleted. The key still existed in funnelbarn's `api_keys` table but `GetProject` returned "not found" → 404.

## Fix

- Created a new `ingest`-scoped API key in funnelbarn production for the **BugBarn** project (slug: `bugbarn-site`, id: `c33ee0ae-23ab-4f3e-9559-7338c253094c`)
- Verified end-to-end: `POST /api/v1/recordings/chunk` with the new key → `202 Accepted`
- Rotated `BUGBARN_FUNNELBARN_API_KEY` in the SOPS-encrypted production secret

## Deploy

After merging, apply the updated secret and restart the deployment:

```bash
ssh deployer@layer7.wiebe.xyz
kubectl apply -f deploy/k8s/production/secret.yaml -n bugbarn-production
kubectl rollout restart deployment/bugbarn -n bugbarn-production
```

## Related

- funnelbarn PR #188 improves the error response (was 404 "not found", now 401 with a clear message) so future misconfiguration is immediately diagnosable