### PR TITLE
ci(quality): ratchet gate thresholds tighter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,19 +29,19 @@ linters:
     - dupl         # Go duplication (jscpd owns the other languages)
   settings:
     gocyclo:
-      min-complexity: 15
+      min-complexity: 12
     gocognit:
-      min-complexity: 20
+      min-complexity: 18
     funlen:
-      lines: 80
-      statements: 50
+      lines: 60
+      statements: 40
     lll:
-      # 140 fits this codebase's inline SQL and OTel-style signatures while
-      # still catching runaway lines; tighten toward 120 as files are reworked.
-      line-length: 140
+      # 135 still accommodates inline SQL and OTel-style signatures while
+      # catching runaway lines.
+      line-length: 135
       tab-width: 1
     dupl:
-      threshold: 150
+      threshold: 120
     misspell:
       locale: US
     errcheck:

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 1.0,
+  "threshold": 0.8,
   "reporters": ["consoleFull"],
   "absolute": true,
   "format": ["typescript", "javascript", "python", "php"],

--- a/web/.jscpd.json
+++ b/web/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 1.0,
+  "threshold": 0.8,
   "reporters": ["consoleFull"],
   "absolute": true,
   "format": ["typescript"],


### PR DESCRIPTION
Now that the de-monolithization debt is paid, tighten the gates. All gates run in **diff-mode**, so the tighter limits only apply to new/changed code — existing borderline code is cleaned as it's touched, nothing breaks retroactively.

| Linter | Before | After |
|---|---|---|
| gocyclo | 15 | **12** |
| gocognit | 20 | **18** |
| funlen | 80 lines / 50 stmts | **60 / 40** |
| lll | 140 | **135** |
| dupl | 150 | **120** |
| jscpd (web + root) | 1.0% | **0.8%** |

Verification: `golangci-lint config verify` OK; diff-mode vs `origin/main` is **0 issues** (config-only change); jscpd passes at 0.8% (web 0.55%, root 0.40%). Latent full-repo debt at the new bar is ~80 issues, surfaced only when those lines are next edited.

Follow-up PR will refactor the legacy-complex functions (the `//nolint … tracked for refactor` ones) against this tighter bar.