### PR TITLE
ci(brew): batch the R2 prune and run it after the tap is published

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -420,15 +420,27 @@ jobs:
 
             COUNT=$(wc -l < /tmp/${GROUP}-versions.txt)
             DROP=$((COUNT - KEEP))
-            if [ "$DROP" -gt 0 ]; then
-              head -n "$DROP" /tmp/${GROUP}-versions.txt | while read -r key; do
-                echo "Pruning old brew tarball: $key"
-                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}"
-                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}.sha256" || true
-              done
-            else
+            if [ "$DROP" -le 0 ]; then
               echo "${GROUP}: ${COUNT} tarball(s) in R2, nothing to prune."
+              continue
             fi
+            head -n "$DROP" /tmp/${GROUP}-versions.txt > /tmp/${GROUP}-drop.txt
+            echo "${GROUP}: ${COUNT} tarball(s), pruning ${DROP}, keeping newest ${KEEP}."
+            # Batch DeleteObjects rather than `s3 rm` per key: one process spawn
+            # per object took ~7s under load and the step was killed mid-prune.
+            # 400 tarballs per chunk = 800 keys with their .sha256 siblings,
+            # under the 1000-key limit. Deleting an absent .sha256 is not an
+            # error, so no per-key existence check is needed.
+            rm -f /tmp/${GROUP}-chunk.*
+            split -l 400 /tmp/${GROUP}-drop.txt /tmp/${GROUP}-chunk.
+            for CHUNK in /tmp/${GROUP}-chunk.*; do
+              awk 'BEGIN { printf "{\"Objects\":[" }
+                   { printf "%s{\"Key\":\"%s\"},{\"Key\":\"%s.sha256\"}", (NR>1 ? "," : ""), $0, $0 }
+                   END { printf "],\"Quiet\":true}" }' "$CHUNK" > "$CHUNK.json"
+              aws --endpoint-url "$AWS_ENDPOINT_URL" s3api delete-objects \
+                --bucket "$R2_BUCKET" --delete "file://$CHUNK.json" >/dev/null
+              echo "  deleted $(wc -l < "$CHUNK") tarball(s) and their .sha256 files"
+            done
           done
 
   update-homebrew-tap:

--- a/.woodpecker/binary-release.yaml
+++ b/.woodpecker/binary-release.yaml
@@ -168,27 +168,6 @@ steps:
           KEY=$${f#brew-repo/}
           aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp "$f" "s3://$R2_BUCKET/brew/$KEY" --cache-control "public, max-age=3600, must-revalidate"
         done
-        # Keep only the newest 10 versions of each tarball this pipeline
-        # publishes — the bucket's 5GB retention policy (rapid-root#2839).
-        # Scoped to our own name+arch prefixes, never a bucket-wide LIST.
-        KEEP=10
-        for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
-          aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
-            --bucket "$R2_BUCKET" --prefix "brew/$GROUP-" \
-            --query 'Contents[].Key' --output text 2>/dev/null \
-            | tr '\t' '\n' | grep -E '\.tar\.gz$$' | sort -V > /tmp/$GROUP.txt || true
-          COUNT=$$(wc -l < /tmp/$GROUP.txt)
-          DROP=$$((COUNT - KEEP))
-          if [ "$DROP" -gt 0 ]; then
-            head -n "$DROP" /tmp/$GROUP.txt | while read -r key; do
-              echo "Pruning old brew tarball: $key"
-              aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://$R2_BUCKET/$key"
-              aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://$R2_BUCKET/$key.sha256" || true
-            done
-          else
-            echo "$GROUP: $COUNT tarball(s) in R2, nothing to prune."
-          fi
-        done
 
   - name: homebrew-tap
     image: bash
@@ -208,3 +187,55 @@ steps:
         git config user.email ci@wiebe.xyz
         git add Formula/bugbarn.rb Formula/bb.rb
         if git diff --staged --quiet; then echo "no formula changes"; else git commit -m "Update formula to $VERSION_NUM"; git push; fi
+
+  # Retention runs AFTER the tap is published, and never with `s3 rm` per
+  # object: one process spawn per key took ~7s under load and the step was
+  # killed mid-prune, which cancelled homebrew-tap and left the tap stale.
+  # DeleteObjects removes up to 1000 keys per call, so a group is one request.
+  # Keeps the newest 10 versions of each tarball this pipeline publishes, per
+  # the bucket's 5GB retention policy (rapid-root#2839). Scoped to our own
+  # name+arch prefixes, never a bucket-wide LIST.
+  - name: r2-brew-prune
+    image: bash
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: r2_access_key
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: r2_secret_key
+      AWS_DEFAULT_REGION: auto
+      AWS_ENDPOINT_URL:
+        from_secret: r2_endpoint
+      R2_BUCKET:
+        from_secret: r2_bucket
+    commands:
+      - |
+        set -euo pipefail
+        . .ci-venv/bin/activate
+        KEEP=10
+        for GROUP in bugbarn-darwin-amd64 bugbarn-darwin-arm64 bb-darwin-amd64 bb-darwin-arm64; do
+          aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
+            --bucket "$R2_BUCKET" --prefix "brew/$GROUP-" \
+            --query 'Contents[].Key' --output text 2>/dev/null \
+            | tr '\t' '\n' | grep -E '\.tar\.gz$$' | sort -V > /tmp/$GROUP.txt || true
+          COUNT=$$(wc -l < /tmp/$GROUP.txt)
+          DROP=$$((COUNT - KEEP))
+          if [ "$DROP" -le 0 ]; then
+            echo "$GROUP: $COUNT tarball(s) in R2, nothing to prune."
+            continue
+          fi
+          head -n "$DROP" /tmp/$GROUP.txt > /tmp/$GROUP.drop
+          echo "$GROUP: $COUNT tarball(s), pruning $DROP, keeping newest $KEEP."
+          # 400 tarballs per chunk = 800 keys with their .sha256 siblings,
+          # under the 1000-key DeleteObjects limit. Deleting an absent
+          # .sha256 is not an error, so no per-key existence check is needed.
+          rm -f /tmp/$GROUP.chunk.*
+          split -l 400 /tmp/$GROUP.drop /tmp/$GROUP.chunk.
+          for CHUNK in /tmp/$GROUP.chunk.*; do
+            awk 'BEGIN { printf "{\"Objects\":[" }
+                 { printf "%s{\"Key\":\"%s\"},{\"Key\":\"%s.sha256\"}", (NR>1 ? "," : ""), $$0, $$0 }
+                 END { printf "],\"Quiet\":true}" }' "$CHUNK" > "$CHUNK.json"
+            aws --endpoint-url "$AWS_ENDPOINT_URL" s3api delete-objects \
+              --bucket "$R2_BUCKET" --delete "file://$CHUNK.json" >/dev/null
+            echo "  deleted $$(wc -l < "$CHUNK") tarball(s) and their .sha256 files"
+          done
+        done


### PR DESCRIPTION
Follow-up to #172 / #173. The retention step failed on its first live run; this fixes the cause and the blast radius.

## What happened

Pipeline 234 published all four tarballs to R2 correctly, then `r2-brew-cdn` was killed 169s in having deleted only ~24 objects.

Each `aws s3 rm` spawns a fresh Python interpreter, so a single key cost roughly 7s on a loaded runner. 684 tarballs plus their `.sha256` siblings is ~1368 spawns — it was never going to finish.

The second problem is worse than the slowness: the prune shared a step with the upload and ran *before* `homebrew-tap`, so when it died the tap update was cancelled. Tarballs published fine, but the tap stayed on `0.236.170`.

## Changes

Both applied to the Woodpecker pipeline and the GitHub Actions workflow so they do not drift:

- **Batch deletes** via `s3api delete-objects`, up to 1000 keys per call, chunked at 400 tarballs (800 keys) per request. A group becomes one request instead of hundreds of process spawns. Deleting an absent `.sha256` is not an error in `DeleteObjects`, so the per-key `|| true` existence dance is gone.
- **Retention moves into its own `r2-brew-prune` step**, ordered after `homebrew-tap`. Retention can no longer block publishing — the tap gets updated first, and a prune problem is contained to the prune.

## Verification

Dry-run against the production bucket using the same list/sort/select/JSON logic, stopping short of `delete-objects`:

```
bugbarn-darwin-amd64: 175 tarballs, pruning 165 -> 330 keys, valid JSON, no kept version in batch
bugbarn-darwin-arm64: 199 tarballs, pruning 189 -> 378 keys, valid JSON, no kept version in batch
bb-darwin-amd64:      165 tarballs, pruning 155 -> 310 keys, valid JSON, no kept version in batch
bb-darwin-arm64:      165 tarballs, pruning 155 -> 310 keys, valid JSON, no kept version in batch
```

Every batch is under the 1000-key limit, and the newest kept per group is `0.236.172`. Both YAML files parse.

https://claude.ai/code/session_01Prwv9SwhJRG337h1ucHeqi