### PR TITLE
ci: fix runner workspace poisoning from quality job's Go cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,14 @@ jobs:
       HOME: /Users/wiebe
       PATH: /Users/wiebe/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
 
       - name: Set up Docker buildx
@@ -67,6 +75,14 @@ jobs:
       HOME: /Users/wiebe
       PATH: /Users/wiebe/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
 
       - name: Transfer manifests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
   spec:
     runs-on: [self-hosted, build]
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
       - name: Install spec tooling
         shell: bash
@@ -46,6 +54,14 @@ jobs:
       HOME: /Users/wiebe
       PATH: /Users/wiebe/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v4
@@ -92,6 +108,14 @@ jobs:
           - "sdks/typescript"
     runs-on: [self-hosted, build]
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -119,6 +143,14 @@ jobs:
   python:
     runs-on: [self-hosted, build]
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
       - name: Python checks (sdks/python)
         working-directory: sdks/python
@@ -145,6 +177,14 @@ jobs:
   php:
     runs-on: [self-hosted, build]
     steps:
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
       - name: PHP checks (sdks/php)
         working-directory: sdks/php
@@ -169,10 +209,19 @@ jobs:
     env:
       HOME: /Users/wiebe
       PATH: /Users/wiebe/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-      GOCACHE: ${{ github.workspace }}/.cache/go-build
-      GOMODCACHE: ${{ github.workspace }}/.cache/go-mod
-      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
+      # Go writes its module cache read-only; if a prior run left one inside a
+      # workspace, the next checkout cannot clean it (EACCES on unlink). Clear
+      # any such leftover across this machine's runner instances before checkout.
+      # Go caches now live under $HOME (default), so this is a no-op going forward.
+      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
+        shell: bash
+        run: |
+          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
+            [ -d "$c" ] || continue
+            chmod -R u+w "$c" 2>/dev/null || true
+            rm -rf "$c" 2>/dev/null || true
+          done
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0          # diff-mode lint needs the merge base


### PR DESCRIPTION
## Problem

The Phase A `quality` job (PR #141) set `GOMODCACHE`/`GOCACHE` to `${{ github.workspace }}/.cache`. Go writes its module cache as **read-only** files, so the next job to land on that runner could not clean the work tree during `actions/checkout` — failing with `EACCES: permission denied, unlink`. This broke the **testing deploy** on the merge of #141 (build succeeded, deploy failed at checkout).

## Fix

- **Stop polluting**: the `quality` job no longer redirects Go caches into the workspace. Go uses its defaults under `$HOME` (outside the work tree), so no read-only files ever land where checkout must clean.
- **Reclaim**: a pre-checkout step on every self-hosted job (`ci.yml`) and on the `build`/`deploy` jobs (`build-and-test.yml`) makes any leftover workspace `.cache` writable and removes it, across the machine's runner instances. Idempotent, a no-op going forward, and recovers runners already poisoned by #141's first run.

## Verification

- Both workflow files validate as YAML.
- Coverage still works: `check-coverage.sh` writes only `coverage/` (gitignored), and Go's module cache now resolves to `$HOME/go/pkg/mod`.
- This PR's own CI run exercises the reclaim guard on the poisoned runners; the subsequent merge re-runs the testing deploy with the fix in place.