### PR TITLE
feat(observability): add OTel tracing/metrics and FunnelBarn analytics events

### DIFF
--- a/cmd/bb/client.go
+++ b/cmd/bb/client.go
@@ -2,12 +2,22 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 type Client struct {
@@ -43,24 +53,77 @@ func (c *Client) patch(path string, body any) (json.RawMessage, error) {
 }
 
 func (c *Client) do(method, path string, body any) (json.RawMessage, error) {
-	return c.doRetry(method, path, body, false)
+	return c.doRetry(context.Background(), method, path, body, false)
 }
 
-func (c *Client) doRetry(method, path string, body any, retried bool) (json.RawMessage, error) {
+func (c *Client) doRetry(ctx context.Context, method, path string, body any, retried bool) (json.RawMessage, error) {
+	target, _, _ := strings.Cut(path, "?")
+
+	ctx, span := tracing.Tracer().Start(ctx, "cli.Request",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("http.method", method),
+			attribute.String("http.target", target),
+		),
+	)
+	defer span.End()
+
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
 			return nil, fmt.Errorf("marshal request: %w", err)
 		}
 		bodyReader = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequest(method, c.base+path, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, bodyReader)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
-	if body != nil {
+	c.setRequestHeaders(req, method, body != nil)
+
+	// Propagate the client span's trace context to the server so this request
+	// correlates with the server-side trace (extracted in tracing.Middleware).
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+
+	if result, retriedResp, err := c.reauthAndRetry(ctx, method, path, body, retried, resp.StatusCode); retriedResp {
+		return result, err
+	}
+
+	if resp.StatusCode >= 400 {
+		msg := string(respBody)
+		if len(msg) > 200 {
+			msg = msg[:200]
+		}
+		span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", resp.StatusCode))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(msg))
+	}
+
+	return json.RawMessage(respBody), nil
+}
+
+// setRequestHeaders sets the content-type, project/group scoping, and auth
+// headers (API key, session cookie, CSRF token) on an outgoing request.
+func (c *Client) setRequestHeaders(req *http.Request, method string, hasBody bool) {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	if c.group != "" {
@@ -78,35 +141,31 @@ func (c *Client) doRetry(method, path string, body any, retried bool) (json.RawM
 			req.Header.Set("X-BugBarn-CSRF", c.config.Auth.CSRFToken)
 		}
 	}
+}
 
-	resp, err := c.http.Do(req)
+// reauthAndRetry re-authenticates with the configured username/password and
+// replays the request once when a session-authenticated call comes back
+// unauthorized. The bool return reports whether it handled (attempted) the
+// retry at all; callers should return its result whenever it does.
+func (c *Client) reauthAndRetry(
+	ctx context.Context, method, path string, body any, retried bool, statusCode int,
+) (json.RawMessage, bool, error) {
+	if statusCode != http.StatusUnauthorized || retried || c.config.Auth.Type != "session" ||
+		c.config.Auth.Username == "" || c.config.Auth.Password == "" {
+		return nil, false, nil
+	}
+
+	session, csrf, err := loginWithPassword(ctx, c.base, c.config.Auth.Username, c.config.Auth.Password)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, false, nil
 	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
+	c.config.Auth.SessionToken = session
+	c.config.Auth.CSRFToken = csrf
+	if err := saveConfig(c.config); err != nil {
+		// Best-effort: the refreshed session/CSRF token still works for the
+		// rest of this run, it just won't be persisted to disk for next time.
+		slog.Warn("cli: failed to persist refreshed session config", "error", err)
 	}
-
-	if resp.StatusCode == 401 && !retried && c.config.Auth.Type == "session" && c.config.Auth.Username != "" && c.config.Auth.Password != "" {
-		session, csrf, err := loginWithPassword(c.base, c.config.Auth.Username, c.config.Auth.Password)
-		if err == nil {
-			c.config.Auth.SessionToken = session
-			c.config.Auth.CSRFToken = csrf
-			_ = saveConfig(c.config)
-			return c.doRetry(method, path, body, true)
-		}
-	}
-
-	if resp.StatusCode >= 400 {
-		msg := string(respBody)
-		if len(msg) > 200 {
-			msg = msg[:200]
-		}
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(msg))
-	}
-
-	return json.RawMessage(respBody), nil
+	result, err := c.doRetry(ctx, method, path, body, true)
+	return result, true, err
 }

--- a/cmd/bb/client.go
+++ b/cmd/bb/client.go
@@ -14,11 +14,35 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// CLI request instruments. Built once from the global meter (a valid no-op
+// until tracing.Init wires a real MeterProvider), matching the construction
+// pattern used elsewhere (see internal/ingestproc/metrics.go) rather than
+// recreating instruments per call.
+var (
+	requestCounter  metric.Int64Counter
+	requestDuration metric.Float64Histogram
+)
+
+func init() {
+	m := tracing.Meter()
+	requestCounter, _ = m.Int64Counter(
+		"bugbarn.cli.request",
+		metric.WithDescription("CLI requests made to the BugBarn API, by method and outcome."),
+		metric.WithUnit("{request}"),
+	)
+	requestDuration, _ = m.Float64Histogram(
+		"bugbarn.cli.request.duration",
+		metric.WithDescription("Wall-clock time for a CLI request to the BugBarn API."),
+		metric.WithUnit("ms"),
+	)
+}
 
 type Client struct {
 	base    string
@@ -56,7 +80,48 @@ func (c *Client) do(method, path string, body any) (json.RawMessage, error) {
 	return c.doRetry(context.Background(), method, path, body, false)
 }
 
-func (c *Client) doRetry(ctx context.Context, method, path string, body any, retried bool) (json.RawMessage, error) {
+// recordRequestMetrics records the CLI request counter and duration
+// histogram for a completed request, classifying it by method and outcome.
+func recordRequestMetrics(ctx context.Context, method string, start time.Time, err error) {
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	requestCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("method", method),
+		attribute.String("outcome", outcome),
+	))
+	requestDuration.Record(ctx, float64(time.Since(start).Milliseconds()),
+		metric.WithAttributes(attribute.String("method", method)))
+}
+
+// buildRequest marshals the request body (if any), constructs the HTTP
+// request, sets the standard headers, and injects the trace context so the
+// server side correlates with this client span.
+func (c *Client) buildRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	c.setRequestHeaders(req, method, body != nil)
+
+	// Propagate the client span's trace context to the server so this request
+	// correlates with the server-side trace (extracted in tracing.Middleware).
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	return req, nil
+}
+
+func (c *Client) doRetry(ctx context.Context, method, path string, body any, retried bool) (result json.RawMessage, err error) {
 	target, _, _ := strings.Cut(path, "?")
 
 	ctx, span := tracing.Tracer().Start(ctx, "cli.Request",
@@ -68,26 +133,14 @@ func (c *Client) doRetry(ctx context.Context, method, path string, body any, ret
 	)
 	defer span.End()
 
-	var bodyReader io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			span.SetStatus(codes.Error, err.Error())
-			return nil, fmt.Errorf("marshal request: %w", err)
-		}
-		bodyReader = bytes.NewReader(data)
-	}
+	start := time.Now()
+	defer func() { recordRequestMetrics(ctx, method, start, err) }()
 
-	req, err := http.NewRequestWithContext(ctx, method, c.base+path, bodyReader)
+	req, err := c.buildRequest(ctx, method, path, body)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
-	c.setRequestHeaders(req, method, body != nil)
-
-	// Propagate the client span's trace context to the server so this request
-	// correlates with the server-side trace (extracted in tracing.Middleware).
-	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/cmd/bb/commands.go
+++ b/cmd/bb/commands.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -12,7 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/term"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 func cmdLogin(args []string) error {
@@ -62,7 +70,7 @@ func cmdLogin(args []string) error {
 			}
 			*password = string(pw)
 		}
-		session, csrf, err := loginWithPassword(*urlFlag, *username, *password)
+		session, csrf, err := loginWithPassword(context.Background(), *urlFlag, *username, *password)
 		if err != nil {
 			return err
 		}
@@ -85,16 +93,37 @@ func cmdLogin(args []string) error {
 	return nil
 }
 
-func loginWithPassword(baseURL, username, password string) (session, csrf string, err error) {
+func loginWithPassword(ctx context.Context, baseURL, username, password string) (session, csrf string, err error) {
+	ctx, span := tracing.Tracer().Start(ctx, "cli.Request",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("http.method", http.MethodPost),
+			attribute.String("http.target", "/api/v1/login"),
+		),
+	)
+	defer span.End()
+
 	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
-	resp, err := http.Post(baseURL+"/api/v1/login", "application/json", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/v1/login", bytes.NewReader(body))
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return "", "", fmt.Errorf("login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return "", "", fmt.Errorf("login request: %w", err)
 	}
 	defer resp.Body.Close()
 	io.ReadAll(resp.Body)
 
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+
 	if resp.StatusCode != 200 {
+		span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", resp.StatusCode))
 		return "", "", fmt.Errorf("login failed: HTTP %d", resp.StatusCode)
 	}
 
@@ -321,120 +350,6 @@ func cmdUnmute(args []string) error {
 		return err
 	}
 	return writeRaw(data)
-}
-
-func cmdProjects(args []string) error {
-	fs := flag.NewFlagSet("projects", flag.ContinueOnError)
-	create := fs.String("create", "", "create a new project with this name")
-	slug := fs.String("slug", "", "project slug (defaults to slugified name)")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-
-	client, err := newClient()
-	if err != nil {
-		return err
-	}
-
-	if *create != "" {
-		body := map[string]string{"name": *create}
-		if *slug != "" {
-			body["slug"] = *slug
-		}
-		data, err := client.post("/api/v1/projects", body)
-		if err != nil {
-			return err
-		}
-		return writeRaw(data)
-	}
-
-	data, err := client.get("/api/v1/projects")
-	if err != nil {
-		return err
-	}
-	return writeRaw(data)
-}
-
-func cmdGroups(args []string) error {
-	fs := flag.NewFlagSet("groups", flag.ContinueOnError)
-	create := fs.String("create", "", "create a new group with this name")
-	slug := fs.String("slug", "", "group slug (defaults to slugified name)")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-
-	client, err := newClient()
-	if err != nil {
-		return err
-	}
-
-	if *create != "" {
-		body := map[string]string{"name": *create}
-		if *slug != "" {
-			body["slug"] = *slug
-		}
-		data, err := client.post("/api/v1/groups", body)
-		if err != nil {
-			return err
-		}
-		return writeRaw(data)
-	}
-
-	data, err := client.get("/api/v1/groups")
-	if err != nil {
-		return err
-	}
-	return writeRaw(data)
-}
-
-func cmdAPIKeys(args []string) error {
-	client, err := newClient()
-	if err != nil {
-		return err
-	}
-	data, err := client.get("/api/v1/apikeys")
-	if err != nil {
-		return err
-	}
-	return writeRaw(data)
-}
-
-func validateProject(c *Client, slug string) error {
-	data, err := c.get("/api/v1/projects")
-	if err != nil {
-		return err
-	}
-	var resp struct {
-		Projects []struct{ Slug string `json:"slug"` } `json:"projects"`
-	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("parse projects response: %w", err)
-	}
-	for _, p := range resp.Projects {
-		if p.Slug == slug {
-			return nil
-		}
-	}
-	return fmt.Errorf("project %q not found — run 'bb projects' to see available projects", slug)
-}
-
-func validateGroup(c *Client, slug string) error {
-	data, err := c.get("/api/v1/groups")
-	if err != nil {
-		return err
-	}
-	var resp struct {
-		Groups []struct{ Slug string `json:"slug"` } `json:"groups"`
-	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("parse groups response: %w", err)
-	}
-	for _, g := range resp.Groups {
-		if g.Slug == slug {
-			return nil
-		}
-	}
-	return fmt.Errorf("group %q not found — run 'bb groups' to see available groups", slug)
 }
 
 func resolveProject(flag string, c *Client) string {

--- a/cmd/bb/logs.go
+++ b/cmd/bb/logs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -12,7 +13,15 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 func cmdLogs(args []string) error {
@@ -86,8 +95,18 @@ func fetchLogs(client *Client, level, project, query string, limit int, noColor 
 func streamLogs(client *Client, level, project string, noColor bool) error {
 	path := "/api/v1/logs/stream"
 
-	req, err := http.NewRequest("GET", client.base+path, nil)
+	ctx, span := tracing.Tracer().Start(context.Background(), "cli.Request",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("http.method", http.MethodGet),
+			attribute.String("http.target", path),
+		),
+	)
+	defer span.End()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, client.base+path, nil)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
@@ -101,13 +120,19 @@ func streamLogs(client *Client, level, project string, noColor bool) error {
 		req.AddCookie(&http.Cookie{Name: "bugbarn_session", Value: client.config.Auth.SessionToken})
 	}
 
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
 	resp, err := client.http.Do(req)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("stream connect: %w", err)
 	}
 	defer resp.Body.Close()
 
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+
 	if resp.StatusCode != 200 {
+		span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", resp.StatusCode))
 		return fmt.Errorf("stream: HTTP %d", resp.StatusCode)
 	}
 

--- a/cmd/bb/projects.go
+++ b/cmd/bb/projects.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+)
+
+func cmdProjects(args []string) error {
+	return cmdResourceList(args, "projects", "project", "/api/v1/projects")
+}
+
+func cmdGroups(args []string) error {
+	return cmdResourceList(args, "groups", "group", "/api/v1/groups")
+}
+
+// cmdResourceList implements the shared shape of `bb projects` / `bb groups`:
+// list all, or create one with --create [--slug].
+func cmdResourceList(args []string, fsName, singular, apiPath string) error {
+	fs := flag.NewFlagSet(fsName, flag.ContinueOnError)
+	create := fs.String("create", "", "create a new "+singular+" with this name")
+	slug := fs.String("slug", "", singular+" slug (defaults to slugified name)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	if *create != "" {
+		body := map[string]string{"name": *create}
+		if *slug != "" {
+			body["slug"] = *slug
+		}
+		data, err := client.post(apiPath, body)
+		if err != nil {
+			return err
+		}
+		return writeRaw(data)
+	}
+
+	data, err := client.get(apiPath)
+	if err != nil {
+		return err
+	}
+	return writeRaw(data)
+}
+
+func cmdAPIKeys(args []string) error {
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+	data, err := client.get("/api/v1/apikeys")
+	if err != nil {
+		return err
+	}
+	return writeRaw(data)
+}
+
+func validateProject(c *Client, slug string) error {
+	data, err := c.get("/api/v1/projects")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Projects []struct {
+			Slug string `json:"slug"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse projects response: %w", err)
+	}
+	for _, p := range resp.Projects {
+		if p.Slug == slug {
+			return nil
+		}
+	}
+	return fmt.Errorf("project %q not found — run 'bb projects' to see available projects", slug)
+}
+
+func validateGroup(c *Client, slug string) error {
+	data, err := c.get("/api/v1/groups")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Groups []struct {
+			Slug string `json:"slug"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parse groups response: %w", err)
+	}
+	for _, g := range resp.Groups {
+		if g.Slug == slug {
+			return nil
+		}
+	}
+	return fmt.Errorf("group %q not found — run 'bb groups' to see available groups", slug)
+}

--- a/cmd/bugbarn/main.go
+++ b/cmd/bugbarn/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	funnelbarn "github.com/webwiebe/funnelbarn/sdks/go"
 	bb "github.com/wiebe-xyz/bugbarn-go"
 	"github.com/wiebe-xyz/bugbarn/internal/alert"
 	"github.com/wiebe-xyz/bugbarn/internal/analytics"
@@ -42,6 +43,13 @@ var (
 	Version   = "dev"
 	BuildTime = "unknown"
 )
+
+// funnelbarnProjectName identifies this backend's own product events in
+// FunnelBarn. There is no other established per-service project-name
+// convention for this dogfood integration (only the frontend has one today,
+// via runtime-config), so this is a fixed constant rather than a config
+// value — every bugbarn deployment reports under the same project.
+const funnelbarnProjectName = "bugbarn"
 
 func main() {
 	if err := run(); err != nil {
@@ -122,6 +130,17 @@ func run() error {
 	bus.Subscribe(evaluator.HandleEvent)
 
 	eventPub := service.NewEventPublisher(bus)
+
+	// FunnelBarn product-event tracking is opt-in, same gate as the frontend's
+	// runtime-config block: only enabled when an API key is configured.
+	if cfg.FunnelBarnAPIKey != "" {
+		funnelbarn.Init(funnelbarn.Options{
+			APIKey:      cfg.FunnelBarnAPIKey,
+			Endpoint:    cfg.FunnelBarnEndpoint,
+			ProjectName: funnelbarnProjectName,
+		})
+		logger.Info("funnelbarn tracking enabled", "endpoint", cfg.FunnelBarnEndpoint, "project", funnelbarnProjectName)
+	}
 
 	selfReporting := cfg.SelfEndpoint != "" && cfg.SelfAPIKey != ""
 	if selfReporting {
@@ -258,6 +277,11 @@ func run() error {
 		}
 		if selfReporting {
 			bb.Shutdown(2 * time.Second)
+		}
+		if cfg.FunnelBarnAPIKey != "" {
+			if err := funnelbarn.Shutdown(5 * time.Second); err != nil {
+				logger.Warn("funnelbarn shutdown", "error", err)
+			}
 		}
 		return shutdownErr
 	case err := <-errCh:

--- a/cmd/bugbarn/reader.go
+++ b/cmd/bugbarn/reader.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	funnelbarn "github.com/webwiebe/funnelbarn/sdks/go"
 	bb "github.com/wiebe-xyz/bugbarn-go"
 	"github.com/wiebe-xyz/bugbarn/internal/api"
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
@@ -39,6 +40,16 @@ func runReader(cfg config.Config, logHandler slog.Handler) error {
 		logger = slog.New(selflog.NewHandler(logHandler))
 		slog.SetDefault(logger)
 		logger.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
+	}
+
+	// FunnelBarn product-event tracking is opt-in, same gate as the writer.
+	if cfg.FunnelBarnAPIKey != "" {
+		funnelbarn.Init(funnelbarn.Options{
+			APIKey:      cfg.FunnelBarnAPIKey,
+			Endpoint:    cfg.FunnelBarnEndpoint,
+			ProjectName: funnelbarnProjectName,
+		})
+		logger.Info("funnelbarn tracking enabled", "endpoint", cfg.FunnelBarnEndpoint, "project", funnelbarnProjectName)
 	}
 
 	shutdownTracing, err := tracing.Init(context.Background(), Version)
@@ -212,6 +223,11 @@ func runReader(cfg config.Config, logHandler slog.Handler) error {
 
 		if selfReporting {
 			bb.Shutdown(2 * time.Second)
+		}
+		if cfg.FunnelBarnAPIKey != "" {
+			if err := funnelbarn.Shutdown(5 * time.Second); err != nil {
+				logger.Warn("funnelbarn shutdown", "error", err)
+			}
 		}
 		return shutdownErr
 	case err := <-errCh:

--- a/cmd/bugbarn/worker.go
+++ b/cmd/bugbarn/worker.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	bb "github.com/wiebe-xyz/bugbarn-go"
@@ -139,6 +140,32 @@ func persistReleaseRecord(ctx context.Context, store *storage.Store, record spoo
 	return err
 }
 
+// workerMetrics holds the OTel instruments for the background spool worker.
+// Built once per worker (see newWorkerMetrics) and reused across ticks rather
+// than recreated per call, matching the convention in internal/ingestproc.
+type workerMetrics struct {
+	eventsProcessed metric.Int64Counter
+	deadLetters     metric.Int64Counter
+}
+
+// newWorkerMetrics builds the worker instruments from the global meter; before
+// tracing.Init wires a MeterProvider they are valid no-op instruments, so
+// construction never fails in tests or when telemetry is disabled.
+func newWorkerMetrics() *workerMetrics {
+	m := tracing.Meter()
+	eventsProcessed, _ := m.Int64Counter(
+		"bugbarn.worker.events_processed",
+		metric.WithDescription("Spool records processed by the background worker, by outcome."),
+		metric.WithUnit("{record}"),
+	)
+	deadLetters, _ := m.Int64Counter(
+		"bugbarn.worker.dead_letters",
+		metric.WithDescription("Spool records dead-lettered by the background worker, by stage."),
+		metric.WithUnit("{record}"),
+	)
+	return &workerMetrics{eventsProcessed: eventsProcessed, deadLetters: deadLetters}
+}
+
 // spoolWorker carries the shared state for the background ingest loop so the
 // per-record processing steps read as small methods instead of one deeply nested
 // function. retryCounts and offset are process-lifetime mutable state; the rest
@@ -152,6 +179,7 @@ type spoolWorker struct {
 	ws            *worker.Status
 	mq            *mutqueue.Queue
 	tracer        trace.Tracer
+	metrics       *workerMetrics
 
 	retryCounts map[string]int // per-ingest-ID failure counts within this process
 	offset      int64          // spool cursor
@@ -174,6 +202,7 @@ func runBackgroundWorker(ctx context.Context, eventSpool *spool.Spool, spoolDir 
 		ws:            ws,
 		mq:            mq,
 		tracer:        tracing.Tracer(),
+		metrics:       newWorkerMetrics(),
 		retryCounts:   make(map[string]int),
 		offset:        offset,
 	}
@@ -291,6 +320,11 @@ func (w *spoolWorker) processEventEntry(ctx context.Context, span trace.Span, en
 		if isTransientPersistError(persistErr) {
 			// Environmental (lock contention); retry forever, don't burn the budget.
 			slog.Warn("worker transient persist failure, will retry", "ingest_id", record.IngestID, "error", persistErr)
+			if w.metrics != nil {
+				w.metrics.eventsProcessed.Add(ctx, 1, metric.WithAttributes(
+					attribute.String("outcome", "transient_error"),
+				))
+			}
 			return true
 		}
 		w.failRecord(record, entry.EndOffset, "persist record", persistErr, true)
@@ -311,7 +345,10 @@ func (w *spoolWorker) processEventEntry(ctx context.Context, span trace.Span, en
 	w.svc.PublishIssueEvent(issue, projectID, isNew, isRegressed)
 
 	span.End()
-	w.markProcessed(record, entry.EndOffset)
+	w.markProcessed(record, entry.EndOffset,
+		attribute.Bool("is_new", isNew),
+		attribute.Bool("is_regressed", isRegressed),
+	)
 	return false
 }
 
@@ -336,12 +373,21 @@ func (w *spoolWorker) resolveProject(ctx context.Context, record spool.Record) c
 }
 
 // markProcessed clears retry state and advances the cursor past a record that was
-// handled successfully.
-func (w *spoolWorker) markProcessed(record spool.Record, endOffset int64) {
+// handled successfully. extraAttrs are attached to the events_processed metric
+// alongside outcome=success (e.g. is_new/is_regressed for event records).
+//
+// Metrics are recorded against context.Background() rather than a per-record
+// span context: this keeps the signature (and its test call sites) stable and
+// exemplar correlation isn't required for these counters.
+func (w *spoolWorker) markProcessed(record spool.Record, endOffset int64, extraAttrs ...attribute.KeyValue) {
 	delete(w.retryCounts, record.IngestID)
 	w.advanceCursor(endOffset)
 	if w.ws != nil {
 		w.ws.RecordProcessed(1)
+	}
+	if w.metrics != nil {
+		attrs := append([]attribute.KeyValue{attribute.String("outcome", "success")}, extraAttrs...)
+		w.metrics.eventsProcessed.Add(context.Background(), 1, metric.WithAttributes(attrs...))
 	}
 }
 
@@ -359,7 +405,7 @@ func (w *spoolWorker) advanceCursor(endOffset int64) {
 // failRecord records a failure for one record. It increments the retry counter
 // and, once the retry budget is exhausted, dead-letters the record and advances
 // the cursor past it. report controls whether the dead-letter is surfaced via
-// self-reporting and the worker's dead-letter metric.
+// self-reporting and the worker's dead-letter metrics.
 func (w *spoolWorker) failRecord(record spool.Record, endOffset int64, stage string, cause error, report bool) {
 	w.retryCounts[record.IngestID]++
 	attempt := w.retryCounts[record.IngestID]
@@ -378,6 +424,9 @@ func (w *spoolWorker) failRecord(record spool.Record, endOffset int64, stage str
 		}
 		if w.ws != nil {
 			w.ws.RecordDeadLetter()
+		}
+		if w.metrics != nil {
+			w.metrics.deadLetters.Add(context.Background(), 1, metric.WithAttributes(attribute.String("stage", stage)))
 		}
 	}
 	delete(w.retryCounts, record.IngestID)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.20.1
+	github.com/webwiebe/funnelbarn/sdks/go v0.5.99
 	github.com/wiebe-xyz/bugbarn-go v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/webwiebe/funnelbarn/sdks/go v0.5.99 h1:lC2xwu0x8wwhdf5WY7Mi2ztYZHEAE9klVw3EvuuL/+U=
+github.com/webwiebe/funnelbarn/sdks/go v0.5.99/go.mod h1:eXwFQGrNRScmhF7C3nvUOuXiSNCR7Y0szIX6qFqnOjw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/internal/alert/deliverer.go
+++ b/internal/alert/deliverer.go
@@ -14,11 +14,24 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// webhookDeliveryCounter counts alert-webhook delivery attempts, built once
+// from the global meter (see tracing.Meter) rather than recreated per call.
+var webhookDeliveryCounter metric.Int64Counter
+
+func init() {
+	webhookDeliveryCounter, _ = tracing.Meter().Int64Counter(
+		"bugbarn.alert.webhook_delivery",
+		metric.WithDescription("Alert webhook delivery attempts, by outcome and attempt number."),
+		metric.WithUnit("{attempt}"),
+	)
+}
 
 // EventVolumeSource provides recent per-issue event volume for sparklines.
 // Index 0 of the returned array is the oldest hour, index 23 the current hour.
@@ -109,6 +122,10 @@ func (d *Deliverer) postWebhookAttempt(ctx context.Context, webhookURL, host str
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", attempt),
+		))
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -116,15 +133,27 @@ func (d *Deliverer) postWebhookAttempt(ctx context.Context, webhookURL, host str
 	resp, err := d.client.Do(req)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", attempt),
+		))
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "success"),
+			attribute.Int("attempt", attempt),
+		))
 		return nil
 	}
 	err = fmt.Errorf("webhook returned status %d", resp.StatusCode)
 	span.SetStatus(codes.Error, err.Error())
+	webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", "error"),
+		attribute.Int("attempt", attempt),
+	))
 	return err
 }
 

--- a/internal/alert/deliverer.go
+++ b/internal/alert/deliverer.go
@@ -7,12 +7,17 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"net/url"
 	"strings"
 	"text/template"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
 	"github.com/wiebe-xyz/bugbarn/internal/digest"
 	"github.com/wiebe-xyz/bugbarn/internal/domain"
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // EventVolumeSource provides recent per-issue event volume for sparklines.
@@ -70,6 +75,7 @@ func (d *Deliverer) fireWebhook(ctx context.Context, rule Rule, issue domain.Iss
 		return fmt.Errorf("build payload: %w", err)
 	}
 
+	host := webhookHost(rule.WebhookURL)
 	delays := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second}
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
@@ -81,25 +87,55 @@ func (d *Deliverer) fireWebhook(ctx context.Context, rule Rule, issue domain.Iss
 			}
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, rule.WebhookURL, bytes.NewReader(payload))
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := d.client.Do(req)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		resp.Body.Close()
-		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		lastErr = d.postWebhookAttempt(ctx, rule.WebhookURL, host, attempt+1, payload)
+		if lastErr == nil {
 			return nil
 		}
-		lastErr = fmt.Errorf("webhook returned status %d", resp.StatusCode)
 	}
 	return lastErr
+}
+
+// postWebhookAttempt performs a single POST attempt to a webhook URL, wrapped
+// in a span recording the target host (not the full URL, which may embed a
+// secret token) and attempt number.
+func (d *Deliverer) postWebhookAttempt(ctx context.Context, webhookURL, host string, attempt int, payload []byte) error {
+	ctx, span := tracing.Tracer().Start(ctx, "alert.WebhookPost")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("webhook.host", host),
+		attribute.Int("attempt", attempt),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	err = fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	span.SetStatus(codes.Error, err.Error())
+	return err
+}
+
+// webhookHost extracts just the host (no scheme/path/query, which may carry a
+// secret webhook token) from a webhook URL, for safe use as a span attribute.
+func webhookHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }
 
 func (d *Deliverer) fireEmail(ctx context.Context, rule Rule, issue domain.Issue, publicURL string) error {
@@ -137,7 +173,7 @@ func (d *Deliverer) fireEmail(ctx context.Context, rule Rule, issue domain.Issue
 	}
 
 	subject := fmt.Sprintf("%s %s: %s", bugbarnTag(d.env), rule.Name, issue.Title)
-	return digest.DeliverEmail(d.mailCfg, rule.EmailTo, subject, plain.String(), htmlBuf.String())
+	return digest.DeliverEmail(ctx, d.mailCfg, rule.EmailTo, subject, plain.String(), htmlBuf.String())
 }
 
 type alertMailData struct {

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -106,7 +107,7 @@ func (s *Server) streamEvents(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return
 			}
-			next, ok := writeLiveEvents(w, events, cursor)
+			next, ok := writeLiveEvents(w, events, cursor, s.logger)
 			if !ok {
 				return
 			}
@@ -136,7 +137,7 @@ func streamSince(r *http.Request) time.Time {
 // writeLiveEvents writes each event newer than cursor as an SSE data frame
 // (oldest first) and returns the advanced cursor. ok is false when writing to
 // the client failed and the stream should terminate.
-func writeLiveEvents(w http.ResponseWriter, events []domain.Event, cursor time.Time) (time.Time, bool) {
+func writeLiveEvents(w http.ResponseWriter, events []domain.Event, cursor time.Time, logger *slog.Logger) (time.Time, bool) {
 	for i := len(events) - 1; i >= 0; i-- {
 		ev := events[i]
 		ts := ev.ReceivedAt
@@ -148,6 +149,7 @@ func writeLiveEvents(w http.ResponseWriter, events []domain.Event, cursor time.T
 		}
 		data, err := json.Marshal(ev)
 		if err != nil {
+			logger.Warn("events: failed to marshal live event; skipping", "issue_id", ev.IssueID, "event_id", ev.ID, "error", err)
 			continue
 		}
 		if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {

--- a/internal/api/forwarder.go
+++ b/internal/api/forwarder.go
@@ -5,6 +5,12 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // WriteForwarder proxies write requests to an upstream writer instance
@@ -29,8 +35,18 @@ func NewWriteForwarder(writerURL string) *WriteForwarder {
 func (f *WriteForwarder) Forward(w http.ResponseWriter, r *http.Request) {
 	upstreamURL := f.writerURL + r.URL.RequestURI()
 
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, r.Body)
+	ctx, span := tracing.Tracer().Start(r.Context(), "forwarder.Forward",
+		trace.WithAttributes(
+			attribute.String("http.target", upstreamURL),
+			attribute.String("http.method", r.Method),
+		),
+	)
+	defer span.End()
+	r = r.WithContext(ctx)
+
+	upstreamReq, err := http.NewRequestWithContext(ctx, r.Method, upstreamURL, r.Body)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		http.Error(w, "upstream writer unavailable", http.StatusBadGateway)
 		return
 	}
@@ -50,10 +66,16 @@ func (f *WriteForwarder) Forward(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := f.client.Do(upstreamReq)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		http.Error(w, "upstream writer unavailable", http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()
+
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+	if resp.StatusCode >= 500 {
+		span.SetStatus(codes.Error, http.StatusText(resp.StatusCode))
+	}
 
 	// Copy response headers, excluding CORS headers that the outer ServeHTTP
 	// already set. Copying them would produce duplicates, and the Fetch spec

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -152,6 +152,7 @@ func (s *Server) issueSparklines(w http.ResponseWriter, r *http.Request) {
 		displayID := strings.TrimSpace(p)
 		rowID, err := s.issues.RowIDByDisplayID(r.Context(), displayID)
 		if err != nil {
+			s.logger.Warn("issues: sparkline lookup failed for display id", "display_id", displayID, "error", err)
 			continue
 		}
 		issueIDs = append(issueIDs, rowID)

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -226,6 +226,7 @@ func (s *Server) serveLogsStream(w http.ResponseWriter, r *http.Request) {
 			}
 			data, err := json.Marshal(entry)
 			if err != nil {
+				s.logger.Warn("logs: failed to marshal live log entry; skipping", "log_id", entry.ID, "project_id", entry.ProjectID, "error", err)
 				continue
 			}
 			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -86,7 +86,9 @@ func (s *Server) serveSetup(w http.ResponseWriter, r *http.Request) {
 
 	keySHA := hex.EncodeToString(sha256Sum(rawKey))
 	if proj.ID != 0 {
-		_ = s.projects.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA)
+		if err := s.projects.EnsureSetupAPIKey(r.Context(), slug+"-setup", proj.ID, keySHA); err != nil {
+			s.logger.Error("setup: failed to provision setup api key", "slug", slug, "project_id", proj.ID, "error", err)
+		}
 	}
 
 	endpoint := s.publicURL

--- a/internal/api/spool_forwarder.go
+++ b/internal/api/spool_forwarder.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -18,9 +17,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
 	"github.com/wiebe-xyz/bugbarn/internal/normalize"
 	"github.com/wiebe-xyz/bugbarn/internal/queue"
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // spooledRequest is a forwardable HTTP write captured by the reader.
@@ -302,6 +306,14 @@ func (s *SpoolForwarder) forwardOne(ctx context.Context, rec spooledRequest) err
 	if s.queue != nil {
 		return s.publishOne(ctx, rec)
 	}
+	ctx, span := tracing.Tracer().Start(ctx, "forwarder.ForwardOne",
+		trace.WithAttributes(
+			attribute.String("http.target", s.writerURL+rec.Path),
+			attribute.String("http.method", rec.Method),
+		),
+	)
+	defer span.End()
+
 	body, err := base64.StdEncoding.DecodeString(rec.BodyBase64)
 	if err != nil {
 		// Record is corrupt — drop it so we don't get stuck.
@@ -311,6 +323,7 @@ func (s *SpoolForwarder) forwardOne(ctx context.Context, rec spooledRequest) err
 	url := s.writerURL + rec.Path
 	req, err := http.NewRequestWithContext(ctx, rec.Method, url, bytes.NewReader(body))
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	for k, v := range rec.Headers {
@@ -318,12 +331,16 @@ func (s *SpoolForwarder) forwardOne(ctx context.Context, rec spooledRequest) err
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	defer resp.Body.Close()
 	io.Copy(io.Discard, resp.Body)
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 	if resp.StatusCode >= 500 {
-		return fmt.Errorf("writer returned %d", resp.StatusCode)
+		err := fmt.Errorf("writer returned %d", resp.StatusCode)
+		span.SetStatus(codes.Error, err.Error())
+		return err
 	}
 	// 4xx is a permanent failure for this record — drop and advance.
 	if resp.StatusCode >= 400 {
@@ -395,98 +412,4 @@ func (s *SpoolForwarder) maybeRotateLocked(currentEnd int64) error {
 	}
 	s.file = file
 	return nil
-}
-
-type spooledRequestAt struct {
-	req       spooledRequest
-	endOffset int64
-}
-
-func readRecords(path string, offset int64) ([]spooledRequestAt, int64, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, offset, nil
-		}
-		return nil, offset, err
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, offset, err
-	}
-	if offset > info.Size() {
-		offset = 0
-	}
-	if offset > 0 {
-		if _, err := file.Seek(offset, 0); err != nil {
-			return nil, offset, err
-		}
-	}
-	var out []spooledRequestAt
-	pos := offset
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		pos += int64(len(line)) + 1
-		if len(line) == 0 {
-			continue
-		}
-		var rec spooledRequest
-		if err := json.Unmarshal(line, &rec); err != nil {
-			// corrupt line (e.g. truncated write during pod restart) — skip it
-			slog.Warn("spool: skipping corrupt record", "offset", pos, "error", err)
-			continue
-		}
-		out = append(out, spooledRequestAt{req: rec, endOffset: pos})
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, pos, err
-	}
-	return out, pos, nil
-}
-
-type cursorState struct {
-	Offset int64 `json:"offset"`
-}
-
-func readCursor(dir string) (int64, error) {
-	data, err := os.ReadFile(filepath.Join(dir, spoolCursorFileName))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	var c cursorState
-	if err := json.Unmarshal(data, &c); err != nil {
-		return 0, err
-	}
-	return c.Offset, nil
-}
-
-func writeCursor(dir string, offset int64) error {
-	data, err := json.Marshal(cursorState{Offset: offset})
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(dir, spoolCursorFileName), data, 0o600)
-}
-
-func resetCursor(dir string) error {
-	err := os.Remove(filepath.Join(dir, spoolCursorFileName))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
-}
-
-func sleepCtx(ctx context.Context, d time.Duration) {
-	t := time.NewTimer(d)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-	case <-t.C:
-	}
 }

--- a/internal/api/spool_forwarder.go
+++ b/internal/api/spool_forwarder.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
@@ -26,6 +27,20 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/queue"
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// produceCounter counts reader-side Redis write-queue publish attempts, built
+// once from the global meter (see tracing.Meter) rather than recreated per
+// call. This is the reader-side mirror of ingestproc's writer-side
+// bugbarn.consumer.items counter.
+var produceCounter metric.Int64Counter
+
+func init() {
+	produceCounter, _ = tracing.Meter().Int64Counter(
+		"bugbarn.queue.produce",
+		metric.WithDescription("Reader-side write-queue publish attempts, by outcome."),
+		metric.WithUnit("{call}"),
+	)
+}
 
 // spooledRequest is a forwardable HTTP write captured by the reader.
 type spooledRequest struct {
@@ -365,7 +380,13 @@ func (s *SpoolForwarder) publishOne(ctx context.Context, rec spooledRequest) err
 		ProjectSlug: rec.Headers["X-Bugbarn-Project"],
 		BodyBase64:  rec.BodyBase64,
 	}
-	return s.queue.Publish(ctx, []queue.Item{item})
+	err := s.queue.Publish(ctx, []queue.Item{item})
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	produceCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
+	return err
 }
 
 // kindForPath maps an ingest request path to its queue Item kind.

--- a/internal/api/spool_forwarder_disk.go
+++ b/internal/api/spool_forwarder_disk.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// spooledRequestAt pairs a decoded spooledRequest with the byte offset of the
+// end of its line in the spool file, so the caller can advance the cursor
+// past exactly the records it successfully forwarded.
+type spooledRequestAt struct {
+	req       spooledRequest
+	endOffset int64
+}
+
+func readRecords(path string, offset int64) ([]spooledRequestAt, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, offset, nil
+		}
+		return nil, offset, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, offset, err
+	}
+	if offset > info.Size() {
+		offset = 0
+	}
+	if offset > 0 {
+		if _, err := file.Seek(offset, 0); err != nil {
+			return nil, offset, err
+		}
+	}
+	var out []spooledRequestAt
+	pos := offset
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		pos += int64(len(line)) + 1
+		if len(line) == 0 {
+			continue
+		}
+		var rec spooledRequest
+		if err := json.Unmarshal(line, &rec); err != nil {
+			// corrupt line (e.g. truncated write during pod restart) — skip it
+			slog.Warn("spool: skipping corrupt record", "offset", pos, "error", err)
+			continue
+		}
+		out = append(out, spooledRequestAt{req: rec, endOffset: pos})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, pos, err
+	}
+	return out, pos, nil
+}
+
+type cursorState struct {
+	Offset int64 `json:"offset"`
+}
+
+func readCursor(dir string) (int64, error) {
+	data, err := os.ReadFile(filepath.Join(dir, spoolCursorFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	var c cursorState
+	if err := json.Unmarshal(data, &c); err != nil {
+		return 0, err
+	}
+	return c.Offset, nil
+}
+
+func writeCursor(dir string, offset int64) error {
+	data, err := json.Marshal(cursorState{Offset: offset})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, spoolCursorFileName), data, 0o600)
+}
+
+func resetCursor(dir string) error {
+	err := os.Remove(filepath.Join(dir, spoolCursorFileName))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -49,10 +50,12 @@ func (s *Server) serveTelemetry(w http.ResponseWriter, r *http.Request) {
 func recordClientSpan(ctx context.Context, tracer trace.Tracer, cs clientSpan) {
 	tid, err := trace.TraceIDFromHex(cs.TraceID)
 	if err != nil {
+		slog.Warn("telemetry: malformed client trace id; dropping span", "trace_id", cs.TraceID, "span_name", cs.Name, "error", err)
 		return
 	}
 	sid, err := trace.SpanIDFromHex(cs.SpanID)
 	if err != nil {
+		slog.Warn("telemetry: malformed client span id; dropping span", "span_id", cs.SpanID, "span_name", cs.Name, "error", err)
 		return
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -121,7 +122,9 @@ func (a *Authorizer) ValidWithProject(ctx context.Context, provided string) (pro
 		pid, sc, found, err := a.dbLookup(ctx, hexSum)
 		if err == nil && found {
 			if a.dbTouch != nil {
-				_ = a.dbTouch(ctx, hexSum)
+				if touchErr := a.dbTouch(ctx, hexSum); touchErr != nil {
+					slog.WarnContext(ctx, "auth: failed to update api key last-used timestamp", "project_id", pid, "error", touchErr)
+				}
 			}
 			return pid, sc, true
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,14 +11,45 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
+
+	funnelbarn "github.com/webwiebe/funnelbarn/sdks/go"
 
 	"github.com/wiebe-xyz/bugbarn/internal/config"
 	"github.com/wiebe-xyz/bugbarn/internal/storage"
 )
 
 var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// funnelbarnProjectName must match cmd/bugbarn's constant of the same name:
+// every bugbarn deployment reports its own product events under one fixed
+// FunnelBarn project. Duplicated here (rather than imported) because cli.go
+// is invoked directly from cmd/bugbarn's argument dispatch, before that
+// package's own long-running server init runs — see trackCLIEvent.
+const funnelbarnProjectName = "bugbarn"
+
+// trackCLIEvent reports a product event for a one-shot CLI invocation
+// (bugbarn user/project/apikey create). These commands run to completion and
+// exit within the same call, unlike the long-running server process that
+// initializes FunnelBarn once at startup and shuts it down on SIGTERM — so
+// each CLI invocation initializes its own short-lived SDK instance and blocks
+// briefly on Shutdown to give the queued event a chance to actually reach the
+// network before the process exits. Gated on the API key being configured,
+// same as the server.
+func trackCLIEvent(cfg config.Config, name string, properties map[string]any) {
+	if cfg.FunnelBarnAPIKey == "" {
+		return
+	}
+	funnelbarn.Init(funnelbarn.Options{
+		APIKey:      cfg.FunnelBarnAPIKey,
+		Endpoint:    cfg.FunnelBarnEndpoint,
+		ProjectName: funnelbarnProjectName,
+	})
+	funnelbarn.Track(name, properties)
+	_ = funnelbarn.Shutdown(3 * time.Second)
+}
 
 // RunUser handles: bugbarn user create --username=X --password=Y
 func RunUser(cfg config.Config, args []string) error {
@@ -53,6 +84,7 @@ func RunUser(cfg config.Config, args []string) error {
 		if err := store.UpsertUser(context.Background(), *username, string(hash)); err != nil {
 			return fmt.Errorf("upsert user: %w", err)
 		}
+		trackCLIEvent(cfg, "cli_login", map[string]any{"action": "user_create"})
 		fmt.Printf("user %q created/updated\n", *username)
 		return nil
 	default:
@@ -92,6 +124,7 @@ func RunProject(cfg config.Config, args []string) error {
 		if err != nil {
 			return fmt.Errorf("create project: %w", err)
 		}
+		trackCLIEvent(cfg, "cli_login", map[string]any{"action": "project_create", "project_slug": p.Slug})
 		return json.NewEncoder(os.Stdout).Encode(map[string]any{
 			"id":   p.ID,
 			"name": p.Name,
@@ -151,6 +184,7 @@ func RunAPIKey(cfg config.Config, args []string) error {
 		if err != nil {
 			return fmt.Errorf("create api key: %w", err)
 		}
+		trackCLIEvent(cfg, "api_key_created", map[string]any{"scope": key.Scope, "project_slug": project.Slug})
 		fmt.Printf("API key created (id=%d, project=%s, name=%s, scope=%s)\n", key.ID, project.Slug, key.Name, key.Scope)
 		fmt.Printf("Key (shown once, store securely): %s\n", plaintext)
 		return nil

--- a/internal/digest/mail.go
+++ b/internal/digest/mail.go
@@ -13,9 +13,22 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// emailDeliveryCounter counts digest email-send attempts, built once from the
+// global meter (see tracing.Meter) rather than recreated per call.
+var emailDeliveryCounter metric.Int64Counter
+
+func init() {
+	emailDeliveryCounter, _ = tracing.Meter().Int64Counter(
+		"bugbarn.digest.email_delivery",
+		metric.WithDescription("Digest email delivery attempts, by outcome and attempt number."),
+		metric.WithUnit("{attempt}"),
+	)
+}
 
 // MailConfig holds SMTP settings. All fields are optional: when Enabled is
 // false (or Host/To are empty) the mailer is a no-op. Env vars follow the
@@ -117,8 +130,16 @@ func sendMailTraced(ctx context.Context, host string, attempt int, send func() e
 	)
 	if err := send(); err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		emailDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", attempt),
+		))
 		return err
 	}
+	emailDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", "success"),
+		attribute.Int("attempt", attempt),
+	))
 	return nil
 }
 

--- a/internal/digest/mail.go
+++ b/internal/digest/mail.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // MailConfig holds SMTP settings. All fields are optional: when Enabled is
@@ -49,12 +54,12 @@ func transientSMTPError(err error) bool {
 
 // DeliverEmail sends the message with up to 3 attempts, retrying only on
 // transient failures (mirrors rapid-root email.ts retryEmailSend).
-func DeliverEmail(mc MailConfig, to, subject, plain, html string) error {
+func DeliverEmail(ctx context.Context, mc MailConfig, to, subject, plain, html string) error {
 	mc.To = to
-	return deliverEmail(mc, subject, plain, html)
+	return deliverEmail(ctx, mc, subject, plain, html)
 }
 
-func deliverEmail(mc MailConfig, subject, plain, html string) error {
+func deliverEmail(ctx context.Context, mc MailConfig, subject, plain, html string) error {
 	from := mc.From
 	if from == "" {
 		from = mc.User
@@ -82,7 +87,9 @@ func deliverEmail(mc MailConfig, subject, plain, html string) error {
 	delays := []time.Duration{time.Second, 3 * time.Second, 5 * time.Second}
 	var lastErr error
 	for attempt, delay := range delays {
-		lastErr = smtp.SendMail(addr, auth, from, []string{mc.To}, raw)
+		lastErr = sendMailTraced(ctx, mc.Host, attempt+1, func() error {
+			return smtp.SendMail(addr, auth, from, []string{mc.To}, raw)
+		})
 		if lastErr == nil {
 			return nil
 		}
@@ -95,6 +102,24 @@ func deliverEmail(mc MailConfig, subject, plain, html string) error {
 		}
 	}
 	return lastErr
+}
+
+// sendMailTraced wraps a single SMTP send attempt in a span, recording the
+// mail host and attempt number and marking the span as failed on error. The
+// existing slog-based retry logging in deliverEmail is unchanged; this adds
+// span-level visibility alongside it.
+func sendMailTraced(ctx context.Context, host string, attempt int, send func() error) error {
+	_, span := tracing.Tracer().Start(ctx, "digest.EmailSend")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("smtp.host", host),
+		attribute.Int("attempt", attempt),
+	)
+	if err := send(); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 // mailData is the template data bag for both plain and HTML renders.
@@ -184,7 +209,7 @@ type EmailNotifier struct {
 
 func (n *EmailNotifier) Name() string { return "email" }
 
-func (n *EmailNotifier) Send(_ context.Context, report Report) error {
+func (n *EmailNotifier) Send(ctx context.Context, report Report) error {
 	if !n.Cfg.active() {
 		return nil
 	}
@@ -215,5 +240,5 @@ func (n *EmailNotifier) Send(_ context.Context, report Report) error {
 		return fmt.Errorf("render html: %w", err)
 	}
 
-	return deliverEmail(n.Cfg, subject, plain.String(), html.String())
+	return deliverEmail(ctx, n.Cfg, subject, plain.String(), html.String())
 }

--- a/internal/digest/webhook.go
+++ b/internal/digest/webhook.go
@@ -6,7 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // WebhookNotifier delivers the digest as a JSON POST to a configured URL.
@@ -17,6 +23,10 @@ type WebhookNotifier struct {
 func (n *WebhookNotifier) Name() string { return "webhook" }
 
 func (n *WebhookNotifier) Send(ctx context.Context, report Report) error {
+	ctx, span := tracing.Tracer().Start(ctx, "digest.WebhookSend")
+	defer span.End()
+	span.SetAttributes(attribute.String("webhook.host", webhookHost(n.URL)))
+
 	p := struct {
 		Type string `json:"type"`
 		Report
@@ -24,22 +34,38 @@ func (n *WebhookNotifier) Send(ctx context.Context, report Report) error {
 
 	body, err := json.Marshal(p)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.URL, bytes.NewReader(body))
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	resp.Body.Close()
+	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("webhook returned %d", resp.StatusCode)
+		err := fmt.Errorf("webhook returned %d", resp.StatusCode)
+		span.SetStatus(codes.Error, err.Error())
+		return err
 	}
 	return nil
+}
+
+// webhookHost extracts just the host (no scheme/path/query, which may carry
+// secrets) from a webhook URL, for safe use as a span attribute.
+func webhookHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }

--- a/internal/digest/webhook.go
+++ b/internal/digest/webhook.go
@@ -11,9 +11,22 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// webhookDeliveryCounter counts digest webhook-send attempts, built once from
+// the global meter (see tracing.Meter) rather than recreated per call.
+var webhookDeliveryCounter metric.Int64Counter
+
+func init() {
+	webhookDeliveryCounter, _ = tracing.Meter().Int64Counter(
+		"bugbarn.digest.webhook_delivery",
+		metric.WithDescription("Digest webhook delivery attempts, by outcome and attempt number."),
+		metric.WithUnit("{attempt}"),
+	)
+}
 
 // WebhookNotifier delivers the digest as a JSON POST to a configured URL.
 type WebhookNotifier struct {
@@ -35,6 +48,10 @@ func (n *WebhookNotifier) Send(ctx context.Context, report Report) error {
 	body, err := json.Marshal(p)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", 1),
+		))
 		return err
 	}
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -42,12 +59,20 @@ func (n *WebhookNotifier) Send(ctx context.Context, report Report) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.URL, bytes.NewReader(body))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", 1),
+		))
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", 1),
+		))
 		return err
 	}
 	resp.Body.Close()
@@ -55,8 +80,16 @@ func (n *WebhookNotifier) Send(ctx context.Context, report Report) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		err := fmt.Errorf("webhook returned %d", resp.StatusCode)
 		span.SetStatus(codes.Error, err.Error())
+		webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("outcome", "error"),
+			attribute.Int("attempt", 1),
+		))
 		return err
 	}
+	webhookDeliveryCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", "success"),
+		attribute.Int("attempt", 1),
+	))
 	return nil
 }
 

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -8,11 +8,14 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+
+	funnelbarn "github.com/webwiebe/funnelbarn/sdks/go"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
 	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
@@ -44,6 +47,51 @@ type Handler struct {
 	maxBodyBytes int64
 	now          func() time.Time
 	idFn         func() string
+
+	// funnelbarnLastFired throttles the "event_ingested" product event: see
+	// trackEventIngested.
+	funnelbarnLastFired sync.Map // map[int64]time.Time, keyed by project ID
+}
+
+// funnelbarnEventThrottle bounds how often the "event_ingested" product event
+// fires for a given project. Ingest volume is unbounded (this is the
+// error/event intake path, potentially many requests per second per
+// project), so tracking every accepted request would flood FunnelBarn with
+// noise disproportionate to its value.
+//
+// There is deliberately no per-event DB lookup here to distinguish a
+// project's genuinely *first* event from a routine one: this handler only
+// touches the on-disk spool by design (event persistence happens later,
+// off the request path, so the single SQLite writer connection is never
+// contended by ingest traffic — see cmd/bugbarn/main.go). Adding a query per
+// accepted request to check "is this the first event for this project"
+// would undo that separation, and a project-level "has received an event"
+// flag would need a schema migration. Instead this fires a coarse "project
+// is actively sending events" ping at most once per throttle window per
+// project — enough for an activation/engagement signal without a migration
+// or a hot-path DB read.
+const funnelbarnEventThrottle = 5 * time.Minute
+
+// trackEventIngested reports "event_ingested" to FunnelBarn for projectID, at
+// most once per funnelbarnEventThrottle window. projectID<=0 means the
+// request used the global/static API key rather than a specific project, so
+// there is no project to attribute the event to and it is skipped.
+func (h *Handler) trackEventIngested(projectID int64, scope, projectSlug string) {
+	if projectID <= 0 {
+		return
+	}
+	now := h.now()
+	if last, ok := h.funnelbarnLastFired.Load(projectID); ok {
+		if now.Sub(last.(time.Time)) < funnelbarnEventThrottle {
+			return
+		}
+	}
+	h.funnelbarnLastFired.Store(projectID, now)
+	funnelbarn.Track("event_ingested", map[string]any{
+		"project_id":   projectID,
+		"project_slug": projectSlug,
+		"scope":        scope,
+	})
 }
 
 func NewHandler(authorizer *auth.Authorizer, eventSpool *spool.Spool, maxBodyBytes int64) *Handler {
@@ -144,7 +192,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.ValidAPIKey(r) {
+	projectID, scope, ok := h.APIKeyProjectScope(r)
+	if !ok {
 		span.SetStatus(codes.Error, "unauthorized")
 		recordIngestReceived(ctx, ingestresp.DropUnauthorized.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropUnauthorized)
@@ -210,6 +259,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	spoolSpan.End()
 
 	recordIngestReceived(ctx, "accepted")
+	h.trackEventIngested(projectID, scope, record.ProjectSlug)
 	ingestresp.WriteAccepted(w, record.IngestID)
 }
 

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/wiebe-xyz/bugbarn/internal/auth"
 	"github.com/wiebe-xyz/bugbarn/internal/ingestresp"
@@ -19,6 +20,23 @@ import (
 	"github.com/wiebe-xyz/bugbarn/internal/spool"
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// ingestReceivedCounter tags every ingest request by its terminal outcome
+// (accepted or one of the ingestresp.Drop reasons). Built once from the
+// package-global meter; before tracing.Init wires a MeterProvider it is a
+// valid no-op instrument, so construction never fails in tests or when
+// telemetry is disabled.
+var ingestReceivedCounter, _ = tracing.Meter().Int64Counter(
+	"bugbarn.ingest.received",
+	metric.WithDescription("Ingest requests received, by outcome."),
+	metric.WithUnit("{request}"),
+)
+
+// recordIngestReceived reports one ingest request's terminal outcome. outcome
+// is either "accepted" or an ingestresp.Drop.Reason value.
+func recordIngestReceived(ctx context.Context, outcome string) {
+	ingestReceivedCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
+}
 
 type Handler struct {
 	auth         *auth.Authorizer
@@ -113,6 +131,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ctx)
 
 	if h == nil || h.auth == nil || h.spool == nil {
+		recordIngestReceived(ctx, ingestresp.DropUnavailable.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropUnavailable)
 		return
 	}
@@ -127,6 +146,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if !h.ValidAPIKey(r) {
 		span.SetStatus(codes.Error, "unauthorized")
+		recordIngestReceived(ctx, ingestresp.DropUnauthorized.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropUnauthorized)
 		return
 	}
@@ -137,10 +157,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
+			recordIngestReceived(ctx, ingestresp.DropTooLarge.Reason)
 			ingestresp.WriteDropped(w, ingestresp.DropTooLarge)
 			return
 		}
 
+		recordIngestReceived(ctx, ingestresp.DropMalformed.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropMalformed)
 		return
 	}
@@ -151,6 +173,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// so the 202 below honestly means "accepted".
 	if err := normalize.Validate(body); err != nil {
 		span.SetStatus(codes.Error, "malformed payload")
+		recordIngestReceived(ctx, ingestresp.DropMalformed.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropMalformed)
 		return
 	}
@@ -176,14 +199,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		spoolSpan.SetStatus(codes.Error, err.Error())
 		spoolSpan.End()
 		if errors.Is(err, spool.ErrFull) {
+			recordIngestReceived(ctx, ingestresp.DropSpoolFull.Reason)
 			ingestresp.WriteDropped(w, ingestresp.DropSpoolFull)
 			return
 		}
+		recordIngestReceived(ctx, ingestresp.DropUnavailable.Reason)
 		ingestresp.WriteDropped(w, ingestresp.DropUnavailable)
 		return
 	}
 	spoolSpan.End()
 
+	recordIngestReceived(ctx, "accepted")
 	ingestresp.WriteAccepted(w, record.IngestID)
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -11,9 +11,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
 
 // WriteQueueKey is the Redis list backing the write queue.
@@ -116,6 +122,15 @@ func NewRedisQueueWithRetry(ctx context.Context, redisURL string) (*RedisQueue, 
 // up to maxItemsPerBatch. Producers call this after a record is durably in the
 // local spool; the spool cursor advances only once Publish returns nil.
 func (q *RedisQueue) Publish(ctx context.Context, items []Item) error {
+	ctx, span := tracing.Tracer().Start(ctx, "queue.Publish",
+		trace.WithAttributes(
+			attribute.String("queue.name", WriteQueueKey),
+			attribute.Int("queue.item_count", len(items)),
+		),
+	)
+	defer span.End()
+
+	batchCount := 0
 	for i := 0; i < len(items); i += maxItemsPerBatch {
 		end := i + maxItemsPerBatch
 		if end > len(items) {
@@ -123,30 +138,52 @@ func (q *RedisQueue) Publish(ctx context.Context, items []Item) error {
 		}
 		data, err := json.Marshal(items[i:end])
 		if err != nil {
-			return fmt.Errorf("queue: marshal: %w", err)
+			err = fmt.Errorf("queue: marshal: %w", err)
+			span.SetStatus(codes.Error, err.Error())
+			slog.ErrorContext(ctx, "queue: publish marshal failed", "queue", WriteQueueKey, "error", err)
+			return err
 		}
 		if err := q.client.LPush(ctx, WriteQueueKey, data).Err(); err != nil {
-			return fmt.Errorf("queue: lpush: %w", err)
+			err = fmt.Errorf("queue: lpush: %w", err)
+			span.SetStatus(codes.Error, err.Error())
+			slog.ErrorContext(ctx, "queue: publish lpush failed", "queue", WriteQueueKey, "error", err)
+			return err
 		}
+		batchCount++
 	}
+	span.SetAttributes(attribute.Int("queue.batch_count", batchCount))
 	return nil
 }
 
 // Consume blocks for up to brpopTimeout waiting for a batch, then returns it.
 // Returns (nil, nil) when the timeout expires with no items — callers loop.
 func (q *RedisQueue) Consume(ctx context.Context) ([]Item, error) {
+	ctx, span := tracing.Tracer().Start(ctx, "queue.Consume",
+		trace.WithAttributes(attribute.String("queue.name", WriteQueueKey)),
+	)
+	defer span.End()
+
 	result, err := q.client.BRPop(ctx, brpopTimeout, WriteQueueKey).Result()
 	if err == redis.Nil {
+		// Timeout with no items is the expected idle case, not a failure.
+		span.SetAttributes(attribute.Int("queue.item_count", 0))
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("queue: brpop: %w", err)
+		err = fmt.Errorf("queue: brpop: %w", err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "queue: consume brpop failed", "queue", WriteQueueKey, "error", err)
+		return nil, err
 	}
 	// result[0] = key, result[1] = JSON payload.
 	var items []Item
 	if err := json.Unmarshal([]byte(result[1]), &items); err != nil {
-		return nil, fmt.Errorf("queue: unmarshal: %w", err)
+		err = fmt.Errorf("queue: unmarshal: %w", err)
+		span.SetStatus(codes.Error, err.Error())
+		slog.ErrorContext(ctx, "queue: consume unmarshal failed", "queue", WriteQueueKey, "error", err)
+		return nil, err
 	}
+	span.SetAttributes(attribute.Int("queue.item_count", len(items)))
 	return items, nil
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -17,10 +17,33 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/wiebe-xyz/bugbarn/internal/tracing"
 )
+
+// publishCounter and consumeCounter are the write-queue producer/consumer
+// instruments, built once from the global meter (see tracing.Meter) rather
+// than recreated per call.
+var (
+	publishCounter metric.Int64Counter
+	consumeCounter metric.Int64Counter
+)
+
+func init() {
+	m := tracing.Meter()
+	publishCounter, _ = m.Int64Counter(
+		"bugbarn.queue.publish",
+		metric.WithDescription("Write-queue Publish calls, by outcome."),
+		metric.WithUnit("{call}"),
+	)
+	consumeCounter, _ = m.Int64Counter(
+		"bugbarn.queue.consume",
+		metric.WithDescription("Write-queue Consume calls, by outcome."),
+		metric.WithUnit("{call}"),
+	)
+}
 
 // WriteQueueKey is the Redis list backing the write queue.
 const WriteQueueKey = "bugbarn:write-queue"
@@ -141,17 +164,20 @@ func (q *RedisQueue) Publish(ctx context.Context, items []Item) error {
 			err = fmt.Errorf("queue: marshal: %w", err)
 			span.SetStatus(codes.Error, err.Error())
 			slog.ErrorContext(ctx, "queue: publish marshal failed", "queue", WriteQueueKey, "error", err)
+			publishCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "error")))
 			return err
 		}
 		if err := q.client.LPush(ctx, WriteQueueKey, data).Err(); err != nil {
 			err = fmt.Errorf("queue: lpush: %w", err)
 			span.SetStatus(codes.Error, err.Error())
 			slog.ErrorContext(ctx, "queue: publish lpush failed", "queue", WriteQueueKey, "error", err)
+			publishCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "error")))
 			return err
 		}
 		batchCount++
 	}
 	span.SetAttributes(attribute.Int("queue.batch_count", batchCount))
+	publishCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "success")))
 	return nil
 }
 
@@ -167,12 +193,14 @@ func (q *RedisQueue) Consume(ctx context.Context) ([]Item, error) {
 	if err == redis.Nil {
 		// Timeout with no items is the expected idle case, not a failure.
 		span.SetAttributes(attribute.Int("queue.item_count", 0))
+		consumeCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "idle-timeout")))
 		return nil, nil
 	}
 	if err != nil {
 		err = fmt.Errorf("queue: brpop: %w", err)
 		span.SetStatus(codes.Error, err.Error())
 		slog.ErrorContext(ctx, "queue: consume brpop failed", "queue", WriteQueueKey, "error", err)
+		consumeCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "error")))
 		return nil, err
 	}
 	// result[0] = key, result[1] = JSON payload.
@@ -181,9 +209,11 @@ func (q *RedisQueue) Consume(ctx context.Context) ([]Item, error) {
 		err = fmt.Errorf("queue: unmarshal: %w", err)
 		span.SetStatus(codes.Error, err.Error())
 		slog.ErrorContext(ctx, "queue: consume unmarshal failed", "queue", WriteQueueKey, "error", err)
+		consumeCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "error")))
 		return nil, err
 	}
 	span.SetAttributes(attribute.Int("queue.item_count", len(items)))
+	consumeCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", "success")))
 	return items, nil
 }
 

--- a/internal/storage/issues_counts.go
+++ b/internal/storage/issues_counts.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -63,6 +64,8 @@ GROUP BY issue_id, hour_bucket`
 		// Parse the hour bucket to determine how many hours ago it is.
 		t, err := time.Parse("2006-01-02T15", hourBucket)
 		if err != nil {
+			slog.WarnContext(ctx, "storage: malformed hour_bucket timestamp; skipping",
+				"issue_id", issueID, "hour_bucket", hourBucket, "error", err)
 			continue
 		}
 		t = t.UTC()

--- a/internal/storage/issues_upsert.go
+++ b/internal/storage/issues_upsert.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -277,7 +278,12 @@ func (s *core) updateExistingIssue(ctx context.Context, tx *sql.Tx, p existingIs
 	issue.RepresentativeEvent = p.evt
 	// Set display ID for existing issue.
 	var existingPrefix string
-	_ = s.readDB().QueryRowContext(ctx, `SELECT issue_prefix FROM projects WHERE id = ?`, p.projectID).Scan(&existingPrefix)
+	prefixRow := s.readDB().QueryRowContext(ctx,
+		`SELECT issue_prefix FROM projects WHERE id = ?`, p.projectID)
+	if err := prefixRow.Scan(&existingPrefix); err != nil {
+		slog.ErrorContext(ctx, "storage: failed to look up issue prefix; display id will be corrupted",
+			"issue_id", p.id, "project_id", p.projectID, "error", err)
+	}
 	issue.ID = displayIssueID(existingPrefix, p.existingIssueNumber, p.id)
 	return issue, p.id, regressed, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -13,8 +13,10 @@ import (
 	"time"
 
 	"github.com/XSAM/otelsql"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	_ "modernc.org/sqlite"
@@ -58,6 +60,7 @@ func tracedDriver() string {
 				OmitConnPrepare:      true,
 				OmitRows:             true,
 			}),
+			otelsql.WithMeterProvider(otel.GetMeterProvider()),
 		)
 		if err != nil {
 			slog.Warn("otelsql driver registration failed; falling back to plain driver", "err", err)
@@ -66,6 +69,47 @@ func tracedDriver() string {
 		registeredDriver = name
 	})
 	return registeredDriver
+}
+
+// dbStatsRegs tracks the otelsql connection-pool metric registrations keyed
+// by the *sql.DB they observe, so Close can unregister the callback and stop
+// the gauges from reporting stats for a closed pool.
+var (
+	dbStatsRegsMu sync.Mutex
+	dbStatsRegs   = map[*sql.DB]metric.Registration{}
+)
+
+// registerDBStats wires otelsql's observable connection-pool gauges
+// (open/idle/in-use connections, wait counts, etc.) for db, tagged with a
+// "pool" attribute so the read-only and read-write pools are distinguishable
+// in exported metrics. Failures are logged, not fatal: metrics are best
+// effort and must never block opening the database.
+func registerDBStats(db *sql.DB, pool string) {
+	reg, err := otelsql.RegisterDBStatsMetrics(db,
+		otelsql.WithAttributes(semconv.DBSystemSqlite, attribute.String("pool", pool)),
+		otelsql.WithMeterProvider(otel.GetMeterProvider()),
+	)
+	if err != nil {
+		slog.Warn("otelsql db stats metrics registration failed", "pool", pool, "err", err)
+		return
+	}
+	dbStatsRegsMu.Lock()
+	dbStatsRegs[db] = reg
+	dbStatsRegsMu.Unlock()
+}
+
+// unregisterDBStats stops the connection-pool gauges registered for db, if
+// any were registered.
+func unregisterDBStats(db *sql.DB) {
+	dbStatsRegsMu.Lock()
+	reg, ok := dbStatsRegs[db]
+	if ok {
+		delete(dbStatsRegs, db)
+	}
+	dbStatsRegsMu.Unlock()
+	if ok {
+		_ = reg.Unregister()
+	}
 }
 
 // OpenReadOnly opens a read-only connection to an existing SQLite database.
@@ -88,9 +132,11 @@ func OpenReadOnly(path string) (*Store, error) {
 		return nil, err
 	}
 	roDB.SetMaxOpenConns(4)
+	registerDBStats(roDB, "read")
 
 	// Verify the database is reachable.
 	if err := roDB.Ping(); err != nil {
+		unregisterDBStats(roDB)
 		roDB.Close()
 		return nil, err
 	}
@@ -125,17 +171,22 @@ func open(path string, autoMigrate bool) (*Store, error) {
 		return nil, err
 	}
 	db.SetMaxOpenConns(1)
+	registerDBStats(db, "write")
 
 	roDB, err := sql.Open(tracedDriver(), sqliteReadOnlyDSN(absPath))
 	if err != nil {
+		unregisterDBStats(db)
 		db.Close()
 		return nil, err
 	}
 	roDB.SetMaxOpenConns(4)
+	registerDBStats(roDB, "read")
 
 	c := &core{db: db, roDB: roDB}
 	ctx := context.Background()
 	if err := c.init(ctx); err != nil {
+		unregisterDBStats(roDB)
+		unregisterDBStats(db)
 		roDB.Close()
 		db.Close()
 		return nil, err
@@ -156,11 +207,13 @@ func (s *core) Close() error {
 	}
 	var firstErr error
 	if s.roDB != nil {
+		unregisterDBStats(s.roDB)
 		if err := s.roDB.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	if s.db != nil {
+		unregisterDBStats(s.db)
 		if err := s.db.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/internal/tracing/middleware.go
+++ b/internal/tracing/middleware.go
@@ -3,13 +3,51 @@ package tracing
 import (
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// httpMetrics holds the OTel instruments for the HTTP server middleware.
+// Instruments come from the global meter; before tracing.Init wires a
+// MeterProvider they are valid no-op instruments, so construction never fails
+// in tests or when telemetry is disabled.
+type httpMetrics struct {
+	requests metric.Int64Counter
+	duration metric.Float64Histogram
+}
+
+var (
+	httpMetricsOnce sync.Once
+	httpMetricsInst *httpMetrics
+)
+
+// getHTTPMetrics builds the middleware instruments the first time it's
+// called and reuses them thereafter, regardless of how many times
+// Middleware() wraps a handler.
+func getHTTPMetrics() *httpMetrics {
+	httpMetricsOnce.Do(func() {
+		m := Meter()
+		requests, _ := m.Int64Counter(
+			"bugbarn.http.requests",
+			metric.WithDescription("HTTP requests handled by the server, by method, route, and status class."),
+			metric.WithUnit("{request}"),
+		)
+		duration, _ := m.Float64Histogram(
+			"bugbarn.http.request.duration",
+			metric.WithDescription("Wall-clock time to handle an HTTP request, by method and route."),
+			metric.WithUnit("ms"),
+		)
+		httpMetricsInst = &httpMetrics{requests: requests, duration: duration}
+	})
+	return httpMetricsInst
+}
 
 type statusRecorder struct {
 	http.ResponseWriter
@@ -28,6 +66,7 @@ func (r *statusRecorder) Flush() {
 }
 
 func Middleware(next http.Handler) http.Handler {
+	hm := getHTTPMetrics()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extract W3C traceparent from incoming request headers.
 		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
@@ -42,12 +81,25 @@ func Middleware(next http.Handler) http.Handler {
 		)
 		defer span.End()
 
+		start := time.Now()
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rec, r.WithContext(ctx))
+		durMs := float64(time.Since(start)) / float64(time.Millisecond)
 
 		span.SetAttributes(attribute.Int("http.status_code", rec.status))
 		if rec.status >= 500 {
 			span.SetStatus(codes.Error, http.StatusText(rec.status))
 		}
+
+		statusClass := fmt.Sprintf("%dxx", rec.status/100)
+		hm.requests.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("method", r.Method),
+			attribute.String("route", r.URL.Path),
+			attribute.String("status_class", statusClass),
+		))
+		hm.duration.Record(ctx, durMs, metric.WithAttributes(
+			attribute.String("method", r.Method),
+			attribute.String("route", r.URL.Path),
+		))
 	})
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -100,6 +101,12 @@ func initTraces(res *resource.Resource) *sdktrace.TracerProvider {
 		otlptracehttp.WithTimeout(2*time.Second),
 	)
 	if err != nil {
+		// Warn (not Error): this runs during Init, before some callers wrap the
+		// default logger with the selflog/BugBarn self-report handler, and an
+		// Error here would otherwise trigger a self-capture in the middle of
+		// telemetry bootstrap. Traces are best-effort by design (see doc comment
+		// above), so Warn is also the right severity on its own merits.
+		slog.Warn("tracing: failed to build OTLP trace exporter; traces disabled", "error", err)
 		return nil
 	}
 

--- a/web/src/bootstrap.ts
+++ b/web/src/bootstrap.ts
@@ -370,7 +370,10 @@ function initInstallPrompt(): void {
   });
 
   // Also hide the banner once the app is actually installed
-  window.addEventListener("appinstalled", () => dismissInstallBanner());
+  window.addEventListener("appinstalled", () => {
+    window.funnelbarn?.track("pwa_installed");
+    dismissInstallBanner();
+  });
 }
 
 function showInstallBanner(onInstall: () => void): void {

--- a/web/src/http.ts
+++ b/web/src/http.ts
@@ -63,6 +63,7 @@ export async function logout(): Promise<void> {
   } catch {
     // ignore network errors on logout
   }
+  window.funnelbarn?.track("logout", state.username ? { username: state.username } : undefined);
   state.authenticated = false;
   state.username = "";
   stopLiveStream();
@@ -268,6 +269,7 @@ export async function login(username: string, password: string): Promise<void> {
       body: JSON.stringify({ username, password }),
     });
     if (!response.ok) {
+      window.funnelbarn?.track("login_failed", { reason: "invalid_credentials" });
       renderLogin("Invalid username or password.");
       return;
     }
@@ -278,9 +280,11 @@ export async function login(username: string, password: string): Promise<void> {
     if (loginScreen) loginScreen.hidden = true;
     if (appFrame) appFrame.hidden = false;
     updateBBMenuUser();
+    window.funnelbarn?.track("login", state.username ? { username: state.username } : undefined);
     setStatus(state.username ? `Logged in as ${state.username}.` : "Logged in.");
     await Promise.all([loadProjects(), refreshAll()]);
   } catch (error) {
+    window.funnelbarn?.track("login_failed", { reason: errorMessage(error) });
     renderLogin(errorMessage(error));
   }
 }

--- a/web/src/views-alerts.ts
+++ b/web/src/views-alerts.ts
@@ -56,6 +56,7 @@ function wireAlertActions(): void {
 async function deleteAlert(id: string): Promise<void> {
   try {
     await deleteJson(`/api/v1/alerts/${encodeURIComponent(id)}`);
+    window.funnelbarn?.track("alert_deleted", { alertId: id });
     setStatus("Alert deleted.");
     await loadAlerts();
   } catch (error) {
@@ -68,16 +69,19 @@ async function submitAlertForm(form: HTMLFormElement): Promise<void> {
   const cooldownRaw = data.get("cooldown_minutes");
   const thresholdRaw = data.get("threshold");
   const param = String(data.get("param") || "").trim();
+  const name = String(data.get("name") || "");
+  const condition = String(data.get("condition") || "");
   try {
     await postJson("/api/v1/alerts", {
-      name: String(data.get("name") || ""),
-      condition: String(data.get("condition") || ""),
+      name,
+      condition,
       param: param || undefined,
       webhook_url: String(data.get("webhook_url") || ""),
       threshold: thresholdRaw ? Number(thresholdRaw) : undefined,
       cooldown_minutes: cooldownRaw ? Number(cooldownRaw) : undefined,
       enabled: data.get("enabled") !== null,
     });
+    window.funnelbarn?.track("alert_created", { name, condition });
     setStatus("Alert saved.");
     await loadAlerts();
   } catch (error) {

--- a/web/src/views-issue-detail.ts
+++ b/web/src/views-issue-detail.ts
@@ -21,6 +21,7 @@ export async function loadIssueDetail(issueId: string): Promise<void> {
     const events = normalizeList<ApiEvent>(raw, "events");
     const hasMore = Boolean(raw?.["hasMore"]);
     renderIssueDetail(issue, events, hasMore);
+    window.funnelbarn?.track("issue_viewed", { issueId });
   } catch (error) {
     renderErrorDetail(`Issue ${issueId}`, error);
   }
@@ -244,6 +245,7 @@ async function muteIssue(id: string, muteMode: string): Promise<void> {
       body: JSON.stringify({ mute_mode: muteMode }),
     });
     if (res.ok) {
+      window.funnelbarn?.track("issue_muted", { issueId: id, muteMode });
       setStatus(`Issue ${id} muted.`);
       await loadIssues();
       if (state.selectedIssueId === id) {
@@ -261,6 +263,7 @@ async function unmuteIssue(id: string): Promise<void> {
   try {
     const res = await apiFetch(`/api/v1/issues/${encodeURIComponent(id)}/unmute`, { method: "PATCH" });
     if (res.ok) {
+      window.funnelbarn?.track("issue_unmuted", { issueId: id });
       setStatus(`Issue ${id} unmuted.`);
       await loadIssues();
       if (state.selectedIssueId === id) {
@@ -277,6 +280,7 @@ async function unmuteIssue(id: string): Promise<void> {
 async function toggleIssueStatus(issueId: string, status: "resolved" | "unresolved"): Promise<void> {
   try {
     await postJson(`/api/v1/issues/${encodeURIComponent(issueId)}/${status === "resolved" ? "resolve" : "reopen"}`, {});
+    window.funnelbarn?.track(status === "resolved" ? "issue_resolved" : "issue_reopened", { issueId });
     showFlash(`Issue ${issueId} marked ${status}.`, "success");
     await loadIssueDetail(issueId);
     await loadIssues();

--- a/web/src/views-releases.ts
+++ b/web/src/views-releases.ts
@@ -109,16 +109,19 @@ function wireReleaseActions(): void {
 
 async function submitReleaseForm(form: HTMLFormElement): Promise<void> {
   const data = new FormData(form);
+  const name = String(data.get("name") || "");
+  const environment = String(data.get("environment") || "");
   try {
     await postJson("/api/v1/releases", {
-      name: String(data.get("name") || ""),
-      environment: String(data.get("environment") || ""),
+      name,
+      environment,
       observedAt: String(data.get("observedAt") || ""),
       version: String(data.get("version") || ""),
       commitSha: String(data.get("commitSha") || ""),
       url: String(data.get("url") || ""),
       notes: String(data.get("notes") || ""),
     });
+    window.funnelbarn?.track("release_created", { name, environment });
     setStatus("Release marker saved.");
     await loadReleases();
   } catch (error) {

--- a/web/src/views-settings.ts
+++ b/web/src/views-settings.ts
@@ -231,6 +231,7 @@ async function approveProject(slug: string, btn?: HTMLButtonElement): Promise<vo
   if (btn) { btn.disabled = true; btn.textContent = "…"; }
   try {
     await postJson(`/api/v1/projects/${encodeURIComponent(slug)}/approve`, {});
+    window.funnelbarn?.track("project_approved", { slug });
     showFlash(`Project "${slug}" approved.`, "success");
     await loadSettings();
     void checkPendingProjects();
@@ -250,6 +251,7 @@ async function deleteProject(slug: string, btn?: HTMLButtonElement): Promise<voi
       const body = await res.json().catch(() => ({}));
       throw new Error((body as Record<string, string>).error || res.statusText);
     }
+    window.funnelbarn?.track("project_deleted", { slug });
     showFlash(`Project "${slug}" deleted.`, "success");
     await loadSettings();
     void checkPendingProjects();
@@ -262,6 +264,7 @@ async function deleteProject(slug: string, btn?: HTMLButtonElement): Promise<voi
 async function createGroup(name: string): Promise<void> {
   try {
     await postJson("/api/v1/groups", { name });
+    window.funnelbarn?.track("project_group_created", { name });
     showFlash(`Group "${name}" created.`, "success");
     await loadSettings();
   } catch (error) {
@@ -307,6 +310,7 @@ async function removeProjectFromGroup(projectSlug: string): Promise<void> {
 async function createAlias(alias: string, project: string): Promise<void> {
   try {
     await postJson("/api/v1/aliases", { alias, project });
+    window.funnelbarn?.track("project_alias_created", { alias, project });
     showFlash(`Alias "${alias}" → "${project}" created.`, "success");
     await loadSettings();
   } catch (error) {
@@ -346,6 +350,7 @@ async function submitSourceMapsForm(form: HTMLFormElement): Promise<void> {
   const data = new FormData(form);
   try {
     await postFormData("/api/v1/source-maps", data);
+    window.funnelbarn?.track("sourcemaps_uploaded");
     setStatus("Source maps uploaded.");
   } catch (error) {
     setStatus(`Source map upload unavailable: ${errorMessage(error)}`);


### PR DESCRIPTION
Adds OpenTelemetry distributed tracing (spans + attributes across the queue, alert/digest delivery, forwarder, worker, ingest, and CLI paths), fixes exceptions that were caught but never logged, adds OTel metrics (DB, HTTP middleware, queue, alert/digest, worker, ingest, and CLI rate/duration instruments), and adds FunnelBarn product-analytics event tracking (frontend UI events plus a new backend Go SDK integration). Part of a consistent observability pass applied across the barn ecosystem.