### PR TITLE
ci(quality): allow parallel golangci-lint runners (fix flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,8 +247,12 @@ jobs:
           GCL="${GITHUB_WORKSPACE}/.tools/golangci-lint"
           BASE="${{ github.base_ref || 'main' }}"
           git fetch --no-tags origin "$BASE" || true
-          "$GCL" run --new-from-rev="origin/$BASE" ./...
-          cd sdks/go && "$GCL" run --new-from-rev="origin/$BASE" ./...
+          # --allow-parallel-runners: the self-hosted runners share $HOME, so
+          # golangci-lint's machine-global lock collides when two CI jobs lint
+          # concurrently ("parallel golangci-lint is running"). This flag skips
+          # that lock so concurrent runs no longer flake.
+          "$GCL" run --allow-parallel-runners --new-from-rev="origin/$BASE" ./...
+          cd sdks/go && "$GCL" run --allow-parallel-runners --new-from-rev="origin/$BASE" ./...
       - name: Go coverage ratchet
         shell: bash
         run: sh scripts/check-coverage.sh


### PR DESCRIPTION
## Problem

The `quality` job intermittently fails with:
```
Error: parallel golangci-lint is running
```
golangci-lint takes a **machine-global file lock** (in its cache dir). The self-hosted build runners all run as the same user with `HOME=/Users/wiebe`, so when two CI jobs (different PRs/runs) land on the same runner and lint concurrently, the second one hits the lock and fails. It flaked multiple times this week and needed manual `gh run rerun`.

## Fix

Pass `--allow-parallel-runners` to both `golangci-lint run` invocations in the `quality` job. The flag is purpose-built for this ("Allow multiple parallel golangci-lint instances running") and is present in the pinned **v2.11.4**. Concurrent runs no longer contend for the lock.

## Verification
- `--allow-parallel-runners` confirmed in `golangci-lint run --help` for v2.11.4.
- ci.yml YAML validated.