### PR TITLE
Publish brew tarballs to R2 instead of the retired MinIO

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -3,22 +3,25 @@ name: Binary Release
 # Builds and publishes bugbarn binaries on every push to main.
 # Publishes to:
 #   - APT repository:      https://webwiebe.nl/apt/  (via rapid-root centralized workflow)
-#   - Homebrew tap (MinIO): https://webwiebe.nl/brew/bugbarn-darwin-*.tar.gz
+#   - Homebrew tap (Cloudflare R2): https://webwiebe.nl/brew/bugbarn-darwin-*.tar.gz
 #   - Homebrew tap (GitHub): webwiebe/homebrew-bugbarn Formula/bugbarn.rb
 #   - GitHub Releases:     attached .deb and .tar.gz files
 #
 # APT publishing is delegated to wiebe-xyz/rapid-root via repository_dispatch —
-# no MinIO credentials or GPG keys needed here for APT.
-# Brew tarballs are uploaded directly to MinIO (bucket: webwiebe-apt-repository,
-# under the brew/ prefix). No --delete flag is ever used, so other apps' files
-# in the shared bucket are never touched.
+# no R2 credentials or GPG keys needed here for APT.
+# Brew tarballs are uploaded directly to R2 (bucket:
+# webwiebe-apt-repository-production, under the brew/ prefix). That prefix is
+# shared with every other publisher, so uploads and prunes are scoped to this
+# tool's own name+arch prefixes — never a bucket-wide sync or LIST, and never
+# --delete. Only the newest 2 versions of each tarball are kept, matching the
+# bucket's 5GB retention policy (wiebe-xyz/rapid-root#2839).
 #
 # Required GitHub secrets:
 #   RAPID_ROOT_DISPATCH_TOKEN  — PAT with repo scope on wiebe-xyz/rapid-root
-#   MINIO_ACCESS_KEY           — MinIO user: webwiebe-apt
-#   MINIO_SECRET_KEY           — MinIO password for webwiebe-apt
-#   MINIO_ENDPOINT             — https://s3.wiebe.xyz
-#   MINIO_BUCKET               — webwiebe-apt-repository
+#   R2_ACCESS_KEY              — Cloudflare R2 S3 access key
+#   R2_SECRET_KEY              — Cloudflare R2 S3 secret key
+#   R2_ENDPOINT                — R2 account S3 endpoint
+#   R2_BUCKET                  — webwiebe-apt-repository-production
 #   TAP_GITHUB_TOKEN           — PAT with repo scope on wiebe-xyz/homebrew-buddy-tools
 
 on:
@@ -285,10 +288,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # macOS: publish tarballs + formula to MinIO and GitHub Homebrew tap
+  # macOS: publish tarballs + formula to R2 and GitHub Homebrew tap
   # ---------------------------------------------------------------------------
   update-brew-repo:
-    name: Update Homebrew Tap (MinIO)
+    name: Update Homebrew Tap (R2)
     runs-on: [self-hosted, build]
     needs: [tag, build-darwin-tarballs]
     steps:
@@ -365,28 +368,67 @@ jobs:
           end
           EOF
 
-      - name: Deploy to MinIO (brew/ prefix — only adds bugbarn files)
+      - name: Deploy to R2 (brew/ prefix — only adds bugbarn files)
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.MINIO_ENDPOINT }}
-          MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
+          for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL R2_BUCKET; do
+            if [ -z "${!var}" ]; then
+              echo "ERROR: ${var} is empty — the R2_* secrets must be configured on this repo."
+              exit 1
+            fi
+          done
           # The self-hosted runner's Homebrew Python is PEP-668 externally-managed,
           # so install awscli into a throwaway venv rather than the global env.
           python3 -m venv .ci-venv
           . .ci-venv/bin/activate
           pip install awscli
-          # Use cp per-file instead of sync to avoid the LIST operation
-          # that consistently times out against the MinIO endpoint from
-          # GitHub Actions runners. --no-delete behaviour is preserved
-          # since we only upload, never remove.
+          # cp per-file rather than sync: the brew/ prefix is shared with every
+          # other publisher, and sync LISTs the whole destination to compute a
+          # delta. cp touches only our own keys.
           find brew-repo -type f | while read f; do
             key="${f#brew-repo/}"
             aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp \
               "$f" \
-              "s3://${MINIO_BUCKET}/brew/${key}" \
+              "s3://${R2_BUCKET}/brew/${key}" \
               --cache-control "public, max-age=3600, must-revalidate"
+          done
+
+      - name: Prune old brew tarballs from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          . .ci-venv/bin/activate
+          # Keep only the newest 2 versions of each tarball this job publishes,
+          # matching the bucket's 5GB retention policy (rapid-root#2839).
+          # Scoped to our own name+arch prefixes — a targeted list per prefix,
+          # never a bucket-wide LIST.
+          KEEP=2
+          for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
+            aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
+              --bucket "$R2_BUCKET" --prefix "brew/${GROUP}-" \
+              --query 'Contents[].Key' --output text 2>/dev/null \
+              | tr '\t' '\n' | grep -E '\.tar\.gz$' | sort -V > /tmp/${GROUP}-versions.txt || true
+
+            COUNT=$(wc -l < /tmp/${GROUP}-versions.txt)
+            DROP=$((COUNT - KEEP))
+            if [ "$DROP" -gt 0 ]; then
+              head -n "$DROP" /tmp/${GROUP}-versions.txt | while read -r key; do
+                echo "Pruning old brew tarball: $key"
+                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}"
+                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}.sha256" || true
+              done
+            else
+              echo "${GROUP}: ${COUNT} tarball(s) in R2, nothing to prune."
+            fi
           done
 
   update-homebrew-tap:

--- a/.woodpecker/binary-release.yaml
+++ b/.woodpecker/binary-release.yaml
@@ -1,6 +1,6 @@
 # Binary release — ported from .github/workflows/binary-release.yml to Woodpecker.
 # Auto-bumps a patch tag, builds linux .debs + macOS tarballs, and publishes to
-# GitHub Releases, the rapid-root APT repo, MinIO (brew CDN) and the Homebrew tap.
+# GitHub Releases, the rapid-root APT repo, Cloudflare R2 (brew CDN) and the Homebrew tap.
 #
 # The 7 GitHub jobs (which passed files via upload/download-artifact) are collapsed
 # into ONE workflow whose steps share the workspace. Mac Mini build agent (local
@@ -10,7 +10,7 @@
 #
 # Secrets: github_token (release_tag_pat — GitHub releases/tap/dispatch/tag),
 # gitea_token (push the bump tag to Gitea -> triggers release.yaml staging deploy),
-# minio_access_key/minio_secret_key/minio_endpoint/minio_bucket.
+# r2_access_key/r2_secret_key/r2_endpoint/r2_bucket.
 # Release on every push to main (validated on Woodpecker; the GitHub
 # binary-release workflow is disabled). Also runnable manually.
 when:
@@ -127,17 +127,18 @@ steps:
           --field "client_payload[tag]=$VERSION" \
           --field 'client_payload[asset_pattern]=*.deb'
 
-  - name: minio-brew-cdn
+  - name: r2-brew-cdn
     image: bash
     environment:
       AWS_ACCESS_KEY_ID:
-        from_secret: minio_access_key
+        from_secret: r2_access_key
       AWS_SECRET_ACCESS_KEY:
-        from_secret: minio_secret_key
+        from_secret: r2_secret_key
+      AWS_DEFAULT_REGION: auto
       AWS_ENDPOINT_URL:
-        from_secret: minio_endpoint
-      MINIO_BUCKET:
-        from_secret: minio_bucket
+        from_secret: r2_endpoint
+      R2_BUCKET:
+        from_secret: r2_bucket
     commands:
       - |
         set -euo pipefail
@@ -154,9 +155,39 @@ steps:
         gen_formula Bugbarn bugbarn bugbarn "$AMD64_SHA" "$ARM64_SHA"
         gen_formula Bb bb bb "$BB_AMD64_SHA" "$BB_ARM64_SHA"
         python3 -m venv .ci-venv && . .ci-venv/bin/activate && pip install -q awscli
+        for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL R2_BUCKET; do
+          eval "v=\$$$var"
+          if [ -z "$v" ]; then
+            echo "ERROR: $var is empty — the r2_* Woodpecker secrets must be set."
+            exit 1
+          fi
+        done
+        # cp per file, never `s3 sync`: the brew/ prefix is shared with every
+        # other publisher and sync LISTs the whole destination to compute a delta.
         find brew-repo -type f | while read -r f; do
           KEY=$${f#brew-repo/}
-          aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp "$f" "s3://$MINIO_BUCKET/brew/$KEY" --cache-control "public, max-age=3600, must-revalidate"
+          aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp "$f" "s3://$R2_BUCKET/brew/$KEY" --cache-control "public, max-age=3600, must-revalidate"
+        done
+        # Keep only the newest 2 versions of each tarball this pipeline
+        # publishes — the bucket's 5GB retention policy (rapid-root#2839).
+        # Scoped to our own name+arch prefixes, never a bucket-wide LIST.
+        KEEP=2
+        for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
+          aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
+            --bucket "$R2_BUCKET" --prefix "brew/$GROUP-" \
+            --query 'Contents[].Key' --output text 2>/dev/null \
+            | tr '\t' '\n' | grep -E '\.tar\.gz$$' | sort -V > /tmp/$GROUP.txt || true
+          COUNT=$$(wc -l < /tmp/$GROUP.txt)
+          DROP=$$((COUNT - KEEP))
+          if [ "$DROP" -gt 0 ]; then
+            head -n "$DROP" /tmp/$GROUP.txt | while read -r key; do
+              echo "Pruning old brew tarball: $key"
+              aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://$R2_BUCKET/$key"
+              aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://$R2_BUCKET/$key.sha256" || true
+            done
+          else
+            echo "$GROUP: $COUNT tarball(s) in R2, nothing to prune."
+          fi
         done
 
   - name: homebrew-tap

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,10 @@ woodpecker-secrets-sync:
 	put ghcr_token            "$$(get ghcr_token)"; \
 	put ghcr_pull_pat         "$$(get ghcr_pull_pat)"; \
 	put bugbarn_api_key       "$$(get bugbarn_api_key)"; \
+	put r2_access_key         "$$(get r2_access_key)"; \
+	put r2_secret_key         "$$(get r2_secret_key)"; \
+	put r2_endpoint           "$$(get r2_endpoint)"; \
+	put r2_bucket             "$$(get r2_bucket)"; \
 	put sops_age_key_testing    "$$AGE_KEY"; \
 	put sops_age_key_staging    "$$AGE_KEY"; \
 	put sops_age_key_production  "$$AGE_KEY"; \

--- a/deploy/ci-secrets.yaml
+++ b/deploy/ci-secrets.yaml
@@ -1,23 +1,18 @@
 #ENC[AES256_GCM,data:66NCmpN6m0LUpe3GUctMNbPdOmO8XKpgx6a4uYEUvJHE3VS1bTq1pj2N0ri++UnOY0Oev0SVaVu1YVVBew==,iv:FTeo4JcqMI0U1UTZgjBoFGjJLWGdgaerjxVPlhEx5xI=,tag:uDMw8sxShXCatb/AVlSAbQ==,type:comment]
-minio:
-    access_key: ENC[AES256_GCM,data:kRGFKKWK3Ic3LZPV,iv:gN6p9PKd7FSFba1FAjAm8piJoFpcWL+SAqSaqdXqqTY=,tag:ggZShF1POysYPTMfd3GgEw==,type:str]
-    secret_key: ENC[AES256_GCM,data:AzRqvclgqkC4dm0v/oxdPUFxvqvlS5kz,iv:zpzf5dwzFfFU9y809mS3Sp0ChqfIcIo0Shc1fD2W4Hc=,tag:iyu5Ns91DbZtT0cC5LrIIw==,type:str]
-    endpoint: ENC[AES256_GCM,data:2FjYAvO2MFnl/pTspHlQZeAtYag=,iv:5tamEupOJfdaixeXwrE4OLecfeVIROZA5sT+7lDMRPw=,tag:Z8TODDyrDVItzm74jdXljg==,type:str]
-    bucket: ENC[AES256_GCM,data:POpIMJ8eCSVkCIHw57YwVGg8gJ6Yyy0=,iv:ilrYMFlKUJcXi0Rzghv8bRyZz+Yawi+/6S8VihzZv1c=,tag:6BYBhyU7A0iByJdyRNZnfQ==,type:str]
 npm:
     token: ENC[AES256_GCM,data:qfm+8J7cCBco6aq9X2vfeoCkPQoIOxP90qnVcjTTPOPJxcJl5TEEug==,iv:gopSnSwuB2iQVUgTe2FyBELW4RhUXR1+Jg9Y7ulPWqA=,tag:ZL464A5TiSNh9mACmekQbg==,type:str]
 pypi:
     token: ENC[AES256_GCM,data:E3S/SCC3uKYCY9qMoMlR66BLrXeOLM0/iN2V95oz61GffmVBFpJFoRAC9v5Somxl48UOm2skfxXmArjVPBNqxFwH/EcCrRkXMn7z5vx2QkI32rnjTcjH0MWQ1wjFqjHZHJMvyU0SprFUhts+x6X7Nxjyz58/wmQmGEYaQ3F3JM6lwslhzgy7IQInKyhuMAdfljBFn80TJ2xT184S4RnXrmuiHNTgu3k9wDj06xqUd9bAdjw=,iv:PpBXkbGW6b52BtznxSO3037BPwLD7A+rYvstuZAsCq0=,tag:C/KpXesEzfxEDqBj47Nd0w==,type:str]
 github:
     release_tag_pat: ENC[AES256_GCM,data:9XI/O7FwotbVpohApnQ+pCqMnVE3wqyZ6ym1UnFhfj2YPn1v6zWOkw==,iv:M5aKFIOdfolfa4PxLVVu/GxaGVX3Au5CosDEGzfkPT0=,tag:kQiDfrr+i9Y/hRwJhi5wBQ==,type:str]
+r2:
+    access_key: ENC[AES256_GCM,data:GfQgbURpuCe0ZhgpNVy1hEFQk/sIt74GEFp6V4YdLtQ=,iv:VEnedzmVlM8zTtInRhhNWUochpmcWCPCB2W95TO+FiI=,tag:IzCJQlOHCxUqrAJF0PR+WQ==,type:str]
+    secret_key: ENC[AES256_GCM,data:fqTVj4+MyukltOzH0QpLSNx3/BXnZKfVew0Ulwvf7RgFzmr+SHZ0i4Kg/45Rl9SR4Rh67c85c1L6wtfhWLfdVQ==,iv:yDMTCHsmZsusTER7BA1HZ1tXbjXv4FlUavdhHhHkgIg=,tag:OaIHdOLhhwT3qwCYW1XptA==,type:str]
+    endpoint: ENC[AES256_GCM,data:IbKqfhIl0l7Fth/lzBuB9uvD1AUs6HBSGtMau/dywWwBGAs9mXKaZquUll3yZUjM6ZLq4A0QJH5bohJDqKCXqK+4fuE=,iv:Kmfea3fJinmEJciNKVA5dIllRssUcukLgjy0fm9Sp00=,tag:+mLXkeLRUg+voTEtVFg3Gg==,type:str]
+    bucket: ENC[AES256_GCM,data:kvienqlVdv/JAkJAsyj87Xd8aY7ra5OgXCd3QzMcoprrZA==,iv:jaNXmKzmXee208yPjY53PXCH8Ywi1ml7wKYdVaqp75A=,tag:wP2bbIuEQ4FpENDGdMTF1w==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUSEY0eWdsajhFWkttLzUw
             VDVQeVEzVVhWVVRpWnlVZzlWRTl2S3VMM1NBCjcrYTRwTVM3OHJnUzNpei9BMStP
@@ -25,8 +20,8 @@ sops:
             bUxVK01xR3VCNEEwYzBqMnVvZmE2NjQKLL9MbTRwWyp/auRXeWytQR29W/Exbi9Y
             fDXC0Ob8zoMLpzMmCdHfP4filAWuMY/COXQj1PH6MPJolw+/dliuog==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T20:16:52Z"
-    mac: ENC[AES256_GCM,data:xscxWaU6Bc2uB/KglVeQ92rnJ1/KsOC1XSUuJ0oA2qPAsOu3I/JmbW6I5LezXBc8s+cMYxLhtW3QqBUDrH7vTcK9B7Zx1GyOF5cbGlLtD2byMbWdSFS0D0dlDLxs6HiIlBpiLOch39MDnjjFvcAXp7rq1Rqq2suKFMy0DcHj/d0=,iv:z5NqKPnYm8VjEKkHTHIVZJxIXR/E0GKGXosG+zR9Idc=,tag:th7O1WzVFddsXjCGHzqOGg==,type:str]
-    pgp: []
+          recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
+    lastmodified: "2026-09-05T13:31:37Z"
+    mac: ENC[AES256_GCM,data:06IFiguZPAtIMckfIqEahMCxt+mUWXfa66DwnKhovA8a5MX9hxHGscAicbprgWF/7YMeUk4VgZPYysHyzPrkHStM5s77MANmoN0CK3VKFMAmFKY+7fDehCvWcafIwJtRzD+zad2JDceLou76w6a4XHufKp2FEPls0km9RevQXs4=,iv:x7ztSSXyTwyV+gT3Oha8914if5/Zb07TZWUpBypRi9E=,tag:XpF16wXc606st6yElOhNiA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/woodpecker-secrets.yaml
+++ b/deploy/woodpecker-secrets.yaml
@@ -17,10 +17,13 @@
 ghcr_token: ENC[AES256_GCM,data:7MT5k2SFksHEAg1AgqzHpdWNYO4nkR1mh4c4S1fOyPYIaQzIomkHPw==,iv:IexliD0pboza1mK35SLCjlr/462AZjOPGFA+42dt8WM=,tag:pL3cb4cLvsfxDaFx6OdkHQ==,type:str]
 ghcr_pull_pat: ENC[AES256_GCM,data:h075y+wH8PVbbHD6BAsEWj6NmUTeMJjV+gZgDWjfB2uGAHCgjHWPcg==,iv:VzvfSuDgVWbGRXqb1AlbKLkQE1LwQAoywf2aEU7ugK4=,tag:ZqyfBgTgjLUrcmt9q0aeGA==,type:str]
 bugbarn_api_key: ENC[AES256_GCM,data:9YviVIhQWarH3c31g4Khwu1cjeTczI+XyugWUSJCSrAqw4YBNVTA7apL7wHhH7V5,iv:+nAY9caIKdgiJ/rxH+nhCoODq9W0P56zxhOodcNar+g=,tag:u90rMbv50F0vMnkgjwKXrw==,type:str]
+r2_access_key: ENC[AES256_GCM,data:LA0fGjeLb5HthKPDutemvBe8r6Guf4WUel8VXaqMaW0=,iv:Ut1E2DOZkSJ8CT7T33lzMGAE2n0VHdNq44ckm8yTOpQ=,tag:DamfFh+rFqnHTNeWSs8aDw==,type:str]
+r2_secret_key: ENC[AES256_GCM,data:S73fBA37CR7Dcp4YtTqzTp9pFloSb2hAq+WwS1y4kfQ+aTd8cUJ/XR6weZ04g3DntpY6N4u5n6BAhyWVFUcJOA==,iv:wjsAW7vwVb2/0SFqSlWTZLeY2CH0R0VYujWlZNrQ1vI=,tag:emAPlN/h1KAHB7Z8VTq83A==,type:str]
+r2_endpoint: ENC[AES256_GCM,data:zC+OWC4LGqAA+rXpRtK1N3wHtx9yJZgcuJPQslnOJSzE0bW0v12xQ1sJpA7g/+HE9LbNdJno4Z7RaieCW5WMNu/8B3g=,iv:K10X6HSG4ECnzy3YSflDmVZWwrnbOkWmrG1jWlcwEuQ=,tag:Ub2YM1zGrX6VXvYxQcvcmQ==,type:str]
+r2_bucket: ENC[AES256_GCM,data:iJoq5HNLJlQIyqtvwdolHGCgb76I6jqPI/TMBQHqyj24JA==,iv:wrs/eC/Q2WskJscA5xSB5nK9YEhPxQE/4rVQZwAyE4Q=,tag:5lwgSqotjm7hs9wrmZkkUA==,type:str]
 sops:
     age:
-        - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIaE5kR3pUWmx5MDVqbW1t
             V0hzMThRdzIrek1PcTRlTHVROXdPcGJoRVV3CmFIQWJlNFR4a2pqaTh5WUtnSXZK
@@ -28,7 +31,8 @@ sops:
             OCtXMnl3eGdkTXdFUW5oRjRwQkxJclEKp7LrTDM8bmojm5ZZKpYxzRBNpOgizPAd
             LmLzS4nmXPKmH8o59BfzSvw/abvWujb+n7ZK1/YS2sRKxBgnBhN1Qw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-29T20:42:13Z"
-    mac: ENC[AES256_GCM,data:eeHAM9/jePktw/VubZsWYVF/nkUPhKhiZMNr2OFalZnJeQgTqK3oqY/IT+UmXS+8bIcS7gf18dR+Wt7hoTA+V+Oryq6wOx9oHTtiWX4MbGHib7Svkvw3tnw56gJ+3Kgw5yrEWLWFWMCOgCdTCY+Q9q6HmxVPkjU+/oXmg3nMEZ4=,iv:M7J0eCD+XpeNoW9Qi2B0/Di4nv2Sm2G1yE1iEwS03Bk=,tag:JZlIptOP98ikRrjTYVbWFA==,type:str]
+          recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
+    lastmodified: "2026-09-05T13:31:30Z"
+    mac: ENC[AES256_GCM,data:GBIGv+h0nXKhB8dwO19lvqsaBbx+vBJwTS/KCqTX9p2vMJ1r5jViSPfo/pYNtqjKgc/L7Rck4ez055MG4MmG0JDDhcvGAAIBXffPQgqmOMZrypCVRePlm3V0nU1sNQMLkFJ77CgYaFjivX6yxsyCPzuPuEHCBsawIfOKiFjLBJU=,iv:BfS5hYrxkXQYE/kxD5YlCBf24x4XPFhFW9/W/8wdDNA=,tag:sl4H4VOC9dJI10tghGWNcg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

The shared MinIO on layer7 is being wound down and the read path already moved to R2 (`wiebe-xyz/rapid-root#2799`, closed as completed). This repo still uploaded brew tarballs to MinIO from both pipelines.

Unlike funnelbarn, **bugbarn is not broken today** — 0.236.170 resolves on `webwiebe.nl/brew` and the tap formula matches. It breaks the moment MinIO is switched off. Fixing it before that, not after.

Supersedes #170, which was closed unmerged.

## Which pipeline actually publishes

`.woodpecker/binary-release.yaml` is the live one. The GitHub Actions release workflow last ran on 2026-06-30 and failed three times, so it is not the active path. Both are migrated so they don't drift.

## Changes

- **Woodpecker `minio-brew-cdn` → `r2-brew-cdn`**: `r2_*` secrets, `AWS_DEFAULT_REGION: auto` (R2 signing needs it), plus the retention step from `rapid-root#2839` — newest 2 versions per tarball per arch across all four groups this pipeline publishes (`bugbarn` and `bb`, amd64 and arm64).
- **GitHub Actions workflow**: same migration, including the prune step.
- **Both fail loudly on a missing R2 secret.** A publish that silently goes nowhere is how funnelbarn's tap drifted four releases unnoticed.
- **Uploads stay per-file `cp`, never `s3 sync`** — the `brew/` prefix is shared with every other publisher, and `sync` LISTs the whole destination to compute a delta.
- `deploy/ci-secrets.yaml`: `minio` block replaced with `r2`.
- `deploy/woodpecker-secrets.yaml`: gains the four `r2_*` values (SOPS-encrypted), and `make woodpecker-secrets-sync` now pushes them.

After this, `grep -ri minio` over the repo returns nothing.

## Testing

- Both YAML files parse. `actionlint`: 16 findings, identical to baseline, all pre-existing `info`-level SC2086 in untouched steps.
- **Prune selection dry-run against the real bucket** using the production R2 credentials:

```
bugbarn-darwin-amd64: 198 tarballs -> prune 196, keep 0.236.169, 0.236.170
bugbarn-darwin-arm64: 198 tarballs -> prune 196, keep 0.236.169, 0.236.170
bb-darwin-amd64:      164 tarballs -> prune 162, keep 0.236.169, 0.236.170
bb-darwin-arm64:      164 tarballs -> prune 162, keep 0.236.169, 0.236.170
```

The kept versions match what is currently published, so the newest release stays installable.

## Before this can publish

The four GitHub `R2_*` secrets are **already set** on this repo. The Woodpecker side is not, and I could not set it — `woodpecker-cli` isn't installed here and there is no server token. The values are already staged in the SOPS file, so it is one command:

```
export WOODPECKER_SERVER=https://woodpecker.nijmegen.wiebe.xyz
export WOODPECKER_TOKEN=...   # woodpecker-cli setup
make woodpecker-secrets-sync
```

Until that runs, the brew step fails loudly rather than publishing nowhere.

## Heads-up on the first prune

The bucket holds 724 bugbarn/bb tarballs. The first run deletes 716 of them plus their `.sha256` files, permanently. That is the intended `rapid-root#2839` policy and matches what funnelbarn's cutover did, but it is not reversible — raise `KEEP` before merging if you want more history.