### PR TITLE
ci(brew): keep 10 versions per tarball instead of 2

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -13,7 +13,7 @@ name: Binary Release
 # webwiebe-apt-repository-production, under the brew/ prefix). That prefix is
 # shared with every other publisher, so uploads and prunes are scoped to this
 # tool's own name+arch prefixes — never a bucket-wide sync or LIST, and never
-# --delete. Only the newest 2 versions of each tarball are kept, matching the
+# --delete. Only the newest 10 versions of each tarball are kept, matching the
 # bucket's 5GB retention policy (wiebe-xyz/rapid-root#2839).
 #
 # Required GitHub secrets:
@@ -407,11 +407,11 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
           . .ci-venv/bin/activate
-          # Keep only the newest 2 versions of each tarball this job publishes,
+          # Keep only the newest 10 versions of each tarball this job publishes,
           # matching the bucket's 5GB retention policy (rapid-root#2839).
           # Scoped to our own name+arch prefixes — a targeted list per prefix,
           # never a bucket-wide LIST.
-          KEEP=2
+          KEEP=10
           for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
             aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
               --bucket "$R2_BUCKET" --prefix "brew/${GROUP}-" \

--- a/.woodpecker/binary-release.yaml
+++ b/.woodpecker/binary-release.yaml
@@ -168,10 +168,10 @@ steps:
           KEY=$${f#brew-repo/}
           aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp "$f" "s3://$R2_BUCKET/brew/$KEY" --cache-control "public, max-age=3600, must-revalidate"
         done
-        # Keep only the newest 2 versions of each tarball this pipeline
+        # Keep only the newest 10 versions of each tarball this pipeline
         # publishes — the bucket's 5GB retention policy (rapid-root#2839).
         # Scoped to our own name+arch prefixes, never a bucket-wide LIST.
-        KEEP=2
+        KEEP=10
         for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
           aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
             --bucket "$R2_BUCKET" --prefix "brew/$GROUP-" \


### PR DESCRIPTION
Follow-up to #172. Raises the R2 brew prune from `KEEP=2` to `KEEP=10` in both pipelines before the retention step ever runs.

## Why

#172 merged with `KEEP=2`, which would have permanently deleted 716 tarballs on its first run, leaving only `0.236.169` and `0.236.170` per group. Pipeline 231 was stopped before it reached `r2-brew-cdn`, so nothing has been pruned yet and the bucket is intact.

At `KEEP=10` the first run deletes 684 instead, leaving a contiguous `0.236.161`-`0.236.170` window per group — roughly ten releases of rollback history.

## Bucket numbers

The shared `brew/` prefix holds **2225 objects / 10.3 GiB** against a 5 GB policy. bugbarn's four groups are **8.3 GB** of that:

```
bugbarn-darwin-amd64  198 tarballs, 3182 MB
bugbarn-darwin-arm64  198 tarballs, 3030 MB
bb-darwin-amd64       164 tarballs, 1075 MB
bb-darwin-arm64       164 tarballs, 1015 MB
```

Pruning at 10 frees ~7.6 GB and lands the prefix near 2.7 GB, under the policy. Pruning at 2 would have freed ~8.0 GB — 0.4 GB more for eight releases less history.

## Verification

Read-only dry-run against the production bucket with the real R2 credentials, using the same list/sort/select logic as the pipeline:

```
bugbarn-darwin-amd64  198 tarballs -> prune 188, keep 0.236.161 ... 0.236.170
bugbarn-darwin-arm64  198 tarballs -> prune 188, keep 0.236.161 ... 0.236.170
bb-darwin-amd64       164 tarballs -> prune 154, keep 0.236.161 ... 0.236.170
bb-darwin-arm64       164 tarballs -> prune 154, keep 0.236.161 ... 0.236.170
```

Both YAML files parse. The four `r2_*` Woodpecker secrets are now set (events: `manual, push, tag`), so the brew step has what it needs.

https://claude.ai/code/session_01Prwv9SwhJRG337h1ucHeqi