### PR TITLE
fix(deploy): writer deploy resilience + litestream sole checkpointer (band-aid)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -133,6 +133,19 @@ jobs:
             echo "ERROR: missing image digests from preflight job" >&2
             exit 1
           fi
+          # Capture the currently-running images BEFORE mutating so a failed
+          # rollout can be reverted to the last-good digest. `kubectl rollout
+          # undo` must NOT be used: `apply -k` first sets the kustomize ":local"
+          # placeholder (an unpullable tag), creating an intermediate revision
+          # that undo would roll back to — which is exactly what broke the writer.
+          SVC_OLD=$(ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" \
+            "kubectl -n ${NAMESPACE} get deployment/bugbarn-writer -o jsonpath='{.spec.template.spec.containers[0].image}'" || true)
+          WEB_OLD=$(ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" \
+            "kubectl -n ${NAMESPACE} get deployment/bugbarn-web -o jsonpath='{.spec.template.spec.containers[0].image}'" || true)
+          echo "SVC_OLD=${SVC_OLD}" >> "$GITHUB_ENV"
+          echo "WEB_OLD=${WEB_OLD}" >> "$GITHUB_ENV"
+          echo "Captured rollback targets: service=${SVC_OLD:-<none>} web=${WEB_OLD:-<none>}"
+
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             set -euo pipefail
             kubectl apply -k /tmp/bugbarn-deploy/deploy/k8s/production
@@ -146,7 +159,9 @@ jobs:
               bugbarn=${SERVICE_IMAGE}@${SERVICE_DIGEST}
             kubectl -n ${NAMESPACE} set image deployment/bugbarn-web \
               bugbarn-web=${WEB_IMAGE}@${WEB_DIGEST}
-            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=180s
+            # Writer runs migrations on startup (gated by its startupProbe), so it
+            # may take minutes — allow more time than the stateless reader/web.
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=600s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-reader --timeout=180s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-web --timeout=180s
           "
@@ -154,11 +169,21 @@ jobs:
       - name: Rollback on failure
         if: failure()
         run: |
+          set -uo pipefail
+          # Restore the digests captured before the deploy. Never roll back to a
+          # ":local" placeholder (unpullable). If no safe target was captured,
+          # leave the deployment as-is for manual inspection rather than break it.
+          case "${SVC_OLD:-}" in
+            ""|*:local)
+              echo "::warning::No safe rollback target captured (SVC_OLD='${SVC_OLD:-}'); leaving deployment for manual inspection."
+              exit 0
+              ;;
+          esac
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
-            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-writer || true
-            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-reader || true
-            kubectl -n ${NAMESPACE} rollout undo deployment/bugbarn-web || true
-            echo 'Rollback triggered'
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-writer bugbarn=${SVC_OLD} || true
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-reader bugbarn=${SVC_OLD} || true
+            kubectl -n ${NAMESPACE} set image deployment/bugbarn-web bugbarn-web=${WEB_OLD} || true
+            echo 'Rolled back to last-good digests'
           " || true
 
       - name: Post release marker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,9 @@ jobs:
               bugbarn=${SERVICE_IMAGE}@${SERVICE_DIGEST}
             kubectl -n ${NAMESPACE} set image deployment/bugbarn-web \
               bugbarn-web=${WEB_IMAGE}@${WEB_DIGEST}
-            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=180s
+            # Writer runs migrations on startup (gated by its startupProbe), so
+            # allow more time than the stateless reader/web.
+            kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-writer --timeout=600s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-reader --timeout=180s
             kubectl -n ${NAMESPACE} rollout status deployment/bugbarn-web --timeout=180s
           "

--- a/deploy/k8s/production/writer-deployment.yaml
+++ b/deploy/k8s/production/writer-deployment.yaml
@@ -199,6 +199,15 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # The writer runs DB migrations before opening :8080. A slow migration
+          # (e.g. building an index on a large table) must not trip liveness, so
+          # gate liveness behind a startupProbe that allows up to 10m of startup.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /api/v1/health

--- a/deploy/k8s/staging/writer-deployment.yaml
+++ b/deploy/k8s/staging/writer-deployment.yaml
@@ -185,6 +185,15 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          # The writer runs DB migrations before opening :8080. A slow migration
+          # (e.g. building an index on a large table) must not trip liveness, so
+          # gate liveness behind a startupProbe that allows up to 10m of startup.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /api/v1/health

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -108,7 +108,11 @@ func sqliteDSN(path string) string {
 		Scheme: "file",
 		Path:   filepath.ToSlash(path),
 	}
-	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=synchronous(normal)"
+	// wal_autocheckpoint(0) disables SQLite's built-in autocheckpoint so that
+	// Litestream is the SOLE checkpointer. With both active they race for the
+	// write lock and spam "database is locked"; the writer owns writes,
+	// Litestream owns checkpointing.
+	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=wal_autocheckpoint(0)&_pragma=synchronous(normal)"
 }
 
 func sqliteReadOnlyDSN(path string) string {

--- a/internal/storage/helpers.go
+++ b/internal/storage/helpers.go
@@ -112,7 +112,16 @@ func sqliteDSN(path string) string {
 	// Litestream is the SOLE checkpointer. With both active they race for the
 	// write lock and spam "database is locked"; the writer owns writes,
 	// Litestream owns checkpointing.
-	return u.String() + "?mode=rwc&_txlock=immediate&_pragma=busy_timeout(10000)&_pragma=foreign_keys(1)&_pragma=journal_mode(wal)&_pragma=wal_autocheckpoint(0)&_pragma=synchronous(normal)"
+	params := strings.Join([]string{
+		"mode=rwc",
+		"_txlock=immediate",
+		"_pragma=busy_timeout(10000)",
+		"_pragma=foreign_keys(1)",
+		"_pragma=journal_mode(wal)",
+		"_pragma=wal_autocheckpoint(0)",
+		"_pragma=synchronous(normal)",
+	}, "&")
+	return u.String() + "?" + params
 }
 
 func sqliteReadOnlyDSN(path string) string {


### PR DESCRIPTION
Band-aid for the prod incident during the digest-index deploy. The root trigger was the **writer being down ~1h**, which created a Redis backlog that the readers-on-the-live-file design can't drain through — so this hardens the deploy so the writer never gets stuck like that again, plus stops the two-checkpointer fight. (The deeper fix — readers off the live SQLite file — is deliberately *not* here; tracked separately.)

## What broke

Deploying migration `00007` (`CREATE INDEX`) failed and left the writer with no healthy pod:

1. **No `startupProbe`.** The writer runs `goose` migrations *before* opening :8080. The index build on prod's large `events` table took **~2.5 min**, but `livenessProbe` starts killing at ~90s → pod killed mid-migration → restart loop, migration never finishes.
2. **Rollback reverted to `:local`.** The deploy does `apply -k` (sets the kustomize `:local` placeholder) then `set image @digest`; on failure `kubectl rollout undo` rolled back to that `:local` revision → `ImagePullBackOff`. **The rollback is what actually took the writer down.**
3. **Rollout timeout too short** (180s) for a multi-minute migration.
4. **Two checkpointers.** The write DSN enabled WAL but left SQLite autocheckpoint on, racing Litestream for the write lock → `database is locked` ~1/sec, WAL never truncating.

## Fixes

| # | Change | File(s) |
|---|---|---|
| 1 | Add `startupProbe` (up to 10m) gating liveness until startup/migration completes | `deploy/k8s/{production,staging}/writer-deployment.yaml` |
| 2 | Capture running digests pre-deploy; roll back via `set image` to them; **never** to `:local` | `deploy-production.yml` |
| 3 | Writer `rollout status` timeout 180s → 600s (reader/web stay 180s) | `deploy-production.yml`, `release.yml` |
| 4 | `wal_autocheckpoint(0)` so Litestream is the sole checkpointer | `internal/storage/helpers.go` |

## Not in scope (follow-up)

The structural cause of WAL/checkpoint contention is that **6 reader pods open the writer's live SQLite file** over a shared PVC, so there's never a quiet window to checkpoint. The real fix is readers off the live file (e.g. a Litestream-restored read replica). Tracked for later — these four changes keep steady-state healthy and make deploys survive slow migrations.

## Verification

- `go build ./...` + `go test ./internal/storage/...` pass.
- `kubectl kustomize` builds clean for production + staging with the `startupProbe`.
- Workflow YAML validated.
- Prod was already manually restored (writer healthy; backlog draining 4607 → ~1900 and falling). This PR makes that state durable and prevents recurrence.