### PR TITLE
perf(storage): drop cross-project facet index + capability

### DIFF
--- a/internal/storage/facets.go
+++ b/internal/storage/facets.go
@@ -212,23 +212,14 @@ func persistFacet(
 	return isNewKey, nil
 }
 
-// ListFacetKeys returns all distinct facet keys observed for a project.
-// Pass projectID=0 to query across all projects.
+// ListFacetKeys returns all distinct facet keys observed for a project. It is
+// always project-scoped: cross-project facet listing is intentionally not
+// supported (no index backs it, and no caller needs it).
 func (s *FacetStore) ListFacetKeys(ctx context.Context, projectID int64) ([]string, error) {
-	var (
-		rows *sql.Rows
-		err  error
+	rows, err := s.readDB().QueryContext(ctx,
+		`SELECT DISTINCT facet_key FROM event_facets WHERE project_id = ? ORDER BY facet_key ASC`,
+		projectID,
 	)
-	if projectID != 0 {
-		rows, err = s.readDB().QueryContext(ctx,
-			`SELECT DISTINCT facet_key FROM event_facets WHERE project_id = ? ORDER BY facet_key ASC`,
-			projectID,
-		)
-	} else {
-		rows, err = s.readDB().QueryContext(ctx,
-			`SELECT DISTINCT facet_key FROM event_facets ORDER BY facet_key ASC`,
-		)
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -245,24 +236,14 @@ func (s *FacetStore) ListFacetKeys(ctx context.Context, projectID int64) ([]stri
 	return keys, rows.Err()
 }
 
-// ListFacetValues returns all distinct values observed for a facet key in a project.
-// Pass projectID=0 to query across all projects.
+// ListFacetValues returns all distinct values observed for a facet key in a
+// project. It is always project-scoped: cross-project facet listing is
+// intentionally not supported (no index backs it, and no caller needs it).
 func (s *FacetStore) ListFacetValues(ctx context.Context, projectID int64, key string) ([]string, error) {
-	var (
-		rows *sql.Rows
-		err  error
+	rows, err := s.readDB().QueryContext(ctx,
+		`SELECT DISTINCT facet_value FROM event_facets WHERE project_id = ? AND facet_key = ? ORDER BY facet_value ASC`,
+		projectID, key,
 	)
-	if projectID != 0 {
-		rows, err = s.readDB().QueryContext(ctx,
-			`SELECT DISTINCT facet_value FROM event_facets WHERE project_id = ? AND facet_key = ? ORDER BY facet_value ASC`,
-			projectID, key,
-		)
-	} else {
-		rows, err = s.readDB().QueryContext(ctx,
-			`SELECT DISTINCT facet_value FROM event_facets WHERE facet_key = ? ORDER BY facet_value ASC`,
-			key,
-		)
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/facets_test.go
+++ b/internal/storage/facets_test.go
@@ -196,11 +196,11 @@ func TestPersistFacetsExistenceChecksUseIndex(t *testing.T) {
 	}
 }
 
-// TestFacetReadQueriesUseIndexes guards the facet read/filter paths (migration
-// 00005). The cross-project ("all projects") variants filter on facet_key with
-// no project_id; before the facet-leading index they full-scanned event_facets.
-// The project-scoped facet→issue filter needs issue_id in the index to avoid a
-// per-row table lookup.
+// TestFacetReadQueriesUseIndexes guards the project-scoped facet→issue filter:
+// it needs issue_id in idx_event_facets_kv_issue to stay covering and avoid a
+// per-row table lookup. Cross-project facet querying is intentionally not
+// supported (migration 00009 dropped idx_event_facets_facet and the code paths),
+// so there are no cross-project cases here.
 func TestFacetReadQueriesUseIndexes(t *testing.T) {
 	t.Parallel()
 
@@ -216,23 +216,6 @@ func TestFacetReadQueriesUseIndexes(t *testing.T) {
 		args      []any
 		wantIndex string
 	}{
-		{
-			name:      "cross-project distinct facet keys",
-			query:     `SELECT DISTINCT facet_key FROM event_facets ORDER BY facet_key ASC`,
-			wantIndex: "idx_event_facets_facet",
-		},
-		{
-			name:      "cross-project distinct facet values for a key",
-			query:     `SELECT DISTINCT facet_value FROM event_facets WHERE facet_key = ? ORDER BY facet_value ASC`,
-			args:      []any{"host.name"},
-			wantIndex: "idx_event_facets_facet",
-		},
-		{
-			name:      "cross-project issue filter by facet",
-			query:     `SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`,
-			args:      []any{"host.name", "web-01"},
-			wantIndex: "idx_event_facets_facet",
-		},
 		{
 			name:      "project-scoped issue filter by facet (covering)",
 			query:     `SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`,

--- a/internal/storage/issues.go
+++ b/internal/storage/issues.go
@@ -41,7 +41,7 @@ func (s *IssueStore) ListIssuesFiltered(ctx context.Context, filter IssueFilter)
 
 	// fromArgs holds bindings for subquery ?-placeholders in the FROM clause.
 	// They must come before whereArgs in the final args slice.
-	fromClause, fromArgs := buildIssueFromClause(facetFilters, projectID, allProjects)
+	fromClause, fromArgs := buildIssueFromClause(facetFilters, projectID)
 
 	// Combine: subquery bindings first (appear in FROM clause), then WHERE bindings.
 	args := append(fromArgs, whereArgs...)
@@ -133,24 +133,21 @@ func collectFacetFilters(filter IssueFilter) []facetFilter {
 // buildIssueFromClause builds the FROM clause (and its subquery bind args) for
 // the issue list query. When facet filters are present it joins an INTERSECT
 // subquery that enforces AND semantics across all filters.
-func buildIssueFromClause(facetFilters []facetFilter, projectID int64, allProjects bool) (string, []any) {
+func buildIssueFromClause(facetFilters []facetFilter, projectID int64) (string, []any) {
 	if len(facetFilters) == 0 {
 		return "issues i LEFT JOIN projects p ON p.id = i.project_id", nil
 	}
 	// Build an INTERSECT subquery: one branch per facet filter that returns
 	// matching issue_ids. The join enforces AND semantics across all filters.
+	// Always project-scoped — facet filtering across all projects is intentionally
+	// unsupported (no backing index, no caller needs it). With projectID==0 the
+	// subquery matches nothing rather than full-scanning every project's facets.
 	var fromArgs []any
 	var subqueries []string
 	for _, f := range facetFilters {
-		if !allProjects {
-			subqueries = append(subqueries,
-				`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
-			fromArgs = append(fromArgs, projectID, f.k, f.v)
-		} else {
-			subqueries = append(subqueries,
-				`SELECT DISTINCT issue_id FROM event_facets WHERE facet_key = ? AND facet_value = ?`)
-			fromArgs = append(fromArgs, f.k, f.v)
-		}
+		subqueries = append(subqueries,
+			`SELECT DISTINCT issue_id FROM event_facets WHERE project_id = ? AND facet_key = ? AND facet_value = ?`)
+		fromArgs = append(fromArgs, projectID, f.k, f.v)
 	}
 	fromClause := fmt.Sprintf(`issues i INNER JOIN (%s) ef ON i.id = ef.issue_id LEFT JOIN projects p ON p.id = i.project_id`,
 		strings.Join(subqueries, " INTERSECT "))

--- a/internal/storage/migrations/00009_event_facets_drop_cross_project_index.sql
+++ b/internal/storage/migrations/00009_event_facets_drop_cross_project_index.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Drop idx_event_facets_facet (facet_key, facet_value, issue_id). It served ONLY
+-- cross-project (projectID=0) facet queries: list-all-keys, list-all-values, and
+-- filter-issues-by-facet across every project. Nothing reachable issues those —
+-- the facets endpoint always resolves a concrete project, and the all-projects /
+-- group UI scopes deliberately carry no facet filter. The cross-project facet
+-- code paths are removed in the same change (ListFacetKeys/ListFacetValues and
+-- buildIssueFromClause are now always project-scoped), so a stray query can't
+-- silently fall back to a full scan of ~2.25M rows. Removing this 3-column index
+-- reclaims a meaningful chunk of the DB.
+DROP INDEX IF EXISTS idx_event_facets_facet;
+
+-- +goose Down
+CREATE INDEX IF NOT EXISTS idx_event_facets_facet ON event_facets(facet_key, facet_value, issue_id);


### PR DESCRIPTION
Follow-up to #158. Removes the **last** redundant `event_facets` index — `idx_event_facets_facet (facet_key, facet_value, issue_id)` — and the cross-project facet capability it backed. After this, `event_facets` has **one** index (`idx_event_facets_kv_issue`), down from four.

## Safety check (you flagged the all-projects view)

Traced every facet path storage → service → API → `web/`. `idx_event_facets_facet` only ever served **cross-project (projectID=0)** queries, and **nothing reachable issues one**:
- The facets endpoint (`/api/v1/facets/...`) always resolves a **concrete** project (context value or `DefaultProjectID()`), never 0.
- The **all-projects (`__all`) and group scopes** deliberately clear the environment filter — group selection sets `currentProject="__all"` + `currentEnv=""`, `__all` renders an empty env switcher, and the issue query only sends `attributes.environment` `if (state.currentEnv)`. So all-projects/group issue queries carry **no facet filter** → `buildIssueFromClause` takes the no-facet branch and never touches `event_facets`.
- `loadEnvironments`/`loadScopeEnvs` are gated to concrete-project scope only.
- The `bb` CLI sends `X-BugBarn-Group` but **no** facet params.

## What changed

To make the guarantee structural (not "the UI happens not to"), the cross-project code paths are removed so a stray query can't silently full-scan ~2.25 M rows:
- `ListFacetKeys`/`ListFacetValues` → always project-scoped.
- `buildIssueFromClause` → always project-scoped facet subquery (drops the unused `allProjects` param); `projectID==0` matches nothing instead of scanning every project.
- Migration `00009` drops the index.
- Test updated: removed the 3 cross-project `TestFacetReadQueriesUseIndexes` cases; the project-scoped filter still asserts COVERING on `idx_event_facets_kv_issue`.

## Verification

- `EXPLAIN`: per-project facet→issue filter stays `COVERING INDEX idx_event_facets_kv_issue`; `event_facets` indexes = just that one.
- `go build` + `go test ./internal/storage/... ./internal/service/issues/... ./internal/api/...` pass.
- Run **VACUUM** during a quiet window after this + #158 deploy to reclaim the freed pages on disk.

Roadmap: #157.