### PR TITLE
perf(storage): drop two dead event_facets indexes

### DIFF
--- a/internal/storage/migrations/00008_event_facets_index_diet.sql
+++ b/internal/storage/migrations/00008_event_facets_index_diet.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- event_facets carried 4 indexes over ~2.25M rows (a large share of the DB).
+-- Two of them are dead weight — no query in the codebase uses their leading
+-- columns:
+--   - idx_event_facets_lookup leads with `section`, which no query ever filters
+--     on (the column is written but never read by a WHERE clause).
+--   - idx_event_facets_issue leads with issue_id, which no query ever filters on
+--     (issue_id only ever appears as a SELECTed result column).
+-- Every per-project access pattern — the ingest write-path cardinality/existence
+-- checks and the UI's per-project facet-value listing and "filter issues by
+-- facet" — is already served by idx_event_facets_kv_issue
+-- (project_id, facet_key, facet_value, issue_id), so dropping these two changes
+-- no behaviour and removes no capability.
+--
+-- (idx_event_facets_facet, which serves only cross-project (projectID=0) facet
+-- queries that the API never issues, is intentionally NOT dropped here: removing
+-- it also requires removing the cross-project facet code path so it can't fall
+-- back to a full scan. Tracked separately.)
+--
+-- The freed pages go to the freelist; run VACUUM during a quiet window to shrink
+-- the file on disk.
+DROP INDEX IF EXISTS idx_event_facets_lookup;
+DROP INDEX IF EXISTS idx_event_facets_issue;
+
+-- +goose Down
+CREATE INDEX IF NOT EXISTS idx_event_facets_lookup ON event_facets(project_id, section, facet_key, facet_value);
+CREATE INDEX IF NOT EXISTS idx_event_facets_issue ON event_facets(project_id, issue_id, facet_key, facet_value);


### PR DESCRIPTION
Drops `idx_event_facets_lookup` (leads with `section`, never filtered) and `idx_event_facets_issue` (leads with `issue_id`, never filtered) from `event_facets` (~2.25 M rows). Every real per-project query — ingest write-path checks, UI facet-value listing, UI filter-issues-by-facet — stays a COVERING lookup on `idx_event_facets_kv_issue` (verified via EXPLAIN). No behaviour/capability change. `idx_event_facets_facet` (cross-project) intentionally kept pending the cross-project capability review.

Reopen of #156 (that PR got auto-closed by a failed out-of-date merge). Build + `go test ./internal/storage/...` green. See #157 for the broader DB-size roadmap.