### PR TITLE
perf(storage): drop two dead event_facets indexes

### DIFF
--- a/internal/storage/migrations/00008_event_facets_index_diet.sql
+++ b/internal/storage/migrations/00008_event_facets_index_diet.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- event_facets carried 4 indexes over ~2.25M rows (a large share of the DB).
+-- Two of them are dead weight — no query in the codebase uses their leading
+-- columns:
+--   - idx_event_facets_lookup leads with `section`, which no query ever filters
+--     on (the column is written but never read by a WHERE clause).
+--   - idx_event_facets_issue leads with issue_id, which no query ever filters on
+--     (issue_id only ever appears as a SELECTed result column).
+-- Every per-project access pattern — the ingest write-path cardinality/existence
+-- checks and the UI's per-project facet-value listing and "filter issues by
+-- facet" — is already served by idx_event_facets_kv_issue
+-- (project_id, facet_key, facet_value, issue_id), so dropping these two changes
+-- no behaviour and removes no capability.
+--
+-- (idx_event_facets_facet, which serves only cross-project (projectID=0) facet
+-- queries that the API never issues, is intentionally NOT dropped here: removing
+-- it also requires removing the cross-project facet code path so it can't fall
+-- back to a full scan. Tracked separately.)
+--
+-- The freed pages go to the freelist; run VACUUM during a quiet window to shrink
+-- the file on disk.
+DROP INDEX IF EXISTS idx_event_facets_lookup;
+DROP INDEX IF EXISTS idx_event_facets_issue;
+
+-- +goose Down
+CREATE INDEX IF NOT EXISTS idx_event_facets_lookup ON event_facets(project_id, section, facet_key, facet_value);
+CREATE INDEX IF NOT EXISTS idx_event_facets_issue ON event_facets(project_id, issue_id, facet_key, facet_value);


### PR DESCRIPTION
## Why

`event_facets` is **~2.25 M rows** and carried **4 indexes** — a big share of the 4.3 GB prod DB (most of the ~2.5 GB of index in the file). A trace of every query against the table (storage → service → API → `web/`) shows two of those indexes are never used:

| Index | Leading column | Used by any query? |
|---|---|---|
| `idx_event_facets_lookup` | `section` | **No** — `section` is written on insert but never appears in a WHERE clause |
| `idx_event_facets_issue` | `issue_id` | **No** — `issue_id` is only ever a SELECTed result column, never a filter |

Everything the system actually does is per-project and already **covered** by `idx_event_facets_kv_issue (project_id, facet_key, facet_value, issue_id)`:
- ingest write-path cardinality/existence checks (the 2026-06-21 hot path),
- the UI's per-project facet-value listing (environment switcher),
- the UI's per-project "filter issues by facet".

## Verification

`EXPLAIN QUERY PLAN` after the drop — all remain `COVERING INDEX idx_event_facets_kv_issue`, no full scans:
```
write-path existence : SEARCH ... USING COVERING INDEX idx_event_facets_kv_issue (project_id=? AND facet_key=? AND facet_value=?)
UI facet values      : SEARCH ... USING COVERING INDEX idx_event_facets_kv_issue (project_id=? AND facet_key=?)
UI issue filter      : SEARCH ... USING COVERING INDEX idx_event_facets_kv_issue (project_id=? AND facet_key=? AND facet_value=?)
```
`go build ./...` + `go test ./internal/storage/...` pass (incl. `TestFacetReadQueriesUseIndexes`). No behaviour or capability change.

## Notes / follow-ups (not in this PR)

- `idx_event_facets_facet` (cross-project, projectID=0) is **kept** — dropping it requires also removing the cross-project facet code path (`buildIssueFromClause` `allProjects` branch + `ListFacetKeys/Values` projectID=0 branches) so it can't fall back to a 2.25 M-row scan. That's a capability removal worth doing deliberately (the UI never issues cross-project facet queries) — tracked separately.
- `DROP INDEX` frees pages to the freelist; the file shrinks only after a **VACUUM** (run during a quiet window).
- Bigger win still ahead: event/facet **retention** + the "smarter projection" (dedup facets to issue-level) — see the DB-size analysis.