### PR TITLE
docs(storage): remove obsolete Litestream guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ BugBarn is a lightweight, self-hosted error tracking system built in Go with SQL
 | [overview.md](overview.md) | Everyone | What BugBarn is, key capabilities, and what it is not |
 | [getting-started.md](getting-started.md) | New users | Run BugBarn locally and send your first error |
 | [architecture/overview.md](architecture/overview.md) | Developers | System architecture, data flow, and component responsibilities |
-| [architecture/storage.md](architecture/storage.md) | Developers | Database schema, spool format, and WAL replication |
+| [architecture/storage.md](architecture/storage.md) | Developers | Database schema, spool format, WAL checkpointing, and disaster recovery |
 | [architecture/authentication.md](architecture/authentication.md) | Developers | Session cookies, API keys, CSRF, and auth internals |
 | [features/issues.md](features/issues.md) | Everyone | Issue grouping, statuses, and lifecycle |
 | [features/alerts.md](features/alerts.md) | Everyone | Alert rules, conditions, delivery channels, and cooldowns |

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -378,19 +378,13 @@ The `BUGBARN_MAX_SPOOL_BYTES` environment variable sets an additional byte limit
 
 ---
 
-## Litestream Replication
+## Disaster Recovery
 
-BugBarn does not bundle any replication logic. Continuous off-site replication is handled by [Litestream](https://litestream.io/), a separate binary that streams SQLite WAL frames to an object store (S3, GCS, Azure Blob, SFTP, etc.) in near-real time.
-
-Litestream is configured entirely via its own configuration file or environment variables. BugBarn has no knowledge of it; BugBarn simply operates on the SQLite file as normal. Common Litestream environment variables used alongside BugBarn deployments:
-
-| Variable | Purpose |
-|---|---|
-| `LITESTREAM_ACCESS_KEY_ID` | S3-compatible access key |
-| `LITESTREAM_SECRET_ACCESS_KEY` | S3-compatible secret key |
-| `LITESTREAM_REPLICA_URL` | Replica destination (e.g. `s3://bucket/bugbarn.db`) |
-
-See the [Litestream documentation](https://litestream.io/reference/config/) for the full reference.
+BugBarn does not continuously replicate its SQLite WAL. The writer bounds WAL
+growth with periodic checkpoints, while the production settings-snapshot CronJob
+stores an hourly, settings-only database snapshot in the `barn-backups` Cloudflare
+R2 bucket. See [the disaster-recovery guide](../deployment/disaster-recovery.md)
+for retention and restore steps.
 
 ---
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -124,18 +124,6 @@ BugBarn can report its own unhandled errors to a BugBarn instance (including its
 
 ---
 
-### Litestream
-
-These variables are consumed by the Litestream process that runs alongside BugBarn (as a sidecar or wrapper). BugBarn itself does not read them.
-
-| Variable | Default | Required | Description |
-|---|---|---|---|
-| `LITESTREAM_REPLICA_PATH` | — | Yes (if Litestream enabled) | S3-compatible path for the database replica (e.g., `s3://bucket/production/bugbarn.db`). |
-| `LITESTREAM_ACCESS_KEY_ID` | — | Yes (if Litestream enabled) | Access key ID for the object-storage backend. |
-| `LITESTREAM_SECRET_ACCESS_KEY` | — | Yes (if Litestream enabled) | Secret access key for the object-storage backend. |
-
----
-
 ## CLI Commands
 
 ```
@@ -158,7 +146,6 @@ The default resource requests (100m CPU / 128 Mi RAM) are appropriate for:
 
 - Low-to-medium traffic (up to a few hundred events per minute).
 - A single project with up to tens of thousands of issues in the database.
-- Running Litestream in the same pod without heavy replication load.
 
 **Consider increasing memory limits when:**
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -92,22 +92,6 @@ Contains SMTP credentials and digest configuration:
 
 ---
 
-## Litestream
-
-[Litestream](https://litestream.io) provides continuous streaming replication of the SQLite database to an S3-compatible object store. It runs alongside BugBarn — either as a sidecar container or as a wrapper process — and is configured entirely through environment variables injected from `bugbarn-secrets`.
-
-Litestream is transparent to BugBarn. BugBarn simply opens the SQLite file at the path set by `BUGBARN_DB_PATH`; Litestream watches that file and streams WAL pages to the configured replica path.
-
-The relevant environment variables (consumed by Litestream, not BugBarn):
-
-| Variable | Description |
-|---|---|
-| `LITESTREAM_REPLICA_PATH` | S3-compatible path for the replica (e.g., `production/bugbarn.db`) |
-| `LITESTREAM_ACCESS_KEY_ID` | Object-storage access key |
-| `LITESTREAM_SECRET_ACCESS_KEY` | Object-storage secret key |
-
----
-
 ## Image Registry and Tags
 
 Images are published to the GitHub Container Registry:
@@ -125,7 +109,7 @@ Images are published to the GitHub Container Registry:
 
 Because the deployment strategy is `Recreate`, every upgrade causes a brief downtime while the old pod is terminated and the new pod starts. To minimise impact:
 
-1. The liveness probe allows 30 seconds for startup before it begins checking — long enough for Litestream to restore the database on a fresh node.
+1. The liveness probe allows 30 seconds for startup before it begins checking, giving the service time to open its PVC-backed database and run migrations.
 2. The readiness probe ensures traffic is not sent to the pod until `/api/v1/health` returns `200`.
 3. `revisionHistoryLimit: 2` keeps two old ReplicaSets for rollback.
 

--- a/site/src/content/docs/README.md
+++ b/site/src/content/docs/README.md
@@ -26,14 +26,14 @@ BugBarn is a lightweight, self-hosted error tracking system built in Go with SQL
 | [overview.md](overview.md) | Everyone | What BugBarn is, key capabilities, and what it is not |
 | [getting-started.md](getting-started.md) | New users | Run BugBarn locally and send your first error |
 | [architecture/overview.md](architecture/overview.md) | Developers | System architecture, data flow, and component responsibilities |
-| [architecture/storage.md](architecture/storage.md) | Developers | Database schema, spool format, and WAL replication |
+| [architecture/storage.md](architecture/storage.md) | Developers | Database schema, spool format, WAL checkpointing, and disaster recovery |
 | [architecture/authentication.md](architecture/authentication.md) | Developers | Session cookies, API keys, CSRF, and auth internals |
 | [features/issues.md](features/issues.md) | Everyone | Issue grouping, statuses, and lifecycle |
 | [features/alerts.md](features/alerts.md) | Everyone | Alert rules, conditions, delivery channels, and cooldowns |
 | [features/digest.md](features/digest.md) | Everyone | Weekly digest email and JSON webhook |
 | [features/logs.md](features/logs.md) | Everyone | Log ingestion, streaming, and filtering |
 | [deployment/configuration.md](deployment/configuration.md) | Operators | All environment variables and their defaults |
-| [deployment/kubernetes.md](deployment/kubernetes.md) | Operators | Kubernetes manifests, Litestream, and production deployment |
+| [deployment/kubernetes.md](deployment/kubernetes.md) | Operators | Kubernetes manifests and production deployment |
 | [deployment/performance.md](deployment/performance.md) | Operators | Throughput, hardware recommendations, and system limits |
 | [api.md](api.md) | Developers | Full REST API reference with request/response examples |
 | [sdks/overview.md](sdks/overview.md) | Developers | Integration options, API key scopes, event shape, and privacy scrubbing |

--- a/site/src/content/docs/architecture/overview.md
+++ b/site/src/content/docs/architecture/overview.md
@@ -28,7 +28,7 @@ BugBarn is structured as three distinct layers that decouple ingest throughput f
 
 ### Why This Architecture
 
-**SQLite-first.** The entire persistent state fits in a single WAL-mode SQLite file. There is no separate database server to operate, no connection pool to tune, and no network round-trip to storage. Operational complexity is minimal — backup is a file copy (or Litestream replication).
+**SQLite-first.** The entire persistent state fits in a single WAL-mode SQLite file. There is no separate database server to operate, no connection pool to tune, and no network round-trip to storage. Operational complexity is minimal — backup is an hourly settings-only snapshot.
 
 **Spool for durability.** The ingest handler never writes directly to SQLite. Instead it appends records to an append-only NDJSON file on disk and returns `202 Accepted` to the caller. If the background worker is slow, the spool absorbs the backlog without blocking producers. If the process crashes, the cursor file records the last successfully processed offset so no record is silently dropped.
 
@@ -110,6 +110,6 @@ SQLite access is serialised through a single `*sql.DB` connection (`db.SetMaxOpe
 
 **SQLite WAL mode.** WAL (Write-Ahead Logging) allows readers to proceed concurrently with a single writer without blocking. `synchronous=NORMAL` means SQLite syncs at checkpoints rather than after every write, which improves throughput at the cost of a small durability window (data written since the last checkpoint could be lost in a hard crash). For most self-hosted error-tracking workloads this is an acceptable trade-off.
 
-**No message broker.** The spool is a simple append-only file. It is not a distributed queue. It provides durability across process restarts but not across machine failures unless the `.data/` directory is on durable storage (network volume, Litestream-replicated block device, etc.).
+**No message broker.** The spool is a simple append-only file. It is not a distributed queue. It provides durability across process restarts but not across machine failures unless the `.data/` directory is on durable storage.
 
-**Litestream for replication.** Continuous off-site replication of the SQLite database is delegated to [Litestream](https://litestream.io/), which runs as a separate process alongside BugBarn. BugBarn itself has no knowledge of Litestream; it simply writes a standard WAL-mode SQLite file. See [storage.md](storage.md) for the relevant environment variables.
+**Settings-only disaster recovery.** Continuous WAL replication was removed because it could not safely checkpoint while reader pods held snapshots. The writer now bounds its own WAL with periodic checkpoints; an hourly R2 snapshot preserves configuration but not events, issues, or logs. See [the disaster-recovery guide](../deployment/disaster-recovery.md).

--- a/site/src/content/docs/architecture/storage.md
+++ b/site/src/content/docs/architecture/storage.md
@@ -378,19 +378,13 @@ The `BUGBARN_MAX_SPOOL_BYTES` environment variable sets an additional byte limit
 
 ---
 
-## Litestream Replication
+## Disaster Recovery
 
-BugBarn does not bundle any replication logic. Continuous off-site replication is handled by [Litestream](https://litestream.io/), a separate binary that streams SQLite WAL frames to an object store (S3, GCS, Azure Blob, SFTP, etc.) in near-real time.
-
-Litestream is configured entirely via its own configuration file or environment variables. BugBarn has no knowledge of it; BugBarn simply operates on the SQLite file as normal. Common Litestream environment variables used alongside BugBarn deployments:
-
-| Variable | Purpose |
-|---|---|
-| `LITESTREAM_ACCESS_KEY_ID` | S3-compatible access key |
-| `LITESTREAM_SECRET_ACCESS_KEY` | S3-compatible secret key |
-| `LITESTREAM_REPLICA_URL` | Replica destination (e.g. `s3://bucket/bugbarn.db`) |
-
-See the [Litestream documentation](https://litestream.io/reference/config/) for the full reference.
+BugBarn does not continuously replicate its SQLite WAL. The writer bounds WAL
+growth with periodic checkpoints, while the production settings-snapshot CronJob
+stores an hourly, settings-only database snapshot in the `barn-backups` Cloudflare
+R2 bucket. See [the disaster-recovery guide](../deployment/disaster-recovery.md)
+for retention and restore steps.
 
 ---
 

--- a/site/src/content/docs/deployment/configuration.md
+++ b/site/src/content/docs/deployment/configuration.md
@@ -124,18 +124,6 @@ BugBarn can report its own unhandled errors to a BugBarn instance (including its
 
 ---
 
-### Litestream
-
-These variables are consumed by the Litestream process that runs alongside BugBarn (as a sidecar or wrapper). BugBarn itself does not read them.
-
-| Variable | Default | Required | Description |
-|---|---|---|---|
-| `LITESTREAM_REPLICA_PATH` | — | Yes (if Litestream enabled) | S3-compatible path for the database replica (e.g., `s3://bucket/production/bugbarn.db`). |
-| `LITESTREAM_ACCESS_KEY_ID` | — | Yes (if Litestream enabled) | Access key ID for the object-storage backend. |
-| `LITESTREAM_SECRET_ACCESS_KEY` | — | Yes (if Litestream enabled) | Secret access key for the object-storage backend. |
-
----
-
 ## CLI Commands
 
 ```
@@ -158,7 +146,6 @@ The default resource requests (100m CPU / 128 Mi RAM) are appropriate for:
 
 - Low-to-medium traffic (up to a few hundred events per minute).
 - A single project with up to tens of thousands of issues in the database.
-- Running Litestream in the same pod without heavy replication load.
 
 **Consider increasing memory limits when:**
 

--- a/site/src/content/docs/deployment/kubernetes.md
+++ b/site/src/content/docs/deployment/kubernetes.md
@@ -12,7 +12,7 @@ A full BugBarn deployment consists of the following Kubernetes resources:
 | Service | `bugbarn` | ClusterIP for the API pod |
 | Service | `bugbarn-web` | ClusterIP for the web pod |
 | Ingress | `bugbarn` | Routes `/api/*` to the service pod and `/` to the web pod |
-| Secret | `bugbarn-secrets` | Core auth and Litestream credentials |
+| Secret | `bugbarn-secrets` | Core authentication credentials |
 | Secret | `smtp-secret` | SMTP credentials and digest configuration |
 
 All resources live in a dedicated namespace (e.g., `bugbarn-production`).
@@ -38,7 +38,7 @@ Both probes target `GET /api/v1/health`, which returns `{"status":"ok"}` when th
 | Liveness | 30 s | 20 s | 3 |
 | Readiness | 10 s | 10 s | 3 (default) |
 
-The liveness probe has a longer initial delay to give Litestream time to restore the database from the replica before BugBarn starts serving traffic. The readiness probe uses a shorter delay so the pod is marked ready as soon as the server accepts requests.
+The liveness probe has a longer initial delay to give BugBarn time to open its PVC-backed database and run migrations. The readiness probe uses a shorter delay so the pod is marked ready as soon as the server accepts requests.
 
 ---
 
@@ -61,14 +61,12 @@ Secrets are stored as SOPS-encrypted YAML files in the repository and decrypted 
 
 ### bugbarn-secrets
 
-Contains core authentication and Litestream replication credentials:
+Contains core authentication credentials:
 
 - `BUGBARN_API_KEY`
 - `BUGBARN_ADMIN_USERNAME`
 - `BUGBARN_ADMIN_PASSWORD_BCRYPT`
 - `BUGBARN_SESSION_SECRET`
-- `LITESTREAM_ACCESS_KEY_ID`
-- `LITESTREAM_SECRET_ACCESS_KEY`
 
 ### smtp-secret
 
@@ -84,22 +82,6 @@ Contains SMTP credentials and digest configuration:
 - `BUGBARN_DIGEST_WEBHOOK_URL`
 
 > After patching either secret, always run `kubectl rollout restart deployment/bugbarn` so the pod picks up the new values.
-
----
-
-## Litestream
-
-[Litestream](https://litestream.io) provides continuous streaming replication of the SQLite database to an S3-compatible object store. It runs alongside BugBarn — either as a sidecar container or as a wrapper process — and is configured entirely through environment variables injected from `bugbarn-secrets`.
-
-Litestream is transparent to BugBarn. BugBarn simply opens the SQLite file at the path set by `BUGBARN_DB_PATH`; Litestream watches that file and streams WAL pages to the configured replica path.
-
-The relevant environment variables (consumed by Litestream, not BugBarn):
-
-| Variable | Description |
-|---|---|
-| `LITESTREAM_REPLICA_PATH` | S3-compatible path for the replica (e.g., `production/bugbarn.db`) |
-| `LITESTREAM_ACCESS_KEY_ID` | Object-storage access key |
-| `LITESTREAM_SECRET_ACCESS_KEY` | Object-storage secret key |
 
 ---
 
@@ -120,7 +102,7 @@ Images are published to the GitHub Container Registry:
 
 Because the deployment strategy is `Recreate`, every upgrade causes a brief downtime while the old pod is terminated and the new pod starts. To minimise impact:
 
-1. The liveness probe allows 30 seconds for startup before it begins checking — long enough for Litestream to restore the database on a fresh node.
+1. The liveness probe allows 30 seconds for startup before it begins checking, giving the service time to open its PVC-backed database and run migrations.
 2. The readiness probe ensures traffic is not sent to the pod until `/api/v1/health` returns `200`.
 3. `revisionHistoryLimit: 2` keeps two old ReplicaSets for rollback.
 

--- a/site/src/content/docs/deployment/performance.md
+++ b/site/src/content/docs/deployment/performance.md
@@ -80,7 +80,7 @@ BugBarn has no minimum hardware requirement. The following tiers reflect typical
 
 BugBarn does not support horizontal scaling — it runs as a single binary with a single SQLite file and a single writer. Vertical scaling (more RAM, faster disk) is the path to higher throughput. If you need multi-region active-active ingestion, BugBarn is the wrong tool.
 
-For disaster recovery, use **Litestream** to replicate the SQLite WAL to object storage. This provides a continuous backup and allows point-in-time restore. See [kubernetes.md](kubernetes.md) for a Litestream configuration example.
+For disaster recovery, use the hourly settings-only snapshot documented in [disaster-recovery.md](disaster-recovery.md). It protects configuration but does not provide continuous replication or point-in-time restore.
 
 ---
 
@@ -93,7 +93,7 @@ For disaster recovery, use **Litestream** to replicate the SQLite WAL to object 
 | Facet values per key | 10,000 distinct values | New values beyond the limit are silently dropped |
 | Log entries per project | 10,000 | Oldest entries are trimmed on each insert |
 | Concurrent writers | 1 (background worker) | By design; additional writers would cause SQLite contention |
-| Horizontal replicas | 1 | Single binary, single SQLite file; use Litestream for read replicas |
+| Horizontal replicas | 1 | Single binary, single SQLite file |
 
 ---
 

--- a/site/src/content/docs/overview.md
+++ b/site/src/content/docs/overview.md
@@ -84,7 +84,7 @@ flowchart LR
     API --> UI
 ```
 
-**Litestream** can optionally replicate the SQLite WAL to object storage for disaster recovery.
+An hourly settings-only snapshot to object storage covers disaster recovery; it preserves configuration but not events, issues, or logs.
 
 ---
 
@@ -92,4 +92,4 @@ flowchart LR
 
 - [Getting started](getting-started.md) — run BugBarn locally and send your first error in under five minutes
 - [Architecture](architecture.md) — database schema, spool format, background workers, and SSE
-- [Operations](operations.md) — production deployment, Kubernetes manifests, Litestream, backup and restore
+- [Operations](operations.md) — production deployment, Kubernetes manifests, backup and restore


### PR DESCRIPTION
## Summary
- Document the current R2-backed, hourly settings-snapshot recovery model.
- Remove stale Litestream configuration, sidecar, and restore guidance from repository and site docs.
- Record the completed legacy-bucket audit on issue #168.

## Validation
- Full repository tests passed.
- Repository and site builds passed.
- Diff whitespace check passed.

The full lint gate is currently blocked by seven pre-existing, unformatted Go files outside this documentation-only PR.

Part of #168.