### PR TITLE
ci(binary-release): fix nfpm on self-hosted, drop dead npm/pypi publish jobs

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -121,7 +121,11 @@ jobs:
           cache: true
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        env:
+          # The self-hosted runner pins GOTOOLCHAIN=local and ships go1.26.2;
+          # nfpm's pinned release needs a newer toolchain. Allow Go to fetch it.
+          GOTOOLCHAIN: auto
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.47.0
 
       - name: Build binaries
         env:
@@ -478,68 +482,3 @@ jobs:
             git commit -m "Update formula to ${VERSION}"
             git push
           fi
-
-  # ---------------------------------------------------------------------------
-  # TypeScript SDK — publish to npm
-  # ---------------------------------------------------------------------------
-  publish-npm:
-    needs: [tag]
-    runs-on: [self-hosted, build]
-    defaults:
-      run:
-        working-directory: sdks/typescript
-    steps:
-      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
-        shell: bash
-        run: |
-          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
-            [ -d "$c" ] || continue
-            chmod -R u+w "$c" 2>/dev/null || true
-            rm -rf "$c" 2>/dev/null || true
-          done
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  # ---------------------------------------------------------------------------
-  # Python SDK — publish to PyPI
-  # ---------------------------------------------------------------------------
-  publish-pypi:
-    needs: [tag]
-    runs-on: [self-hosted, build]
-    defaults:
-      run:
-        working-directory: sdks/python
-    steps:
-      - name: Reclaim workspaces (clear read-only Go cache from prior runs)
-        shell: bash
-        run: |
-          for c in "$HOME"/github-runners/*/_work/bugbarn/bugbarn/.cache; do
-            [ -d "$c" ] || continue
-            chmod -R u+w "$c" 2>/dev/null || true
-            rm -rf "$c" 2>/dev/null || true
-          done
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install build tools
-        run: pip install build twine
-      - name: Build
-        run: python -m build
-      - name: Test before publish
-        run: pip install -e ".[dev]" && python -m pytest tests/ -v
-      - name: Publish to PyPI
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Follow-up to the self-hosted migration (#150). The first post-merge `binary-release` run surfaced one migration regression and two long-standing dead jobs.

## nfpm toolchain (migration regression)

`go install nfpm@latest` failed on the self-hosted runner:
```
nfpm/v2@v2.47.0 requires go >= 1.26.4 (running go 1.26.2; GOTOOLCHAIN=local)
```
The runner pins `GOTOOLCHAIN=local` and ships go1.26.2, so Go won't fetch the newer toolchain unpinned nfpm now needs. Fixed by pinning `nfpm@v2.47.0` and setting `GOTOOLCHAIN: auto` on that step (reproducible; lets Go fetch the toolchain). The macOS/linux Go *builds* already passed — only the external-tool install was affected.

## Remove publish-npm + publish-pypi (pre-existing, never worked)

Both jobs have failed on **every** binary-release run for weeks, independent of the runner:
- `publish-npm`: `404 Scope not found — @bugbarn/typescript`; the `@bugbarn` npm org doesn't exist, version hardcoded to `1.0.0`.
- `publish-pypi`: PyPI upload never configured (failed at `twine upload` on ubuntu; at `setup-python` on self-hosted).

They never published anything, so they're removed to make `binary-release` fully green. SDK publishing can be reintroduced when the npm org / PyPI project / tokens and a version-bumping scheme actually exist.

## Result

`binary-release` jobs now: tag, build-debs (×2), build-darwin-tarballs (×2), attach-debs/​tarballs-to-release, update-brew-repo, update-homebrew-tap — all on `[self-hosted, build]`. The other parts of the first post-merge run already succeeded on self-hosted (tag, darwin builds, brew/apt publish via the awscli venv fix, release attach).