### PR TITLE
fix(digest): add covering index for weekly top-issues query (timeout fix)

### DIFF
--- a/internal/storage/migrations/00007_events_digest_covering_index.sql
+++ b/internal/storage/migrations/00007_events_digest_covering_index.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- The weekly digest's top-issues query aggregates events per issue within a
+-- 7-day window per project:
+--   SELECT i.id, ..., COUNT(e.id) FROM events e JOIN issues i ON i.id = e.issue_id
+--   WHERE e.project_id = ? AND e.received_at >= ? GROUP BY i.id ...
+-- idx_events_project_received_at is (project_id, received_at, id) and does NOT
+-- carry issue_id, so the GROUP BY forced a table rowid lookup for every event in
+-- the window. For high-volume projects (tens of thousands of events/week) that
+-- was tens of thousands of random lookups per project, run serially across the
+-- whole fleet under one timeout — the digest's "context deadline exceeded".
+-- Adding issue_id makes the scan covering: issue_id is read straight from the
+-- index, so no per-event table access.
+CREATE INDEX IF NOT EXISTS idx_events_project_received_issue
+  ON events(project_id, received_at DESC, issue_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_project_received_issue;


### PR DESCRIPTION
## Problem

`bugbarn-service` self-reports the weekly digest failing daily at 08:00 with `digest: ... context deadline exceeded` — 8 open issues, all the same family, with the **videoslop-* entries newly appearing 06-28**.

## Root cause (confirmed via EXPLAIN QUERY PLAN)

`digest.Send` loops serially over all ~45 projects under a single 10s budget (`scheduler.go`), calling `WeeklyDigest` per project. Four of its five queries are properly indexed (two covering). The fifth — top issues — is not:

```sql
SELECT i.id, i.title, COUNT(e.id), i.status
FROM events e JOIN issues i ON i.id = e.issue_id
WHERE e.project_id = ? AND e.received_at >= ?
GROUP BY i.id ORDER BY event_count DESC LIMIT 5
```

`idx_events_project_received_at` is `(project_id, received_at, id)` — **no `issue_id`**. EXPLAIN before:

```
SEARCH e USING INDEX idx_events_project_received_at (project_id=? AND received_at>?)   ← non-covering
SEARCH i USING INTEGER PRIMARY KEY (rowid=?)
```

So the `GROUP BY` does a table rowid lookup for **every event in the 7-day window** to read `issue_id`. For high-volume projects (videoslop ~36k, load-test ~90k events) that's tens of thousands of random lookups per project, serially, under one shared deadline → timeout.

## Fix

Add a covering index `(project_id, received_at DESC, issue_id)` (migration `00007`). EXPLAIN after:

```
SEARCH e USING COVERING INDEX idx_events_project_received_issue (project_id=? AND received_at>?)
```

`issue_id` is read straight from the index — no per-event table access. With covering scans, each project's queries are sub-millisecond, so the fleet fits comfortably in the existing 10s budget (no timeout change needed).

## Verification

- `EXPLAIN QUERY PLAN` before/after against the real migrated schema (non-covering → COVERING).
- Migration applies cleanly in the full goose sequence; `go build ./...` and `go test ./internal/storage/...` pass.
- Index auto-applies on deploy (goose `//go:embed migrations/*.sql`).

Closes the BS2-88 digest-timeout family once deployed (the daily 08:00 self-report should stop).