### PR TITLE
refactor: simplify legacy-complex functions; drop the nolints

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -62,8 +62,7 @@ func sameOrigin(origin, host string) bool {
 // scoping because the row ID is globally unique across all projects.
 func isIssueAction(r *http.Request) bool {
 	p := r.URL.Path
-	return strings.HasPrefix(p, "/api/v1/issues/") && (
-		strings.HasSuffix(p, "/resolve") ||
+	return strings.HasPrefix(p, "/api/v1/issues/") && (strings.HasSuffix(p, "/resolve") ||
 		strings.HasSuffix(p, "/reopen") ||
 		strings.HasSuffix(p, "/mute") ||
 		strings.HasSuffix(p, "/unmute"))

--- a/internal/api/pipeline.go
+++ b/internal/api/pipeline.go
@@ -14,14 +14,11 @@ import (
 // its context. It returns the (possibly context-augmented) request and true to
 // proceed, or false after writing an error response. When user auth is not
 // configured it is a pass-through.
-//
-//nolint:gocognit,gocyclo,funlen // auth + key-scope + CSRF + project/group resolution pipeline; tracked for refactor.
 func (s *Server) authenticateAndResolve(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
 	// All remaining endpoints require authentication. When auth is configured, the
 	// request must carry either a valid session cookie or a valid API key. Full-scope
 	// API keys are accepted on all protected endpoints; ingest-only keys are rejected here
 	// (they may only reach the ingest endpoint handled above).
-	var resolvedProjectID int64
 	if s.users == nil || !s.users.Enabled() {
 		return r, true
 	}
@@ -32,28 +29,8 @@ func (s *Server) authenticateAndResolve(w http.ResponseWriter, r *http.Request) 
 	if s.ingestHandler != nil {
 		pid, scope, ok := s.ingestHandler.APIKeyProjectScope(r)
 		if ok {
-			if scope == domain.APIKeyScopeIngest {
-				// Allow ingest keys to post release markers — the setup page uses
-				// the same key for both events and releases — but reject every
-				// other endpoint.
-				isReleaseMarker := r.URL.Path == "/api/v1/releases" && r.Method == http.MethodPost
-				if !isReleaseMarker {
-					s.logger.Warn("auth: ingest-only key rejected", "method", r.Method, "path", r.URL.Path)
-					http.Error(w, "forbidden: ingest-only key cannot access this endpoint", http.StatusForbidden)
-					return r, false
-				}
-			}
-			if scope == domain.APIKeyScopeRead {
-				if r.Method != http.MethodGet {
-					s.logger.Warn("auth: read-only key rejected non-GET", "method", r.Method, "path", r.URL.Path)
-					http.Error(w, "forbidden: read-only key cannot modify data", http.StatusForbidden)
-					return r, false
-				}
-				if strings.HasPrefix(r.URL.Path, "/api/v1/settings") || strings.HasPrefix(r.URL.Path, "/api/v1/apikeys") {
-					s.logger.Warn("auth: read-only key rejected settings/apikeys", "method", r.Method, "path", r.URL.Path)
-					http.Error(w, "forbidden: read-only key cannot access this endpoint", http.StatusForbidden)
-					return r, false
-				}
+			if !s.checkAPIKeyScope(w, r, scope) {
+				return r, false
 			}
 			usingAPIKey = true
 			apiKeyProjectID = pid
@@ -76,9 +53,47 @@ func (s *Server) authenticateAndResolve(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Refresh the CSRF cookie on every session-authenticated response when
-	// the browser's copy is missing or stale, so the frontend always has a
-	// valid token available for state-changing requests.
+	s.refreshCSRFCookie(w, r, usingSession)
+
+	r = s.resolveProjectScope(r, usingSession, usingAPIKey, apiKeyProjectID)
+
+	return r, true
+}
+
+// checkAPIKeyScope enforces the ingest-only and read-only API key restrictions
+// for the current request. It returns false (after writing an error response)
+// when the key's scope forbids this endpoint.
+func (s *Server) checkAPIKeyScope(w http.ResponseWriter, r *http.Request, scope string) bool {
+	if scope == domain.APIKeyScopeIngest {
+		// Allow ingest keys to post release markers — the setup page uses
+		// the same key for both events and releases — but reject every
+		// other endpoint.
+		isReleaseMarker := r.URL.Path == "/api/v1/releases" && r.Method == http.MethodPost
+		if !isReleaseMarker {
+			s.logger.Warn("auth: ingest-only key rejected", "method", r.Method, "path", r.URL.Path)
+			http.Error(w, "forbidden: ingest-only key cannot access this endpoint", http.StatusForbidden)
+			return false
+		}
+	}
+	if scope == domain.APIKeyScopeRead {
+		if r.Method != http.MethodGet {
+			s.logger.Warn("auth: read-only key rejected non-GET", "method", r.Method, "path", r.URL.Path)
+			http.Error(w, "forbidden: read-only key cannot modify data", http.StatusForbidden)
+			return false
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/v1/settings") || strings.HasPrefix(r.URL.Path, "/api/v1/apikeys") {
+			s.logger.Warn("auth: read-only key rejected settings/apikeys", "method", r.Method, "path", r.URL.Path)
+			http.Error(w, "forbidden: read-only key cannot access this endpoint", http.StatusForbidden)
+			return false
+		}
+	}
+	return true
+}
+
+// refreshCSRFCookie re-issues the CSRF cookie on session-authenticated requests
+// when the browser's copy is missing or stale, so the frontend always has a
+// valid token available for state-changing requests.
+func (s *Server) refreshCSRFCookie(w http.ResponseWriter, r *http.Request, usingSession bool) {
 	if usingSession && s.sessions != nil {
 		if sessionCookie, err := r.Cookie("bugbarn_session"); err == nil {
 			if csrfCookie, err := r.Cookie("bugbarn_csrf"); err != nil || csrfCookie.Value != s.sessions.CSRFToken(sessionCookie.Value) {
@@ -88,10 +103,32 @@ func (s *Server) authenticateAndResolve(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 	}
+}
 
+// resolveProjectScope determines the request's project (or group) scope and
+// returns the request augmented with the resolved IDs in its context.
+func (s *Server) resolveProjectScope(r *http.Request, usingSession, usingAPIKey bool, apiKeyProjectID int64) *http.Request {
+	resolvedProjectID := s.resolveProjectID(r, usingSession, usingAPIKey, apiKeyProjectID)
+	r = r.WithContext(storage.WithProjectID(r.Context(), resolvedProjectID))
+
+	// Group-scoped filtering: when a GET carries X-BugBarn-Group and no
+	// specific project was selected, resolve the group to its member IDs so that
+	// storage queries use IN (...) instead of showing all projects.
+	// Works for both session and API key auth.
+	if r.Method == http.MethodGet && resolvedProjectID == 0 {
+		r = s.applyGroupScope(r)
+	}
+
+	return r
+}
+
+// resolveProjectID derives the request's effective project ID from the
+// X-BugBarn-Project header, the API key, or the session/default fallbacks.
+func (s *Server) resolveProjectID(r *http.Request, usingSession, usingAPIKey bool, apiKeyProjectID int64) int64 {
 	// Resolve project ID. X-BugBarn-Project header takes precedence for both
 	// API key and session requests — it auto-creates the project if unknown,
 	// so a single shared API key can route events to any project via the header.
+	var resolvedProjectID int64
 	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" {
 		if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
 			resolvedProjectID = proj.ID
@@ -108,23 +145,20 @@ func (s *Server) authenticateAndResolve(w http.ResponseWriter, r *http.Request) 
 	if resolvedProjectID == 0 && (!usingSession || r.Method != http.MethodGet) {
 		resolvedProjectID = s.projects.DefaultProjectID()
 	}
-	r = r.WithContext(storage.WithProjectID(r.Context(), resolvedProjectID))
+	return resolvedProjectID
+}
 
-	// Group-scoped filtering: when a GET carries X-BugBarn-Group and no
-	// specific project was selected, resolve the group to its member IDs so that
-	// storage queries use IN (...) instead of showing all projects.
-	// Works for both session and API key auth.
-	if r.Method == http.MethodGet && resolvedProjectID == 0 {
-		if groupSlug := r.Header.Get("X-BugBarn-Group"); groupSlug != "" {
-			if members, err := s.projects.ListGroupProjects(r.Context(), groupSlug); err == nil && len(members) > 0 {
-				ids := make([]int64, len(members))
-				for i, p := range members {
-					ids[i] = p.ID
-				}
-				r = r.WithContext(storage.WithProjectIDs(r.Context(), ids))
+// applyGroupScope resolves an X-BugBarn-Group header to its member project IDs
+// and stores them on the request context when the group has members.
+func (s *Server) applyGroupScope(r *http.Request) *http.Request {
+	if groupSlug := r.Header.Get("X-BugBarn-Group"); groupSlug != "" {
+		if members, err := s.projects.ListGroupProjects(r.Context(), groupSlug); err == nil && len(members) > 0 {
+			ids := make([]int64, len(members))
+			for i, p := range members {
+				ids[i] = p.ID
 			}
+			r = r.WithContext(storage.WithProjectIDs(r.Context(), ids))
 		}
 	}
-
-	return r, true
+	return r
 }

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -50,17 +50,17 @@ func (s *Server) serveProjectsRoot(w http.ResponseWriter, r *http.Request) {
 		}
 		usage, _ := s.projects.UsageAll(r.Context())
 		type projectWithUsage struct {
-			ID           int64   `json:"id"`
-			Name         string  `json:"name"`
-			Slug         string  `json:"slug"`
-			Status       string  `json:"status"`
-			IssuePrefix  string  `json:"issue_prefix"`
-			IssueCounter int     `json:"issue_counter"`
-			GroupID      *int64  `json:"group_id"`
-			CreatedAt    string  `json:"created_at"`
-			IssueCount   int     `json:"issue_count"`
-			EventCount   int     `json:"event_count"`
-			LogCount     int     `json:"log_count"`
+			ID           int64  `json:"id"`
+			Name         string `json:"name"`
+			Slug         string `json:"slug"`
+			Status       string `json:"status"`
+			IssuePrefix  string `json:"issue_prefix"`
+			IssueCounter int    `json:"issue_counter"`
+			GroupID      *int64 `json:"group_id"`
+			CreatedAt    string `json:"created_at"`
+			IssueCount   int    `json:"issue_count"`
+			EventCount   int    `json:"event_count"`
+			LogCount     int    `json:"log_count"`
 		}
 		out := make([]projectWithUsage, len(projects))
 		for i, p := range projects {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -12,74 +12,11 @@ import (
 // (events, logs, analytics/collect) and the public, no-CORS endpoints (setup,
 // theme manifest, analytics snippet). It returns true when it has written a
 // response and the caller should stop.
-//
-//nolint:gocognit,gocyclo,funlen // sequential special-endpoint handlers with per-endpoint CORS/forwarding.
 func (s *Server) serveSpecialEndpoint(w http.ResponseWriter, r *http.Request) bool {
-	// Ingest endpoint uses wildcard CORS so browser SDKs can POST from any origin
-	// without credentials. The ingest-only key scope ensures read access is impossible.
-	if r.URL.Path == "/api/v1/events" {
-		setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return true
-		}
-		if r.Method == http.MethodPost {
-			if s.ingestHandler != nil && !s.ingestHandler.ValidAPIKey(r) {
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
-				return true
-			}
-			if s.ingestSpool != nil {
-				s.ingestSpool.Forward(w, r)
-				return true
-			}
-			if s.writeForwarder != nil {
-				s.writeForwarder.Forward(w, r)
-				return true
-			}
-			s.ingestHandler.ServeHTTP(w, r)
-			return true
-		}
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if s.serveEventsIngestEndpoint(w, r) {
 		return true
 	}
-
-	// Log ingest endpoint — wildcard CORS, accepts ingest-scope or full-scope API keys.
-	if r.URL.Path == "/api/v1/logs" && r.Method == http.MethodPost {
-		setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
-		if s.ingestHandler != nil && !s.ingestHandler.ValidAPIKey(r) {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return true
-		}
-		if s.ingestSpool != nil {
-			s.ingestSpool.Forward(w, r)
-			return true
-		}
-		if s.writeForwarder != nil {
-			s.writeForwarder.Forward(w, r)
-			return true
-		}
-		// Resolve project from API key / header.
-		var logProjectID int64
-		if s.ingestHandler != nil {
-			pid, _, ok := s.ingestHandler.APIKeyProjectScope(r)
-			if ok && pid > 0 {
-				logProjectID = pid
-			}
-		}
-		if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.projects != nil {
-			if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
-				logProjectID = proj.ID
-			}
-		}
-		if logProjectID > 0 {
-			r = r.WithContext(storage.WithProjectID(r.Context(), logProjectID))
-		}
-		s.serveLogsIngest(w, r)
-		return true
-	}
-	if r.URL.Path == "/api/v1/logs" && r.Method == http.MethodOptions {
-		setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
-		w.WriteHeader(http.StatusNoContent)
+	if s.serveLogsIngestEndpoint(w, r) {
 		return true
 	}
 
@@ -101,30 +38,121 @@ func (s *Server) serveSpecialEndpoint(w http.ResponseWriter, r *http.Request) bo
 		return true
 	}
 
-	// Analytics collection — public, wildcard CORS for sendBeacon from any origin.
-	if r.URL.Path == "/api/v1/analytics/collect" {
-		setWildcardCORS(w, "POST, OPTIONS", analyticsCORSHeaders)
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return true
-		}
-		if r.Method == http.MethodPost {
-			if s.ingestSpool != nil {
-				s.ingestSpool.Forward(w, r)
-				return true
-			}
-			if s.writeForwarder != nil {
-				s.writeForwarder.Forward(w, r)
-				return true
-			}
-			s.collectPageView(w, r)
-			return true
-		}
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if s.serveAnalyticsCollectEndpoint(w, r) {
 		return true
 	}
 
 	return false
+}
+
+// serveEventsIngestEndpoint handles /api/v1/events with wildcard CORS so browser
+// SDKs can POST from any origin without credentials. The ingest-only key scope
+// ensures read access is impossible.
+func (s *Server) serveEventsIngestEndpoint(w http.ResponseWriter, r *http.Request) bool {
+	if r.URL.Path != "/api/v1/events" {
+		return false
+	}
+	setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	if r.Method == http.MethodPost {
+		if s.ingestHandler != nil && !s.ingestHandler.ValidAPIKey(r) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return true
+		}
+		if s.ingestSpool != nil {
+			s.ingestSpool.Forward(w, r)
+			return true
+		}
+		if s.writeForwarder != nil {
+			s.writeForwarder.Forward(w, r)
+			return true
+		}
+		s.ingestHandler.ServeHTTP(w, r)
+		return true
+	}
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return true
+}
+
+// serveLogsIngestEndpoint handles POST/OPTIONS /api/v1/logs — wildcard CORS,
+// accepts ingest-scope or full-scope API keys.
+func (s *Server) serveLogsIngestEndpoint(w http.ResponseWriter, r *http.Request) bool {
+	if r.URL.Path == "/api/v1/logs" && r.Method == http.MethodPost {
+		s.handleLogsIngestPost(w, r)
+		return true
+	}
+	if r.URL.Path == "/api/v1/logs" && r.Method == http.MethodOptions {
+		setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	return false
+}
+
+// handleLogsIngestPost serves a POST to the log-ingest endpoint: it sets CORS,
+// validates the API key, forwards to the spool/writer when configured, and
+// otherwise resolves the project and persists the batch locally.
+func (s *Server) handleLogsIngestPost(w http.ResponseWriter, r *http.Request) {
+	setWildcardCORS(w, "POST, OPTIONS", ingestCORSHeaders)
+	if s.ingestHandler != nil && !s.ingestHandler.ValidAPIKey(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.ingestSpool != nil {
+		s.ingestSpool.Forward(w, r)
+		return
+	}
+	if s.writeForwarder != nil {
+		s.writeForwarder.Forward(w, r)
+		return
+	}
+	// Resolve project from API key / header.
+	var logProjectID int64
+	if s.ingestHandler != nil {
+		pid, _, ok := s.ingestHandler.APIKeyProjectScope(r)
+		if ok && pid > 0 {
+			logProjectID = pid
+		}
+	}
+	if slug := r.Header.Get("X-BugBarn-Project"); slug != "" && s.projects != nil {
+		if proj, err := s.projects.Ensure(r.Context(), slug); err == nil {
+			logProjectID = proj.ID
+		}
+	}
+	if logProjectID > 0 {
+		r = r.WithContext(storage.WithProjectID(r.Context(), logProjectID))
+	}
+	s.serveLogsIngest(w, r)
+}
+
+// serveAnalyticsCollectEndpoint handles /api/v1/analytics/collect — public,
+// wildcard CORS for sendBeacon from any origin.
+func (s *Server) serveAnalyticsCollectEndpoint(w http.ResponseWriter, r *http.Request) bool {
+	if r.URL.Path != "/api/v1/analytics/collect" {
+		return false
+	}
+	setWildcardCORS(w, "POST, OPTIONS", analyticsCORSHeaders)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	if r.Method == http.MethodPost {
+		if s.ingestSpool != nil {
+			s.ingestSpool.Forward(w, r)
+			return true
+		}
+		if s.writeForwarder != nil {
+			s.writeForwarder.Forward(w, r)
+			return true
+		}
+		s.collectPageView(w, r)
+		return true
+	}
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return true
 }
 
 // servePublicEndpoint handles the endpoints that require no authentication but
@@ -185,31 +213,84 @@ func (s *Server) servePublicEndpoint(w http.ResponseWriter, r *http.Request) boo
 	return false
 }
 
-// dispatchProtected routes an authenticated request to its domain handler.
-//
-//nolint:gocyclo,gocognit,funlen // flat route table mapping path+method to a handler.
+// dispatchProtected routes an authenticated request to its domain handler. The
+// request is offered to each per-domain sub-dispatcher in order; the first that
+// reports it handled the request wins, otherwise it's a 404.
 func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
+	dispatchers := []func(http.ResponseWriter, *http.Request) bool{
+		s.dispatchSourceMapRoutes,
+		s.dispatchSettingsReleaseRoutes,
+		s.dispatchAlertRoutes,
+		s.dispatchIssueRoutes,
+		s.dispatchLogEventRoutes,
+		s.dispatchProjectRoutes,
+		s.dispatchProjectItemRoutes,
+		s.dispatchGroupAliasRoutes,
+		s.dispatchAPIKeyFacetAnalyticsRoutes,
+		s.dispatchMiscRoutes,
+	}
+	for _, d := range dispatchers {
+		if d(w, r) {
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (s *Server) dispatchSourceMapRoutes(w http.ResponseWriter, r *http.Request) bool {
 	switch {
 	case r.URL.Path == "/api/v1/source-maps" && r.Method == http.MethodGet:
 		s.listSourceMaps(w, r)
 	case r.URL.Path == "/api/v1/source-maps" && r.Method == http.MethodPost:
 		s.uploadSourceMap(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchSettingsReleaseRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/settings" && (r.Method == http.MethodGet || r.Method == http.MethodPut || r.Method == http.MethodPost):
 		s.serveSettingsRoute(w, r)
 	case r.URL.Path == "/api/v1/releases" && (r.Method == http.MethodGet || r.Method == http.MethodPost):
 		s.serveReleasesRoot(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/releases/"):
 		s.serveReleaseRoute(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchAlertRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/alerts" && (r.Method == http.MethodGet || r.Method == http.MethodPost):
 		s.serveAlertsRoot(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/alerts/"):
 		s.serveAlertRoute(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchIssueRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/issues" && r.Method == http.MethodGet:
 		s.listIssues(w, r)
 	case r.URL.Path == "/api/v1/issues/sparklines" && r.Method == http.MethodGet:
 		s.issueSparklines(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/issues/"):
 		s.serveIssueRoute(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchLogEventRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/logs" && r.Method == http.MethodGet:
 		s.serveLogs(w, r)
 	case r.URL.Path == "/api/v1/logs/stream" && r.Method == http.MethodGet:
@@ -220,10 +301,26 @@ func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
 		s.getEvent(w, r)
 	case r.URL.Path == "/api/v1/live/events" && r.Method == http.MethodGet:
 		s.listRecentEvents(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchProjectRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/projects" && (r.Method == http.MethodGet || r.Method == http.MethodPost):
 		s.serveProjectsRoot(w, r)
 	case r.URL.Path == "/api/v1/projects/pending-count" && r.Method == http.MethodGet:
 		s.servePendingProjectCount(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchProjectItemRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case strings.HasPrefix(r.URL.Path, "/api/v1/projects/") && strings.HasSuffix(r.URL.Path, "/approve") && r.Method == http.MethodPost:
 		s.approveProject(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/projects/") && strings.HasSuffix(r.URL.Path, "/merge") && r.Method == http.MethodPost:
@@ -232,6 +329,14 @@ func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
 		s.renameProject(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/projects/") && r.Method == http.MethodDelete:
 		s.deleteProject(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchGroupAliasRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/groups" && (r.Method == http.MethodGet || r.Method == http.MethodPost):
 		s.serveGroupsRoot(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/groups/"):
@@ -240,6 +345,14 @@ func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
 		s.serveAliasesRoot(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/aliases/") && r.Method == http.MethodDelete:
 		s.deleteAlias(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchAPIKeyFacetAnalyticsRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/apikeys" && r.Method == http.MethodGet:
 		s.listAPIKeys(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/apikeys/") && r.Method == http.MethodDelete:
@@ -248,6 +361,14 @@ func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
 		s.serveFacetsRoute(w, r)
 	case strings.HasPrefix(r.URL.Path, "/api/v1/analytics/") && r.Method == http.MethodGet:
 		s.serveAnalyticsQuery(w, r)
+	default:
+		return false
+	}
+	return true
+}
+
+func (s *Server) dispatchMiscRoutes(w http.ResponseWriter, r *http.Request) bool {
+	switch {
 	case r.URL.Path == "/api/v1/telemetry" && r.Method == http.MethodPost:
 		s.serveTelemetry(w, r)
 	case r.URL.Path == "/api/v1/client-errors" && r.Method == http.MethodPost:
@@ -255,6 +376,7 @@ func (s *Server) dispatchProtected(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/api/v1/admin/digest" && r.Method == http.MethodPost:
 		s.serveDigestTrigger(w, r)
 	default:
-		http.NotFound(w, r)
+		return false
 	}
+	return true
 }

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -230,8 +230,8 @@ curl -X POST %s/api/v1/logs \
 ---
 Generated %s
 `,
-		slug,                   // 1: title
-		slug,                   // 2: description slug
+		slug,                           // 1: title
+		slug,                           // 2: description slug
 		endpoint, slug, rawKey, status, // 3,4,5,6: table
 		pendingNote,            // 7: pending note block
 		endpoint, rawKey, slug, // 8,9,10: curl example
@@ -241,7 +241,7 @@ Generated %s
 		rawKey, endpoint, // 20,21: python (no project_slug param — routed by API key)
 		endpoint, rawKey, slug, // 22,23,24: release curl
 		endpoint, rawKey, slug, // 25,26,27: logs curl
-		endpoint,               // 28: view link
+		endpoint,                              // 28: view link
 		time.Now().UTC().Format(time.RFC3339), // 29: generated timestamp
 	)
 

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -21,7 +21,7 @@ type clientSpan struct {
 	Kind         string         `json:"kind"`
 	Status       string         `json:"status"`
 	StartTime    int64          `json:"startTime"` // microseconds
-	Duration     int64          `json:"duration"`   // microseconds
+	Duration     int64          `json:"duration"`  // microseconds
 	Attributes   map[string]any `json:"attributes,omitempty"`
 }
 

--- a/internal/storage/analytics_query.go
+++ b/internal/storage/analytics_query.go
@@ -214,8 +214,6 @@ func (s *AnalyticsStore) QuerySegments(ctx context.Context, q analytics.Query, d
 }
 
 // QueryPageFlow returns page-flow data for a given pathname.
-//
-//nolint:funlen // sequential "where users went / came from" query; tracked for a dedicated refactor.
 func (s *AnalyticsStore) QueryPageFlow(ctx context.Context, q analytics.Query, pathname string) (analytics.PageFlowResult, error) {
 	result := analytics.PageFlowResult{
 		Pathname: pathname,
@@ -223,7 +221,23 @@ func (s *AnalyticsStore) QueryPageFlow(ctx context.Context, q analytics.Query, p
 		WentTo:   []analytics.FlowEntry{},
 	}
 
-	// WentTo — aggregate exit_pathname from raw pageviews
+	wentTo, err := s.queryWentTo(ctx, q, pathname)
+	if err != nil {
+		return result, err
+	}
+	result.WentTo = wentTo
+
+	cameFrom, err := s.queryCameFrom(ctx, q, pathname)
+	if err != nil {
+		return result, err
+	}
+	result.CameFrom = cameFrom
+
+	return result, nil
+}
+
+// queryWentTo aggregates exit_pathname from raw pageviews for the given path.
+func (s *AnalyticsStore) queryWentTo(ctx context.Context, q analytics.Query, pathname string) ([]analytics.FlowEntry, error) {
 	wentToRows, err := s.readDB().QueryContext(ctx, `
 		SELECT exit_pathname, COUNT(*) as cnt, COUNT(DISTINCT session_id) as sess
 		FROM analytics_pageviews
@@ -233,30 +247,35 @@ func (s *AnalyticsStore) QueryPageFlow(ctx context.Context, q analytics.Query, p
 		q.ProjectID, pathname, q.Start.Unix(), q.End.Unix(),
 	)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	defer wentToRows.Close()
 
+	wentTo := []analytics.FlowEntry{}
 	var wentToTotal int64
 	for wentToRows.Next() {
 		var e analytics.FlowEntry
 		var sess int64
 		if err := wentToRows.Scan(&e.Pathname, &e.Count, &sess); err != nil {
-			return result, err
+			return nil, err
 		}
 		wentToTotal += e.Count
-		result.WentTo = append(result.WentTo, e)
+		wentTo = append(wentTo, e)
 	}
 	if err := wentToRows.Err(); err != nil {
-		return result, err
+		return nil, err
 	}
-	for i := range result.WentTo {
+	for i := range wentTo {
 		if wentToTotal > 0 {
-			result.WentTo[i].Pct = float64(result.WentTo[i].Count) / float64(wentToTotal) * 100
+			wentTo[i].Pct = float64(wentTo[i].Count) / float64(wentToTotal) * 100
 		}
 	}
+	return wentTo, nil
+}
 
-	// CameFrom — find what page users were on just before visiting pathname in the same session
+// queryCameFrom finds what page users were on just before visiting pathname in
+// the same session.
+func (s *AnalyticsStore) queryCameFrom(ctx context.Context, q analytics.Query, pathname string) ([]analytics.FlowEntry, error) {
 	cameFromRows, err := s.readDB().QueryContext(ctx, `
 		SELECT prev.pathname, COUNT(*) as cnt
 		FROM analytics_pageviews cur
@@ -278,29 +297,29 @@ func (s *AnalyticsStore) QueryPageFlow(ctx context.Context, q analytics.Query, p
 		q.ProjectID, pathname, q.Start.Unix(), q.End.Unix(),
 	)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	defer cameFromRows.Close()
 
+	cameFrom := []analytics.FlowEntry{}
 	var cameFromTotal int64
 	for cameFromRows.Next() {
 		var e analytics.FlowEntry
 		if err := cameFromRows.Scan(&e.Pathname, &e.Count); err != nil {
-			return result, err
+			return nil, err
 		}
 		cameFromTotal += e.Count
-		result.CameFrom = append(result.CameFrom, e)
+		cameFrom = append(cameFrom, e)
 	}
 	if err := cameFromRows.Err(); err != nil {
-		return result, err
+		return nil, err
 	}
-	for i := range result.CameFrom {
+	for i := range cameFrom {
 		if cameFromTotal > 0 {
-			result.CameFrom[i].Pct = float64(result.CameFrom[i].Count) / float64(cameFromTotal) * 100
+			cameFrom[i].Pct = float64(cameFrom[i].Count) / float64(cameFromTotal) * 100
 		}
 	}
-
-	return result, nil
+	return cameFrom, nil
 }
 
 // QueryScrollDepth returns scroll-depth bucket counts for a pathname.

--- a/internal/storage/facets.go
+++ b/internal/storage/facets.go
@@ -110,8 +110,6 @@ func stringFromMap(m map[string]any, key string) string {
 
 // PersistFacets inserts extracted facet key/value pairs for a given event into
 // event_facets, enforcing per-project cardinality caps (T030).
-//
-//nolint:gocognit,gocyclo // facet upsert with per-project cardinality caps; tracked for refactor.
 func (s *core) PersistFacets(ctx context.Context, eventID int64, issueID int64, facets map[string]string) error {
 	if len(facets) == 0 {
 		return nil
@@ -141,65 +139,77 @@ func (s *core) PersistFacets(ctx context.Context, eventID int64, issueID int64, 
 		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
 			continue
 		}
-
-		// Determine whether this key is new to this project. EXISTS stops at the
-		// first matching row; the old COUNT(*) counted every row for the key,
-		// which on a high-frequency facet key meant scanning hundreds of
-		// thousands of index entries per facet per event — the dominant cost in
-		// event persistence. We only need the existence boolean.
-		var keyExists bool
-		if err := tx.QueryRowContext(ctx,
-			`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ?)`,
-			projectID, k,
-		).Scan(&keyExists); err != nil {
+		inserted, err := persistFacet(ctx, tx, projectID, eventID, issueID, k, v, keyCount)
+		if err != nil {
 			return err
 		}
-		isNewKey := !keyExists
-
-		// Cardinality guard: max 50 distinct keys per project.
-		if isNewKey && keyCount >= maxFacetKeysPerProject {
-			continue
-		}
-
-		// Determine whether this specific value is new for this key — again an
-		// existence check, not a count.
-		var valueExists bool
-		if err := tx.QueryRowContext(ctx,
-			`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?)`,
-			projectID, k, v,
-		).Scan(&valueExists); err != nil {
-			return err
-		}
-		isNewValue := !valueExists
-
-		// Cardinality guard: max 10,000 distinct values per key.
-		if isNewValue {
-			var distinctValueCount int
-			if err := tx.QueryRowContext(ctx,
-				`SELECT COUNT(DISTINCT facet_value) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
-				projectID, k,
-			).Scan(&distinctValueCount); err != nil {
-				return err
-			}
-			if distinctValueCount >= maxFacetValuesPerKey {
-				continue
-			}
-		}
-
-		section := rootSection(k)
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO event_facets (project_id, event_id, issue_id, section, facet_key, facet_value) VALUES (?, ?, ?, ?, ?, ?)`,
-			projectID, eventID, issueID, section, k, v,
-		); err != nil {
-			return err
-		}
-
-		if isNewKey {
+		if inserted {
 			keyCount++
 		}
 	}
 
 	return tx.Commit()
+}
+
+// persistFacet applies the cardinality guards for a single facet key/value and
+// inserts it when allowed. It returns whether the inserted row introduced a new
+// facet key for the project (so the caller can bump its key count).
+func persistFacet(
+	ctx context.Context, tx *sql.Tx, projectID, eventID, issueID int64, k, v string, keyCount int,
+) (newKeyInserted bool, err error) {
+	// Determine whether this key is new to this project. EXISTS stops at the
+	// first matching row; the old COUNT(*) counted every row for the key,
+	// which on a high-frequency facet key meant scanning hundreds of
+	// thousands of index entries per facet per event — the dominant cost in
+	// event persistence. We only need the existence boolean.
+	var keyExists bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ?)`,
+		projectID, k,
+	).Scan(&keyExists); err != nil {
+		return false, err
+	}
+	isNewKey := !keyExists
+
+	// Cardinality guard: max 50 distinct keys per project.
+	if isNewKey && keyCount >= maxFacetKeysPerProject {
+		return false, nil
+	}
+
+	// Determine whether this specific value is new for this key — again an
+	// existence check, not a count.
+	var valueExists bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?)`,
+		projectID, k, v,
+	).Scan(&valueExists); err != nil {
+		return false, err
+	}
+	isNewValue := !valueExists
+
+	// Cardinality guard: max 10,000 distinct values per key.
+	if isNewValue {
+		var distinctValueCount int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(DISTINCT facet_value) FROM event_facets WHERE project_id = ? AND facet_key = ?`,
+			projectID, k,
+		).Scan(&distinctValueCount); err != nil {
+			return false, err
+		}
+		if distinctValueCount >= maxFacetValuesPerKey {
+			return false, nil
+		}
+	}
+
+	section := rootSection(k)
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO event_facets (project_id, event_id, issue_id, section, facet_key, facet_value) VALUES (?, ?, ?, ?, ?, ?)`,
+		projectID, eventID, issueID, section, k, v,
+	); err != nil {
+		return false, err
+	}
+
+	return isNewKey, nil
 }
 
 // ListFacetKeys returns all distinct facet keys observed for a project.

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -16,7 +17,6 @@ func (s *IssueStore) ListIssues(ctx context.Context) ([]Issue, error) {
 	return s.ListIssuesFiltered(ctx, IssueFilter{})
 }
 
-//nolint:gocognit,gocyclo,funlen // dynamic filter/sort/facet query builder; tracked for refactor.
 func (s *IssueStore) ListIssuesFiltered(ctx context.Context, filter IssueFilter) (_ []Issue, retErr error) {
 	ctx, span := tracing.Tracer().Start(ctx, "storage.ListIssuesFiltered")
 	defer func() {
@@ -25,27 +25,9 @@ func (s *IssueStore) ListIssuesFiltered(ctx context.Context, filter IssueFilter)
 		}
 		span.End()
 	}()
-	var orderBy string
-	switch filter.Sort {
-	case "first_seen":
-		orderBy = "i.first_seen DESC, i.id DESC"
-	case "event_count":
-		orderBy = "i.event_count DESC, i.id DESC"
-	default:
-		orderBy = "i.last_seen DESC, i.id DESC"
-	}
-	if filter.Status == "open" {
-		orderBy = "(CASE WHEN i.status = 'regressed' THEN 0 ELSE 1 END), " + orderBy
-	}
+	orderBy := issueOrderBy(filter)
 
-	// Collect non-empty facet filters.
-	type kv struct{ k, v string }
-	var facetFilters []kv
-	for fk, fv := range filter.Facets {
-		if strings.TrimSpace(fk) != "" && strings.TrimSpace(fv) != "" {
-			facetFilters = append(facetFilters, kv{fk, fv})
-		}
-	}
+	facetFilters := collectFacetFilters(filter)
 
 	projectID, ok := ProjectIDFromContext(ctx)
 	if !ok {
@@ -55,64 +37,30 @@ func (s *IssueStore) ListIssuesFiltered(ctx context.Context, filter IssueFilter)
 
 	groupIDs, hasGroupFilter := ProjectIDsFromContext(ctx)
 
-	var conditions []string
-	var whereArgs []any
-	if hasGroupFilter {
-		placeholders := make([]string, len(groupIDs))
-		for i, id := range groupIDs {
-			placeholders[i] = "?"
-			whereArgs = append(whereArgs, id)
-		}
-		conditions = append(conditions, "i.project_id IN ("+strings.Join(placeholders, ",")+")")
-	} else if !allProjects {
-		conditions = append(conditions, "i.project_id = ?")
-		whereArgs = append(whereArgs, projectID)
-	}
-
-	switch filter.Status {
-	case "open":
-		conditions = append(conditions, "i.status IN ('unresolved', 'regressed')")
-	case "muted":
-		conditions = append(conditions, "i.status = 'muted'")
-	case "resolved":
-		conditions = append(conditions, "i.status = 'resolved'")
-		// "all" or "" → no status filter
-	}
-
-	if q := strings.TrimSpace(filter.Query); q != "" {
-		conditions = append(conditions, "(i.title LIKE ? OR i.normalized_title LIKE ?)")
-		like := "%" + q + "%"
-		whereArgs = append(whereArgs, like, like)
-	}
+	conditions, whereArgs := issueWhereConditions(filter, projectID, allProjects, groupIDs, hasGroupFilter)
 
 	// fromArgs holds bindings for subquery ?-placeholders in the FROM clause.
 	// They must come before whereArgs in the final args slice.
-	var fromArgs []any
-	var fromClause string
-	if len(facetFilters) > 0 {
-		// Build an INTERSECT subquery: one branch per facet filter that returns
-		// matching issue_ids. The join enforces AND semantics across all filters.
-		var subqueries []string
-		for _, f := range facetFilters {
-			if !allProjects {
-				subqueries = append(subqueries,
-					`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
-				fromArgs = append(fromArgs, projectID, f.k, f.v)
-			} else {
-				subqueries = append(subqueries,
-					`SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`)
-				fromArgs = append(fromArgs, f.k, f.v)
-			}
-		}
-		fromClause = fmt.Sprintf(`issues i INNER JOIN (%s) ef ON i.id = ef.issue_id LEFT JOIN projects p ON p.id = i.project_id`,
-			strings.Join(subqueries, " INTERSECT "))
-	} else {
-		fromClause = "issues i LEFT JOIN projects p ON p.id = i.project_id"
-	}
+	fromClause, fromArgs := buildIssueFromClause(facetFilters, projectID, allProjects)
 
 	// Combine: subquery bindings first (appear in FROM clause), then WHERE bindings.
 	args := append(fromArgs, whereArgs...)
 
+	sqlQuery := buildIssueListQuery(fromClause, conditions, orderBy, filter)
+
+	rows, err := s.readDB().QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanIssueRows(rows)
+}
+
+// buildIssueListQuery assembles the SELECT/FROM/WHERE/ORDER BY/LIMIT SQL for the
+// issue list query from the already-built FROM clause, WHERE conditions, and
+// ORDER BY expression.
+func buildIssueListQuery(fromClause string, conditions []string, orderBy string, filter IssueFilter) string {
 	sqlQuery := `
 SELECT
 	i.id,
@@ -149,13 +97,11 @@ ORDER BY ` + orderBy
 			sqlQuery += fmt.Sprintf(" OFFSET %d", filter.Offset)
 		}
 	}
+	return sqlQuery
+}
 
-	rows, err := s.readDB().QueryContext(ctx, sqlQuery, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
+// scanIssueRows materializes all rows from an issue list query into a slice.
+func scanIssueRows(rows *sql.Rows) ([]Issue, error) {
 	issues := []Issue{}
 	for rows.Next() {
 		issue, err := scanIssue(rows)
@@ -168,6 +114,100 @@ ORDER BY ` + orderBy
 		return nil, err
 	}
 	return issues, nil
+}
+
+// facetFilter is a single non-empty facet key/value constraint.
+type facetFilter struct{ k, v string }
+
+// collectFacetFilters returns the filter's non-empty facet key/value pairs.
+func collectFacetFilters(filter IssueFilter) []facetFilter {
+	var facetFilters []facetFilter
+	for fk, fv := range filter.Facets {
+		if strings.TrimSpace(fk) != "" && strings.TrimSpace(fv) != "" {
+			facetFilters = append(facetFilters, facetFilter{fk, fv})
+		}
+	}
+	return facetFilters
+}
+
+// buildIssueFromClause builds the FROM clause (and its subquery bind args) for
+// the issue list query. When facet filters are present it joins an INTERSECT
+// subquery that enforces AND semantics across all filters.
+func buildIssueFromClause(facetFilters []facetFilter, projectID int64, allProjects bool) (string, []any) {
+	if len(facetFilters) == 0 {
+		return "issues i LEFT JOIN projects p ON p.id = i.project_id", nil
+	}
+	// Build an INTERSECT subquery: one branch per facet filter that returns
+	// matching issue_ids. The join enforces AND semantics across all filters.
+	var fromArgs []any
+	var subqueries []string
+	for _, f := range facetFilters {
+		if !allProjects {
+			subqueries = append(subqueries,
+				`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
+			fromArgs = append(fromArgs, projectID, f.k, f.v)
+		} else {
+			subqueries = append(subqueries,
+				`SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`)
+			fromArgs = append(fromArgs, f.k, f.v)
+		}
+	}
+	fromClause := fmt.Sprintf(`issues i INNER JOIN (%s) ef ON i.id = ef.issue_id LEFT JOIN projects p ON p.id = i.project_id`,
+		strings.Join(subqueries, " INTERSECT "))
+	return fromClause, fromArgs
+}
+
+// issueOrderBy maps the filter's sort/status to the ORDER BY clause.
+func issueOrderBy(filter IssueFilter) string {
+	var orderBy string
+	switch filter.Sort {
+	case "first_seen":
+		orderBy = "i.first_seen DESC, i.id DESC"
+	case "event_count":
+		orderBy = "i.event_count DESC, i.id DESC"
+	default:
+		orderBy = "i.last_seen DESC, i.id DESC"
+	}
+	if filter.Status == "open" {
+		orderBy = "(CASE WHEN i.status = 'regressed' THEN 0 ELSE 1 END), " + orderBy
+	}
+	return orderBy
+}
+
+// issueWhereConditions builds the WHERE conditions and their bound args from the
+// project/group scope and the filter's status/query.
+func issueWhereConditions(
+	filter IssueFilter, projectID int64, allProjects bool, groupIDs []int64, hasGroupFilter bool,
+) (conditions []string, whereArgs []any) {
+	if hasGroupFilter {
+		placeholders := make([]string, len(groupIDs))
+		for i, id := range groupIDs {
+			placeholders[i] = "?"
+			whereArgs = append(whereArgs, id)
+		}
+		conditions = append(conditions, "i.project_id IN ("+strings.Join(placeholders, ",")+")")
+	} else if !allProjects {
+		conditions = append(conditions, "i.project_id = ?")
+		whereArgs = append(whereArgs, projectID)
+	}
+
+	switch filter.Status {
+	case "open":
+		conditions = append(conditions, "i.status IN ('unresolved', 'regressed')")
+	case "muted":
+		conditions = append(conditions, "i.status = 'muted'")
+	case "resolved":
+		conditions = append(conditions, "i.status = 'resolved'")
+		// "all" or "" → no status filter
+	}
+
+	if q := strings.TrimSpace(filter.Query); q != "" {
+		conditions = append(conditions, "(i.title LIKE ? OR i.normalized_title LIKE ?)")
+		like := "%" + q + "%"
+		whereArgs = append(whereArgs, like, like)
+	}
+
+	return conditions, whereArgs
 }
 
 func (s *IssueStore) GetIssue(ctx context.Context, issueID string) (Issue, error) {

--- a/internal/storage/issues_insert.go
+++ b/internal/storage/issues_insert.go
@@ -1,0 +1,172 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/bugbarn/internal/event"
+)
+
+type newIssueParams struct {
+	projectID        int64
+	fingerprintValue string
+	material         string
+	explanation      []string
+	title            string
+	normalizedTitle  string
+	exceptionType    string
+	seenAt           time.Time
+	evt              event.Event
+	representative   []byte
+}
+
+// insertNewIssue allocates the next issue number and INSERTs a new issue within
+// the open transaction.
+func (s *core) insertNewIssue(ctx context.Context, tx *sql.Tx, p newIssueParams) (Issue, int64, bool, error) {
+	issueNumber, issuePrefix, err := allocateIssueNumber(ctx, tx, p.projectID)
+	if err != nil {
+		return Issue{}, 0, false, err
+	}
+
+	issue := Issue{
+		Fingerprint:            p.fingerprintValue,
+		FingerprintMaterial:    p.material,
+		FingerprintExplanation: p.explanation,
+		Title:                  p.title,
+		NormalizedTitle:        p.normalizedTitle,
+		ExceptionType:          p.exceptionType,
+		Status:                 "unresolved",
+		FirstSeen:              p.seenAt,
+		LastSeen:               p.seenAt,
+		EventCount:             1,
+		RepresentativeEvent:    p.evt,
+		IssueNumber:            issueNumber,
+	}
+
+	id, err := insertIssueRow(ctx, tx, p, issueNumber)
+	if err != nil {
+		return Issue{}, 0, false, err
+	}
+	issue.ID = displayIssueID(issuePrefix, issueNumber, id)
+
+	if err := tx.Commit(); err != nil {
+		return Issue{}, 0, false, err
+	}
+
+	return issue, id, false, nil
+}
+
+// insertIssueRow executes the INSERT for a new issue and returns its row id.
+func insertIssueRow(ctx context.Context, tx *sql.Tx, p newIssueParams, issueNumber int) (int64, error) {
+	res, err := tx.ExecContext(ctx, `
+INSERT INTO issues (
+	project_id,
+	fingerprint,
+	fingerprint_material,
+	fingerprint_explanation_json,
+	title,
+	normalized_title,
+	exception_type,
+	status,
+	first_seen,
+	last_seen,
+	event_count,
+	representative_event_json,
+	issue_number
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.projectID,
+		p.fingerprintValue,
+		p.material,
+		mustMarshalStrings(p.explanation),
+		p.title,
+		p.normalizedTitle,
+		p.exceptionType,
+		"unresolved",
+		formatTime(p.seenAt),
+		formatTime(p.seenAt),
+		1,
+		p.representative,
+		issueNumber,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// allocateIssueNumber atomically increments the project's issue counter and
+// returns the new issue number along with the project's display prefix.
+func allocateIssueNumber(ctx context.Context, tx *sql.Tx, projectID int64) (issueNumber int, issuePrefix string, err error) {
+	// Atomically increment the project's issue counter.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE projects SET issue_counter = issue_counter + 1 WHERE id = ?`, projectID); err != nil {
+		return 0, "", err
+	}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT issue_counter, issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&issueNumber, &issuePrefix); err != nil {
+		return 0, "", err
+	}
+	return issueNumber, issuePrefix, nil
+}
+
+func issueSeenAt(evt event.Event) time.Time {
+	if !evt.ObservedAt.IsZero() {
+		return evt.ObservedAt.UTC()
+	}
+	if !evt.ReceivedAt.IsZero() {
+		return evt.ReceivedAt.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func issueDetails(evt event.Event) (title, normalizedTitle, exceptionType string) {
+	exceptionType = strings.TrimSpace(evt.Exception.Type)
+	message := strings.TrimSpace(evt.Exception.Message)
+	if message == "" {
+		message = strings.TrimSpace(evt.Message)
+	}
+
+	// When exception is empty, fall back to rawScrubbed data. This handles
+	// browser errors (promise rejections, cross-origin) that arrive with
+	// exception: {} but have details in rawScrubbed.
+	if exceptionType == "" && message == "" {
+		if raw := rawScrubbedFallback(evt.RawScrubbed); raw.name != "" || raw.message != "" {
+			exceptionType = strings.TrimSpace(raw.name)
+			message = strings.TrimSpace(raw.message)
+		}
+	}
+
+	switch {
+	case exceptionType != "" && message != "":
+		title = exceptionType + ": " + message
+	case exceptionType != "":
+		title = exceptionType
+	default:
+		title = message
+	}
+
+	const maxTitleLen = 512
+	if len(title) > maxTitleLen {
+		title = title[:maxTitleLen]
+	}
+
+	normalizedTitle = normalizeTitle(title)
+	if len(normalizedTitle) > maxTitleLen {
+		normalizedTitle = normalizedTitle[:maxTitleLen]
+	}
+	return title, normalizedTitle, exceptionType
+}
+
+func normalizeTitle(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = uuidPattern.ReplaceAllString(value, "<id>")
+	value = ipv4Pattern.ReplaceAllString(value, "<ip>")
+	value = hexAddress.ReplaceAllString(value, "<hex>")
+	value = longNumber.ReplaceAllString(value, "<num>")
+	value = pathNumber.ReplaceAllString(value, "/:num")
+	value = whitespace.ReplaceAllString(value, " ")
+	value = trimPunctuation.ReplaceAllString(value, "")
+	return value
+}

--- a/internal/storage/issues_upsert.go
+++ b/internal/storage/issues_upsert.go
@@ -14,9 +14,81 @@ import (
 
 // upsertIssue is the ingest write path: it finds-or-creates the issue for an
 // event's fingerprint and applies regression/mute transitions in one tx.
-//
-//nolint:gocognit,gocyclo,funlen // legacy ingest write path; complexity is tracked for a dedicated refactor.
 func (s *core) upsertIssue(ctx context.Context, projectID int64, processed worker.ProcessedEvent) (Issue, int64, bool, error) {
+	in, err := prepareUpsertInputs(processed)
+	if err != nil {
+		return Issue{}, 0, false, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Issue{}, 0, false, err
+	}
+	defer tx.Rollback()
+
+	row, existing, err := findExistingIssue(ctx, tx, projectID, in.fingerprintValue)
+	if err != nil {
+		return Issue{}, 0, false, err
+	}
+
+	if existing {
+		return s.updateExistingIssue(ctx, tx, existingIssueParams{
+			projectID:            projectID,
+			id:                   row.id,
+			issue:                row.issue,
+			eventCount:           row.eventCount,
+			firstSeen:            row.firstSeen,
+			lastSeen:             row.lastSeen,
+			resolvedAt:           row.resolvedAt,
+			reopenedAt:           row.reopenedAt,
+			lastRegressedAt:      row.lastRegressedAt,
+			regressionCount:      row.regressionCount,
+			status:               row.status,
+			muteMode:             row.muteMode,
+			storedMaterial:       row.storedMaterial,
+			storedExplanation:    row.storedExplanation,
+			storedRepresentative: row.storedRepresentative,
+			existingIssueNumber:  row.existingIssueNumber,
+			material:             in.material,
+			explanation:          in.explanation,
+			seenAt:               in.seenAt,
+			evt:                  in.evt,
+			fingerprintValue:     in.fingerprintValue,
+		})
+	}
+
+	return s.insertNewIssue(ctx, tx, newIssueParams{
+		projectID:        projectID,
+		fingerprintValue: in.fingerprintValue,
+		material:         in.material,
+		explanation:      in.explanation,
+		title:            in.title,
+		normalizedTitle:  in.normalizedTitle,
+		exceptionType:    in.exceptionType,
+		seenAt:           in.seenAt,
+		evt:              in.evt,
+		representative:   in.representative,
+	})
+}
+
+// upsertInputs holds the derived event metadata used by both the find-existing
+// and the create-new paths of upsertIssue.
+type upsertInputs struct {
+	evt              event.Event
+	fingerprintValue string
+	material         string
+	explanation      []string
+	title            string
+	normalizedTitle  string
+	exceptionType    string
+	seenAt           time.Time
+	representative   []byte
+}
+
+// prepareUpsertInputs derives the fingerprint, material, explanation, title and
+// representative-event blob from the processed event, applying the same
+// fallbacks the ingest path relied on.
+func prepareUpsertInputs(processed worker.ProcessedEvent) (upsertInputs, error) {
 	evt := processed.Event
 	fingerprintValue := strings.TrimSpace(processed.Fingerprint)
 	if fingerprintValue == "" {
@@ -35,35 +107,47 @@ func (s *core) upsertIssue(ctx context.Context, projectID int64, processed worke
 	seenAt := issueSeenAt(evt)
 	representative, err := marshalEvent(evt)
 	if err != nil {
-		return Issue{}, 0, false, err
+		return upsertInputs{}, err
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return Issue{}, 0, false, err
-	}
-	defer tx.Rollback()
+	return upsertInputs{
+		evt:              evt,
+		fingerprintValue: fingerprintValue,
+		material:         material,
+		explanation:      explanation,
+		title:            title,
+		normalizedTitle:  normalizedTitle,
+		exceptionType:    exceptionType,
+		seenAt:           seenAt,
+		representative:   representative,
+	}, nil
+}
 
-	var (
-		id                   int64
-		issue                Issue
-		existing             bool
-		eventCount           int
-		firstSeen            string
-		lastSeen             string
-		resolvedAt           string
-		reopenedAt           string
-		lastRegressedAt      string
-		regressionCount      int
-		status               string
-		muteMode             string
-		storedMaterial       string
-		storedExplanation    []byte
-		storedRepresentative []byte
-	)
+// scannedIssueRow holds the columns scanned from the find-existing-issue query.
+type scannedIssueRow struct {
+	id                   int64
+	issue                Issue
+	eventCount           int
+	firstSeen            string
+	lastSeen             string
+	resolvedAt           string
+	reopenedAt           string
+	lastRegressedAt      string
+	regressionCount      int
+	status               string
+	muteMode             string
+	storedMaterial       string
+	storedExplanation    []byte
+	storedRepresentative []byte
+	existingIssueNumber  int
+}
 
-	var existingIssueNumber int
-	err = tx.QueryRowContext(ctx, `
+// findExistingIssue looks up an issue by (project, fingerprint) within the
+// transaction. It returns the scanned row and existing=false (no error) when no
+// matching issue is found.
+func findExistingIssue(ctx context.Context, tx *sql.Tx, projectID int64, fingerprintValue string) (scannedIssueRow, bool, error) {
+	var row scannedIssueRow
+	err := tx.QueryRowContext(ctx, `
 SELECT
 	id,
 	fingerprint,
@@ -88,264 +172,185 @@ WHERE project_id = ? AND fingerprint = ?`,
 		projectID,
 		fingerprintValue,
 	).Scan(
-		&id,
-		&issue.Fingerprint,
-		&storedMaterial,
-		&storedExplanation,
-		&issue.Title,
-		&issue.NormalizedTitle,
-		&issue.ExceptionType,
-		&status,
-		&muteMode,
-		&resolvedAt,
-		&reopenedAt,
-		&lastRegressedAt,
-		&regressionCount,
-		&firstSeen,
-		&lastSeen,
-		&eventCount,
-		&storedRepresentative,
-		&existingIssueNumber,
+		&row.id,
+		&row.issue.Fingerprint,
+		&row.storedMaterial,
+		&row.storedExplanation,
+		&row.issue.Title,
+		&row.issue.NormalizedTitle,
+		&row.issue.ExceptionType,
+		&row.status,
+		&row.muteMode,
+		&row.resolvedAt,
+		&row.reopenedAt,
+		&row.lastRegressedAt,
+		&row.regressionCount,
+		&row.firstSeen,
+		&row.lastSeen,
+		&row.eventCount,
+		&row.storedRepresentative,
+		&row.existingIssueNumber,
 	)
 	switch {
 	case err == nil:
-		existing = true
+		return row, true, nil
 	case errors.Is(err, sql.ErrNoRows):
-		existing = false
-	case err != nil:
-		return Issue{}, 0, false, err
+		return row, false, nil
+	default:
+		return row, false, err
+	}
+}
+
+// applyRegressionTransition decides whether a new event on an existing issue
+// constitutes a regression and mutates the issue's status/mute/regression fields
+// accordingly. It returns whether a regression occurred (which drives the UPDATE).
+func applyRegressionTransition(issue *Issue, muteMode string, seenAt time.Time) bool {
+	regressed := issue.Status == "resolved"
+
+	if muteMode == "until_regression" && (issue.Status == "resolved" || issue.Status == "muted") {
+		// A new event on a muted-until-regression issue triggers a regression.
+		regressed = true
 	}
 
-	if existing {
-		parsedFirstSeen, err := parseTime(firstSeen)
-		if err != nil {
-			return Issue{}, 0, false, err
-		}
-		parsedLastSeen, err := parseTime(lastSeen)
-		if err != nil {
-			return Issue{}, 0, false, err
-		}
-		issue.IssueNumber = existingIssueNumber
-		issue.FirstSeen = parsedFirstSeen
-		issue.LastSeen = parsedLastSeen
-		issue.EventCount = eventCount + 1
-		issue.Status = status
-		issue.RegressionCount = regressionCount
-		issue.FingerprintMaterial = storedMaterial
-		issue.ResolvedAt, _ = parseTime(resolvedAt)
-		issue.ReopenedAt, _ = parseTime(reopenedAt)
-		issue.LastRegressedAt, _ = parseTime(lastRegressedAt)
-		if err := unmarshalStringSlice(storedExplanation, &issue.FingerprintExplanation); err != nil {
-			return Issue{}, 0, false, err
-		}
-		if err := json.Unmarshal(storedRepresentative, &issue.RepresentativeEvent); err != nil {
-			return Issue{}, 0, false, err
-		}
-		if issue.FingerprintMaterial == "" {
-			issue.FingerprintMaterial = material
-		}
-		if len(issue.FingerprintExplanation) == 0 {
-			issue.FingerprintExplanation = explanation
-		}
-		if seenAt.After(issue.LastSeen) {
-			issue.LastSeen = seenAt
-		}
-
-		issue.MuteMode = muteMode
-		regressed := issue.Status == "resolved"
-
-		if existing && muteMode == "until_regression" && (issue.Status == "resolved" || issue.Status == "muted") {
-			// A new event on a muted-until-regression issue triggers a regression.
-			regressed = true
-		}
-
-		if regressed {
-			if muteMode == "forever" {
-				// Keep muted; don't change status.
-				regressed = false
-			} else {
-				newStatus := "unresolved"
-				if muteMode == "until_regression" {
-					newStatus = "regressed"
-					issue.MuteMode = "" // unmute now that regression occurred
-				}
-				issue.Status = newStatus
-				issue.RegressionCount++
-				issue.ReopenedAt = seenAt
-				issue.LastRegressedAt = seenAt
+	if regressed {
+		if muteMode == "forever" {
+			// Keep muted; don't change status.
+			regressed = false
+		} else {
+			newStatus := "unresolved"
+			if muteMode == "until_regression" {
+				newStatus = "regressed"
+				issue.MuteMode = "" // unmute now that regression occurred
 			}
+			issue.Status = newStatus
+			issue.RegressionCount++
+			issue.ReopenedAt = seenAt
+			issue.LastRegressedAt = seenAt
 		}
-
-		assignments := []string{
-			"last_seen = ?",
-			"event_count = event_count + 1",
-			"updated_at = CURRENT_TIMESTAMP",
-		}
-		args := []any{formatTime(issue.LastSeen)}
-		if regressed {
-			newStatus := issue.Status
-			assignments = append(assignments,
-				"status = ?",
-				"mute_mode = ?",
-				"reopened_at = ?",
-				"last_regressed_at = ?",
-				"regression_count = regression_count + 1",
-			)
-			args = append(args, newStatus, issue.MuteMode, formatTime(issue.ReopenedAt), formatTime(issue.LastRegressedAt))
-		}
-		args = append(args, id, projectID)
-
-		if _, err := tx.ExecContext(ctx, `
-UPDATE issues
-SET `+strings.Join(assignments, ", ")+`
-WHERE id = ? AND project_id = ?`,
-			args...,
-		); err != nil {
-			return Issue{}, 0, false, err
-		}
-
-		if err := tx.Commit(); err != nil {
-			return Issue{}, 0, false, err
-		}
-		issue.Fingerprint = fingerprintValue
-		issue.RepresentativeEvent = evt
-		// Set display ID for existing issue.
-		var existingPrefix string
-		_ = s.readDB().QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&existingPrefix)
-		issue.ID = displayIssueID(existingPrefix, existingIssueNumber, id)
-		return issue, id, regressed, nil
 	}
+	return regressed
+}
 
-	// Atomically increment the project's issue counter.
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE projects SET issue_counter = issue_counter + 1 WHERE id = ?`, projectID); err != nil {
-		return Issue{}, 0, false, err
-	}
-	var issueNumber int
-	var issuePrefix string
-	if err := tx.QueryRowContext(ctx,
-		`SELECT issue_counter, issue_prefix FROM projects WHERE id = ?`, projectID).Scan(&issueNumber, &issuePrefix); err != nil {
-		return Issue{}, 0, false, err
-	}
+type existingIssueParams struct {
+	projectID            int64
+	id                   int64
+	issue                Issue
+	eventCount           int
+	firstSeen            string
+	lastSeen             string
+	resolvedAt           string
+	reopenedAt           string
+	lastRegressedAt      string
+	regressionCount      int
+	status               string
+	muteMode             string
+	storedMaterial       string
+	storedExplanation    []byte
+	storedRepresentative []byte
+	existingIssueNumber  int
+	material             string
+	explanation          []string
+	seenAt               time.Time
+	evt                  event.Event
+	fingerprintValue     string
+}
 
-	issue = Issue{
-		Fingerprint:            fingerprintValue,
-		FingerprintMaterial:    material,
-		FingerprintExplanation: explanation,
-		Title:                  title,
-		NormalizedTitle:        normalizedTitle,
-		ExceptionType:          exceptionType,
-		Status:                 "unresolved",
-		FirstSeen:              seenAt,
-		LastSeen:               seenAt,
-		EventCount:             1,
-		RepresentativeEvent:    evt,
-		IssueNumber:            issueNumber,
-	}
-
-	res, err := tx.ExecContext(ctx, `
-INSERT INTO issues (
-	project_id,
-	fingerprint,
-	fingerprint_material,
-	fingerprint_explanation_json,
-	title,
-	normalized_title,
-	exception_type,
-	status,
-	first_seen,
-	last_seen,
-	event_count,
-	representative_event_json,
-	issue_number
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		projectID,
-		fingerprintValue,
-		material,
-		mustMarshalStrings(explanation),
-		title,
-		normalizedTitle,
-		exceptionType,
-		"unresolved",
-		formatTime(seenAt),
-		formatTime(seenAt),
-		1,
-		representative,
-		issueNumber,
-	)
+// updateExistingIssue computes the regression/mute transition for an existing
+// issue and applies the UPDATE within the open transaction.
+func (s *core) updateExistingIssue(ctx context.Context, tx *sql.Tx, p existingIssueParams) (Issue, int64, bool, error) {
+	issue, err := hydrateExistingIssue(p)
 	if err != nil {
 		return Issue{}, 0, false, err
 	}
 
-	id, err = res.LastInsertId()
-	if err != nil {
+	issue.MuteMode = p.muteMode
+	regressed := applyRegressionTransition(&issue, p.muteMode, p.seenAt)
+
+	if err := updateIssueRow(ctx, tx, issue, regressed, p.id, p.projectID); err != nil {
 		return Issue{}, 0, false, err
 	}
-	issue.ID = displayIssueID(issuePrefix, issueNumber, id)
 
 	if err := tx.Commit(); err != nil {
 		return Issue{}, 0, false, err
 	}
-
-	return issue, id, false, nil
+	issue.Fingerprint = p.fingerprintValue
+	issue.RepresentativeEvent = p.evt
+	// Set display ID for existing issue.
+	var existingPrefix string
+	_ = s.readDB().QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, p.projectID).Scan(&existingPrefix)
+	issue.ID = displayIssueID(existingPrefix, p.existingIssueNumber, p.id)
+	return issue, p.id, regressed, nil
 }
 
-func issueSeenAt(evt event.Event) time.Time {
-	if !evt.ObservedAt.IsZero() {
-		return evt.ObservedAt.UTC()
+// hydrateExistingIssue reconstructs the in-memory Issue from the scanned row
+// columns, parsing timestamps and decoding the stored JSON fields.
+func hydrateExistingIssue(p existingIssueParams) (Issue, error) {
+	issue := p.issue
+	parsedFirstSeen, err := parseTime(p.firstSeen)
+	if err != nil {
+		return Issue{}, err
 	}
-	if !evt.ReceivedAt.IsZero() {
-		return evt.ReceivedAt.UTC()
+	parsedLastSeen, err := parseTime(p.lastSeen)
+	if err != nil {
+		return Issue{}, err
 	}
-	return time.Now().UTC()
+	issue.IssueNumber = p.existingIssueNumber
+	issue.FirstSeen = parsedFirstSeen
+	issue.LastSeen = parsedLastSeen
+	issue.EventCount = p.eventCount + 1
+	issue.Status = p.status
+	issue.RegressionCount = p.regressionCount
+	issue.FingerprintMaterial = p.storedMaterial
+	issue.ResolvedAt, _ = parseTime(p.resolvedAt)
+	issue.ReopenedAt, _ = parseTime(p.reopenedAt)
+	issue.LastRegressedAt, _ = parseTime(p.lastRegressedAt)
+	if err := unmarshalStringSlice(p.storedExplanation, &issue.FingerprintExplanation); err != nil {
+		return Issue{}, err
+	}
+	if err := json.Unmarshal(p.storedRepresentative, &issue.RepresentativeEvent); err != nil {
+		return Issue{}, err
+	}
+	if issue.FingerprintMaterial == "" {
+		issue.FingerprintMaterial = p.material
+	}
+	if len(issue.FingerprintExplanation) == 0 {
+		issue.FingerprintExplanation = p.explanation
+	}
+	if p.seenAt.After(issue.LastSeen) {
+		issue.LastSeen = p.seenAt
+	}
+	return issue, nil
 }
 
-func issueDetails(evt event.Event) (title, normalizedTitle, exceptionType string) {
-	exceptionType = strings.TrimSpace(evt.Exception.Type)
-	message := strings.TrimSpace(evt.Exception.Message)
-	if message == "" {
-		message = strings.TrimSpace(evt.Message)
+// updateIssueRow builds the dynamic UPDATE assignments (adding the regression
+// columns when a regression occurred) and applies it within the transaction.
+func updateIssueRow(ctx context.Context, tx *sql.Tx, issue Issue, regressed bool, id, projectID int64) error {
+	assignments := []string{
+		"last_seen = ?",
+		"event_count = event_count + 1",
+		"updated_at = CURRENT_TIMESTAMP",
 	}
-
-	// When exception is empty, fall back to rawScrubbed data. This handles
-	// browser errors (promise rejections, cross-origin) that arrive with
-	// exception: {} but have details in rawScrubbed.
-	if exceptionType == "" && message == "" {
-		if raw := rawScrubbedFallback(evt.RawScrubbed); raw.name != "" || raw.message != "" {
-			exceptionType = strings.TrimSpace(raw.name)
-			message = strings.TrimSpace(raw.message)
-		}
+	args := []any{formatTime(issue.LastSeen)}
+	if regressed {
+		newStatus := issue.Status
+		assignments = append(assignments,
+			"status = ?",
+			"mute_mode = ?",
+			"reopened_at = ?",
+			"last_regressed_at = ?",
+			"regression_count = regression_count + 1",
+		)
+		args = append(args, newStatus, issue.MuteMode, formatTime(issue.ReopenedAt), formatTime(issue.LastRegressedAt))
 	}
+	args = append(args, id, projectID)
 
-	switch {
-	case exceptionType != "" && message != "":
-		title = exceptionType + ": " + message
-	case exceptionType != "":
-		title = exceptionType
-	default:
-		title = message
+	if _, err := tx.ExecContext(ctx, `
+UPDATE issues
+SET `+strings.Join(assignments, ", ")+`
+WHERE id = ? AND project_id = ?`,
+		args...,
+	); err != nil {
+		return err
 	}
-
-	const maxTitleLen = 512
-	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen]
-	}
-
-	normalizedTitle = normalizeTitle(title)
-	if len(normalizedTitle) > maxTitleLen {
-		normalizedTitle = normalizedTitle[:maxTitleLen]
-	}
-	return title, normalizedTitle, exceptionType
-}
-
-func normalizeTitle(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	value = uuidPattern.ReplaceAllString(value, "<id>")
-	value = ipv4Pattern.ReplaceAllString(value, "<ip>")
-	value = hexAddress.ReplaceAllString(value, "<hex>")
-	value = longNumber.ReplaceAllString(value, "<num>")
-	value = pathNumber.ReplaceAllString(value, "/:num")
-	value = whitespace.ReplaceAllString(value, " ")
-	value = trimPunctuation.ReplaceAllString(value, "")
-	return value
+	return nil
 }

--- a/internal/storage/logs.go
+++ b/internal/storage/logs.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -27,8 +28,6 @@ const logTrimInterval = 32
 // shared with event ingestion, so if a client disconnects we must abandon the
 // insert promptly rather than hold the connection. A short ceiling also bounds
 // how long any one batch can occupy the writer.
-//
-//nolint:gocognit,gocyclo // batched log writer with amortized retention trim; tracked for refactor.
 func (s *LogStore) InsertLogEntries(ctx context.Context, entries []LogEntry) error {
 	if len(entries) == 0 {
 		return nil
@@ -48,30 +47,7 @@ func (s *LogStore) InsertLogEntries(ctx context.Context, entries []LogEntry) err
 		if end > len(entries) {
 			end = len(entries)
 		}
-		chunk := entries[start:end]
-
-		var sb strings.Builder
-		sb.WriteString(`INSERT INTO log_entries (project_id, received_at, level_num, level, message, data_json) VALUES `)
-		args := make([]any, 0, len(chunk)*6)
-		for i, e := range chunk {
-			if i > 0 {
-				sb.WriteByte(',')
-			}
-			sb.WriteString(`(?, ?, ?, ?, ?, ?)`)
-
-			dataJSON := "{}"
-			if len(e.Data) > 0 {
-				if b, err := json.Marshal(e.Data); err == nil {
-					dataJSON = string(b)
-				}
-			}
-			receivedAt := e.ReceivedAt
-			if receivedAt.IsZero() {
-				receivedAt = time.Now().UTC()
-			}
-			args = append(args, e.ProjectID, receivedAt.UTC().Format(time.RFC3339Nano), e.LevelNum, e.Level, e.Message, dataJSON)
-		}
-		if _, err := tx.ExecContext(ctx, sb.String(), args...); err != nil {
+		if err := insertLogChunk(ctx, tx, entries[start:end]); err != nil {
 			return err
 		}
 	}
@@ -82,26 +58,63 @@ func (s *LogStore) InsertLogEntries(ctx context.Context, entries []LogEntry) err
 	// between trims is harmless. A batch large enough to breach the cap on its
 	// own always trims so the cap can't be blown past in a single call.
 	if len(entries) >= logTrimInterval || s.logInsertCount.Add(1)%logTrimInterval == 0 {
-		projectID := entries[0].ProjectID
-		var count int
-		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM log_entries WHERE project_id = ?`, projectID).Scan(&count); err != nil {
+		if err := trimLogRetention(ctx, tx, entries[0].ProjectID); err != nil {
 			return err
-		}
-		if count > logRetentionCap {
-			_, err = tx.ExecContext(ctx, `
-				DELETE FROM log_entries WHERE project_id = ? AND id <= (
-					SELECT MIN(id) FROM (
-						SELECT id FROM log_entries WHERE project_id = ? ORDER BY id DESC LIMIT ?
-					)
-				)
-			`, projectID, projectID, logRetentionCap)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
 	return tx.Commit()
+}
+
+// insertLogChunk writes one multi-row INSERT for a slice of log entries that is
+// already sized within the bound-parameter limit.
+func insertLogChunk(ctx context.Context, tx *sql.Tx, chunk []LogEntry) error {
+	var sb strings.Builder
+	sb.WriteString(`INSERT INTO log_entries (project_id, received_at, level_num, level, message, data_json) VALUES `)
+	args := make([]any, 0, len(chunk)*6)
+	for i, e := range chunk {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`(?, ?, ?, ?, ?, ?)`)
+
+		dataJSON := "{}"
+		if len(e.Data) > 0 {
+			if b, err := json.Marshal(e.Data); err == nil {
+				dataJSON = string(b)
+			}
+		}
+		receivedAt := e.ReceivedAt
+		if receivedAt.IsZero() {
+			receivedAt = time.Now().UTC()
+		}
+		args = append(args, e.ProjectID, receivedAt.UTC().Format(time.RFC3339Nano), e.LevelNum, e.Level, e.Message, dataJSON)
+	}
+	if _, err := tx.ExecContext(ctx, sb.String(), args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// trimLogRetention deletes the oldest log entries for a project beyond the
+// retention cap.
+func trimLogRetention(ctx context.Context, tx *sql.Tx, projectID int64) error {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM log_entries WHERE project_id = ?`, projectID).Scan(&count); err != nil {
+		return err
+	}
+	if count > logRetentionCap {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM log_entries WHERE project_id = ? AND id <= (
+				SELECT MIN(id) FROM (
+					SELECT id FROM log_entries WHERE project_id = ? ORDER BY id DESC LIMIT ?
+				)
+			)
+		`, projectID, projectID, logRetentionCap); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ListLogEntries returns up to limit entries for a project (or all projects when projectID=0), newest first.

--- a/internal/storage/migrate_fingerprints.go
+++ b/internal/storage/migrate_fingerprints.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"log/slog"
 
@@ -87,7 +88,6 @@ func (s *core) migrateFingerprints(ctx context.Context) error {
 	return nil
 }
 
-//nolint:gocognit // one-time fingerprint recompute/merge batch; tracked for refactor.
 func (s *core) applyFingerprintBatch(ctx context.Context, batch []fingerprintUpdate) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -106,45 +106,63 @@ func (s *core) applyFingerprintBatch(ctx context.Context, batch []fingerprintUpd
 		explanationJSON, _ := json.Marshal(u.newExplanation)
 
 		if err == nil {
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE events SET issue_id = ? WHERE issue_id = ?`,
-				keeperID, u.id); err != nil {
+			if err := mergeIntoKeeper(ctx, tx, u, keeperID); err != nil {
 				return err
 			}
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE event_facets SET issue_id = ? WHERE issue_id = ?`,
-				keeperID, u.id); err != nil {
-				return err
-			}
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE issues SET
-					event_count = (SELECT COUNT(*) FROM events WHERE issue_id = ?),
-					first_seen = (SELECT MIN(observed_at) FROM events WHERE issue_id = ?),
-					last_seen = (SELECT MAX(observed_at) FROM events WHERE issue_id = ?),
-					updated_at = CURRENT_TIMESTAMP
-				WHERE id = ?`,
-				keeperID, keeperID, keeperID, keeperID); err != nil {
-				return err
-			}
-			if _, err := tx.ExecContext(ctx, `DELETE FROM issues WHERE id = ?`, u.id); err != nil {
-				return err
-			}
-			slog.Info("merged issue", "from_id", u.id, "into_id", keeperID, "fingerprint", u.newFingerprint)
 		} else {
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE issues SET fingerprint = ?, fingerprint_material = ?, fingerprint_explanation_json = ?, updated_at = CURRENT_TIMESTAMP
-				WHERE id = ?`,
-				u.newFingerprint, u.newMaterial, string(explanationJSON), u.id); err != nil {
-				return err
-			}
-			if _, err := tx.ExecContext(ctx, `
-				UPDATE events SET fingerprint = ?, fingerprint_material = ?
-				WHERE issue_id = ?`,
-				u.newFingerprint, u.newMaterial, u.id); err != nil {
+			if err := rewriteFingerprint(ctx, tx, u, string(explanationJSON)); err != nil {
 				return err
 			}
 		}
 	}
 
 	return tx.Commit()
+}
+
+// mergeIntoKeeper folds issue u into the existing keeper issue that already
+// carries the recomputed fingerprint, then deletes u.
+func mergeIntoKeeper(ctx context.Context, tx *sql.Tx, u fingerprintUpdate, keeperID int64) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE events SET issue_id = ? WHERE issue_id = ?`,
+		keeperID, u.id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE event_facets SET issue_id = ? WHERE issue_id = ?`,
+		keeperID, u.id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE issues SET
+			event_count = (SELECT COUNT(*) FROM events WHERE issue_id = ?),
+			first_seen = (SELECT MIN(observed_at) FROM events WHERE issue_id = ?),
+			last_seen = (SELECT MAX(observed_at) FROM events WHERE issue_id = ?),
+			updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`,
+		keeperID, keeperID, keeperID, keeperID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM issues WHERE id = ?`, u.id); err != nil {
+		return err
+	}
+	slog.Info("merged issue", "from_id", u.id, "into_id", keeperID, "fingerprint", u.newFingerprint)
+	return nil
+}
+
+// rewriteFingerprint updates issue u and its events in place with the
+// recomputed fingerprint when no keeper issue exists to merge into.
+func rewriteFingerprint(ctx context.Context, tx *sql.Tx, u fingerprintUpdate, explanationJSON string) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE issues SET fingerprint = ?, fingerprint_material = ?, fingerprint_explanation_json = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`,
+		u.newFingerprint, u.newMaterial, explanationJSON, u.id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE events SET fingerprint = ?, fingerprint_material = ?
+		WHERE issue_id = ?`,
+		u.newFingerprint, u.newMaterial, u.id); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Final cleanup pass: reduce the complexity of the functions previously carrying `//nolint … tracked for refactor`, so the markers can be removed — now held to the tightened bar (gocyclo 12 / gocognit 18 / funlen 60-40).

**Method:** strictly **extract-method** — contiguous blocks lifted into named private helpers called at the same spot. No logic, conditions, SQL, error handling, or control flow reordered. Behavior is identical, verified by the real-SQLite storage suite + full-stack API integration tests, **including `-race`**.

| Area | Functions simplified |
|---|---|
| storage | `upsertIssue`, `ListIssuesFiltered`, `PersistFacets`, `InsertLogEntries`, `applyFingerprintBatch`, `QueryPageFlow` |
| api | `authenticateAndResolve` → `checkAPIKeyScope`/`refreshCSRFCookie`/`resolveProjectScope`/`resolveProjectID`/`applyGroupScope`; `serveSpecialEndpoint` → per-endpoint handlers; `dispatchProtected` → per-domain dispatchers |

All targeted nolints removed except `servePublicEndpoint` (a flat public-route table — splitting it would game the metric without improving readability, so it keeps its marker).

I personally reviewed the two highest-risk diffs: the **auth pipeline** (early-return `(r,false)` semantics + ordering preserved) and the **ingest write path** (`applyRegressionTransition` regression/mute logic byte-for-byte; the only delta is dropping an always-true `existing &&` guard inside the existing-issue branch).

**Verification:** `go build ./...`, full `go test ./...`, `-race` on storage+api, golangci-lint diff-mode (0 issues), gofmt clean — all green.