### PR TITLE
fix(auth): redirect OIDC callback errors into the SPA, not the marketing site

### DIFF
--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -141,7 +141,7 @@ func (s *Server) oidcCallback(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/api/v1/oidc/login?"+q.Encode(), http.StatusFound)
 		default:
 			http.SetCookie(w, oidcShortLivedCookie(oidcReturnCookie, "", secure))
-			http.Redirect(w, r, "/?oidc_error="+url.QueryEscape(oidcErr), http.StatusFound)
+			http.Redirect(w, r, "/app/?oidc_error="+url.QueryEscape(oidcErr), http.StatusFound)
 		}
 		return
 	}
@@ -176,7 +176,7 @@ func (s *Server) oidcCallback(w http.ResponseWriter, r *http.Request) {
 		if id := claims.PreferredName(); id != "" {
 			q.Set("identity", id)
 		}
-		http.Redirect(w, r, "/?"+q.Encode(), http.StatusFound)
+		http.Redirect(w, r, "/app/?"+q.Encode(), http.StatusFound)
 		return
 	}
 	if s.sessions == nil {


### PR DESCRIPTION
## Summary
- `oidcCallback`'s error paths (protocol error, access-denied) redirected to bare `/`, which is unconditionally served by the separate static marketing site (`deploy/docker/Caddyfile`) — the SPA only lives under `/app/`.
- As a result `renderOIDCAccessDenied()` never ran and OIDC errors silently dead-ended on the marketing homepage with an inert `?oidc_error=...` query string.
- Redirect targets changed from `/` to `/app/` so the SPA actually boots and can show the user a real error.

Found while diagnosing "can't log in via IAMBarn" on testing: the actual unblock was IAMBarn's `oauth_clients.scopes_json` for the bugbarn-testing (and bugbarn-staging) client missing `offline_access`, which BugBarn started unconditionally requesting in the PKCE/session-store migration (`1a30ddb`). That was fixed directly against the live IAMBarn testing/staging DBs (data-only change, no code). This PR is the accompanying code fix for the silent-error-swallowing bug uncovered along the way — it affects every environment for any future OIDC error, not just this one.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Confirmed `iambarn-testing`/`iambarn-staging` client scopes now include `offline_access`, and testing's `/api/v1/oidc/login` redirect is unaffected/still well-formed
- [ ] After deploy, manually trigger an OIDC error against testing and confirm the browser lands under `/app/` with a visible error instead of silently on `/`

https://claude.ai/code/session_01RCKTWP6XT1r872FK3iukxZ